### PR TITLE
Minor fixes/improvements

### DIFF
--- a/core/pubnub_ssl.c
+++ b/core/pubnub_ssl.c
@@ -9,8 +9,8 @@ void pubnub_set_ssl_options(pubnub_t *p, bool useSSL, bool reduceSecurityOnError
 {
     PUBNUB_ASSERT(pb_valid_ctx_ptr(p));
 #if PUBNUB_USE_SSL
-    p->ssl.use = useSSL;
-    p->ssl.ignore = reduceSecurityOnError;
-    p->ssl.fallback = ignoreSecureConnectionRequirement;
+    p->options.useSSL = useSSL;
+    p->options.ignoreSSL = reduceSecurityOnError;
+    p->options.fallbackSSL = ignoreSecureConnectionRequirement;
 #endif
 }

--- a/openssl/posix.mk
+++ b/openssl/posix.mk
@@ -1,4 +1,4 @@
-SOURCEFILES = ../core/pubnub_coreapi.c ../core/pubnub_ccore.c ../core/pubnub_netcore.c  pbpal_openssl.c pbpal_resolv_and_connect_openssl.c ../core/pubnub_alloc_std.c ../core/pubnub_assert_std.c ../core/pubnub_generate_uuid.c ../core/pubnub_blocking_io.c ../core/pubnub_timers.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c pubnub_version_openssl.c ../posix/pubnub_generate_uuid_posix.c pbpal_openssl_blocking_io.c
+SOURCEFILES = ../core/pubnub_ssl.c ../core/pubnub_coreapi.c ../core/pubnub_ccore.c ../core/pubnub_netcore.c  pbpal_openssl.c pbpal_resolv_and_connect_openssl.c ../core/pubnub_alloc_std.c ../core/pubnub_assert_std.c ../core/pubnub_generate_uuid.c ../core/pubnub_blocking_io.c ../core/pubnub_timers.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c pubnub_version_openssl.c ../posix/pubnub_generate_uuid_posix.c pbpal_openssl_blocking_io.c
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin)

--- a/openssl/pubnub_config.h
+++ b/openssl/pubnub_config.h
@@ -30,11 +30,13 @@
  */
 #define PUBNUB_CTX_MAX 2
 
+#ifndef PUBNUB_BUF_MAXLEN
 /** Maximum length of the HTTP buffer. This is a major component of
  * the memory size of the whole pubnub context, but it is also an
  * upper bound on URL-encoded form of published message, so if you
  * need to construct big messages, you may need to raise this.  */
 #define PUBNUB_BUF_MAXLEN 32000
+#endif
 
 /** Set to 0 to use a static buffer and then set its size via
     #PUBNUB_REPLY_MAXLEN.  Set to anything !=0 to use a dynamic
@@ -45,6 +47,7 @@
 
 #if !PUBNUB_DYNAMIC_REPLY_BUFFER
 
+#ifndef PUBNUB_REPLY_MAXLEN
 /** Maximum length of the HTTP reply when using a static buffer. The
  * other major component of the memory size of the PubNub context,
  * beside #PUBNUB_BUF_MAXLEN.  Replies of API calls longer than this
@@ -52,6 +55,7 @@
  * may cause lost messages returned by subscribe if too many too large
  * messages got queued on the Pubnub server. */
 #define PUBNUB_REPLY_MAXLEN 32000
+#endif
 
 #endif
 


### PR DESCRIPTION
- `core/pubnub_ssl.c` was not compiling
- we should be able to set the buffer sizes from outside the project