### PR TITLE
Cannot start new openssl transaction after previous transaction was cancelled

### DIFF
--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -274,6 +274,7 @@ void pbpal_forget(pubnub_t *pb)
 int pbpal_close(pubnub_t *pb)
 {
     pb->readlen = 0;
+    pb->sock_state = STATE_NONE;
     if (pb->pal.socket != NULL) {
         pbntf_lost_socket(pb, pb->pal.socket);
         BIO_free_all(pb->pal.socket);


### PR DESCRIPTION
When an openssl transaction was cancelled it was not possible to start a new transaction.

It would perhaps be a good idea to write a test for this, but the tests are currently failing on my system because quota are exceeded with the used account. 