### PR TITLE
OpenSSL: Set timeout

### DIFF
--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -131,6 +131,12 @@ enum pubnub_res pbpal_line_read_status(pubnub_t *pb)
     if (pb->readlen == 0) {
         int recvres = BIO_read(pb->pal.socket, pb->ptr, pb->left);
         if (recvres < 0) {
+            /* This is error or connection close, but, since it is an
+               unexpected close, we treat it like an error.
+             */
+            if (PUBNUB_BLOCKING_IO_SETTABLE && pb->options.use_blocking_io) {
+                return PNR_IO_ERROR;
+            }
             if (BIO_should_retry(pb->pal.socket)) {
                 return PNR_IN_PROGRESS;
             }

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -48,6 +48,8 @@ static enum pubnub_res resolv_and_connect_wout_SSL(pubnub_t *pb)
     }
 
     DEBUG_PRINTF("pb=%p: BIO connected\n", pb);
+    int fd = BIO_get_fd(pb->pal.socket, NULL);
+    socket_set_rcv_timeout(fd, 310);
 
     return PNR_OK;
 }
@@ -176,6 +178,8 @@ enum pubnub_res pbpal_resolv_and_connect(pubnub_t *pb)
     }
 
     DEBUG_PRINTF("pb=%p: BIO connected\n", pb);
+    int fd = BIO_get_fd(pb->pal.socket, NULL);
+    socket_set_rcv_timeout(fd, 310);
 
     rslt = SSL_get_verify_result(ssl);
     if (rslt != X509_V_OK) {

--- a/openssl/pubnub_internal.h
+++ b/openssl/pubnub_internal.h
@@ -3,6 +3,8 @@
 #define      INC_PUBNUB_INTERNAL
 
 
+#include <unistd.h>
+#include <sys/socket.h>
 #include "openssl/bio.h"
 #include "openssl/err.h"
 
@@ -14,6 +16,11 @@ struct pubnub_pal {
     BIO *socket;
     SSL_CTX *ctx;
 };
+
+#define socket_set_rcv_timeout(socket, seconds) do {                            \
+    struct timeval M_tm = { (seconds), 0 };                                     \
+    setsockopt((socket), SOL_SOCKET, SO_RCVTIMEO, (char*)&M_tm, sizeof M_tm);   \
+    } while(0)
 
 /** With OpenSSL, one can set I/O to be blocking or non-blocking,
     though it can only be done before establishing the connection.


### PR DESCRIPTION
Use timeout on openssl connection to ensure BIO_read does not block infinitely