### PR TITLE
Some more (mostly) openssl-related improvements

### DIFF
--- a/core/pbpal.h
+++ b/core/pbpal.h
@@ -149,10 +149,10 @@ void pbpal_forget(pubnub_t *pb);
 */
 int pbpal_close(pubnub_t *pb);
 
-/** Returns whether a TCP connection has been established for the
+/** Returns whether a connection has been established for the
     given Pubnub context.
 */
-bool pbpal_connected(pubnub_t *pb);
+enum pbpal_resolv_n_connect_result pbpal_connected(pubnub_t *pb);
 
 /** Sets blocking I/O option on the context for the communication */
 int pbpal_set_blocking_io(pubnub_t *pb);

--- a/core/pubnub_coreapi.c
+++ b/core/pubnub_coreapi.c
@@ -22,6 +22,7 @@ pubnub_t* pubnub_init(pubnub_t *p, const char *publish_key, const char *subscrib
     pbcc_init(&p->core, publish_key, subscribe_key);
     if (PUBNUB_TIMERS_API) {
         p->transaction_timeout_ms = PUBNUB_DEFAULT_TRANSACTION_TIMER;
+        p->connection_timeout_s = PUBNUB_DEFAULT_CONNECTION_TIMER;
 #if defined(PUBNUB_CALLBACK_API)
         p->previous = p->next = NULL;
 #endif

--- a/core/pubnub_coreapi.c
+++ b/core/pubnub_coreapi.c
@@ -48,7 +48,7 @@ enum pubnub_res pubnub_publish(pubnub_t *pb, const char *channel, const char *me
     enum pubnub_res rslt;
 
     PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
-    
+
     pubnub_mutex_lock(pb->monitor);
     if (pb->state != PBS_IDLE) {
         pubnub_mutex_unlock(pb->monitor);
@@ -63,7 +63,7 @@ enum pubnub_res pubnub_publish(pubnub_t *pb, const char *channel, const char *me
         rslt = pb->core.last_result;
     }
     pubnub_mutex_unlock(pb->monitor);
-    
+
     return rslt;
 }
 
@@ -73,7 +73,7 @@ enum pubnub_res pubnub_publishv2(pubnub_t *pb, const char *channel, const char *
     enum pubnub_res rslt;
 
     PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
-    
+
     pubnub_mutex_lock(pb->monitor);
     if (pb->state != PBS_IDLE) {
         pubnub_mutex_unlock(pb->monitor);
@@ -87,7 +87,7 @@ enum pubnub_res pubnub_publishv2(pubnub_t *pb, const char *channel, const char *
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -124,13 +124,13 @@ enum pubnub_res pubnub_subscribe(pubnub_t *p, const char *channel, const char *c
     enum pubnub_res rslt;
 
     PUBNUB_ASSERT(pb_valid_ctx_ptr(p));
-    
+
     pubnub_mutex_lock(p->monitor);
     if (p->state != PBS_IDLE) {
         pubnub_mutex_unlock(p->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_subscribe_prep(&p->core, channel, channel_group, NULL);
     if (PNR_STARTED == rslt) {
         p->trans = PBTT_SUBSCRIBE;
@@ -138,7 +138,7 @@ enum pubnub_res pubnub_subscribe(pubnub_t *p, const char *channel, const char *c
         pbnc_fsm(p);
         rslt = p->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(p->monitor);
     return rslt;
 }
@@ -155,7 +155,7 @@ enum pubnub_res pubnub_leave(pubnub_t *p, const char *channel, const char *chann
         pubnub_mutex_unlock(p->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_leave_prep(&p->core, channel, channel_group);
     if (PNR_STARTED == rslt) {
         p->trans = PBTT_LEAVE;
@@ -163,7 +163,7 @@ enum pubnub_res pubnub_leave(pubnub_t *p, const char *channel, const char *chann
         pbnc_fsm(p);
         rslt = p->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(p->monitor);
     return rslt;
 }
@@ -180,7 +180,7 @@ enum pubnub_res pubnub_time(pubnub_t *p)
         pubnub_mutex_unlock(p->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_time_prep(&p->core);
     if (PNR_STARTED == rslt) {
         p->trans = PBTT_TIME;
@@ -188,7 +188,7 @@ enum pubnub_res pubnub_time(pubnub_t *p)
         pbnc_fsm(p);
         rslt = p->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(p->monitor);
     return rslt;
 }
@@ -205,7 +205,7 @@ enum pubnub_res pubnub_history(pubnub_t *pb, const char *channel, unsigned count
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_history_prep(&pb->core, channel, count, include_token);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_HISTORY;
@@ -213,7 +213,7 @@ enum pubnub_res pubnub_history(pubnub_t *pb, const char *channel, unsigned count
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -230,7 +230,7 @@ enum pubnub_res pubnub_heartbeat(pubnub_t *pb, const char *channel, const char *
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_heartbeat_prep(&pb->core, channel, channel_group);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_HEARTBEAT;
@@ -238,7 +238,7 @@ enum pubnub_res pubnub_heartbeat(pubnub_t *pb, const char *channel, const char *
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -255,7 +255,7 @@ enum pubnub_res pubnub_here_now(pubnub_t *pb, const char *channel, const char *c
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_here_now_prep(&pb->core, channel, channel_group, pbccNotSet, pbccNotSet);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_HERENOW;
@@ -263,7 +263,7 @@ enum pubnub_res pubnub_here_now(pubnub_t *pb, const char *channel, const char *c
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -280,7 +280,7 @@ enum pubnub_res pubnub_global_here_now(pubnub_t *pb)
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_here_now_prep(&pb->core, NULL, NULL, pbccNotSet, pbccNotSet);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_GLOBAL_HERENOW;
@@ -288,7 +288,7 @@ enum pubnub_res pubnub_global_here_now(pubnub_t *pb)
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -305,7 +305,7 @@ enum pubnub_res pubnub_where_now(pubnub_t *pb, const char *uuid)
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_where_now_prep(&pb->core, uuid ? uuid : pb->core.uuid);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_WHERENOW;
@@ -313,7 +313,7 @@ enum pubnub_res pubnub_where_now(pubnub_t *pb, const char *uuid)
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -330,7 +330,7 @@ enum pubnub_res pubnub_set_state(pubnub_t *pb, char const *channel, char const *
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_set_state_prep(&pb->core, channel, channel_group, uuid ? uuid : pb->core.uuid, state);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_SET_STATE;
@@ -338,7 +338,7 @@ enum pubnub_res pubnub_set_state(pubnub_t *pb, char const *channel, char const *
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -355,7 +355,7 @@ enum pubnub_res pubnub_state_get(pubnub_t *pb, char const *channel, char const *
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_state_get_prep(&pb->core, channel, channel_group, uuid ? uuid : pb->core.uuid);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_STATE_GET;
@@ -363,7 +363,7 @@ enum pubnub_res pubnub_state_get(pubnub_t *pb, char const *channel, char const *
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -380,7 +380,7 @@ enum pubnub_res pubnub_remove_channel_group(pubnub_t *pb, char const *channel_gr
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_remove_channel_group_prep(&pb->core, channel_group);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_REMOVE_CHANNEL_GROUP;
@@ -388,7 +388,7 @@ enum pubnub_res pubnub_remove_channel_group(pubnub_t *pb, char const *channel_gr
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -405,7 +405,7 @@ enum pubnub_res pubnub_remove_channel_from_group(pubnub_t *pb, char const *chann
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_channel_registry_prep(&pb->core, channel_group, "remove", channel);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_REMOVE_CHANNEL_FROM_GROUP;
@@ -413,7 +413,7 @@ enum pubnub_res pubnub_remove_channel_from_group(pubnub_t *pb, char const *chann
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -430,7 +430,7 @@ enum pubnub_res pubnub_add_channel_to_group(pubnub_t *pb, char const *channel, c
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_channel_registry_prep(&pb->core, channel_group, "add", channel);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_ADD_CHANNEL_TO_GROUP;
@@ -438,7 +438,7 @@ enum pubnub_res pubnub_add_channel_to_group(pubnub_t *pb, char const *channel, c
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }
@@ -455,7 +455,7 @@ enum pubnub_res pubnub_list_channel_group(pubnub_t *pb, char const *channel_grou
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    
+
     rslt = pbcc_channel_registry_prep(&pb->core, channel_group, NULL, NULL);
     if (PNR_STARTED == rslt) {
         pb->trans = PBTT_LIST_CHANNEL_GROUP;
@@ -463,7 +463,7 @@ enum pubnub_res pubnub_list_channel_group(pubnub_t *pb, char const *channel_grou
         pbnc_fsm(pb);
         rslt = pb->core.last_result;
     }
-    
+
     pubnub_mutex_unlock(pb->monitor);
     return rslt;
 }

--- a/core/pubnub_coreapi.c
+++ b/core/pubnub_coreapi.c
@@ -22,7 +22,9 @@ pubnub_t* pubnub_init(pubnub_t *p, const char *publish_key, const char *subscrib
     pbcc_init(&p->core, publish_key, subscribe_key);
     if (PUBNUB_TIMERS_API) {
         p->transaction_timeout_ms = PUBNUB_DEFAULT_TRANSACTION_TIMER;
+#if defined(PUBNUB_DEFAULT_CONNECTION_TIMER)
         p->connection_timeout_s = PUBNUB_DEFAULT_CONNECTION_TIMER;
+#endif
 #if defined(PUBNUB_CALLBACK_API)
         p->previous = p->next = NULL;
 #endif

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -41,7 +41,7 @@ enum PBSocketState {
 };
 
 
-/** The Pubnub context 
+/** The Pubnub context
 
     @note Don't declare any members as `bool`, as there may be
     alignment issues when this is included from both C and C++
@@ -57,25 +57,25 @@ struct pubnub_ {
     enum pubnub_trans trans;
 
     /** Pointer to the next data to be sent. */
-    uint8_t const *sendptr;   
+    uint8_t const *sendptr;
 
     /** The number of bytes left to be sent. */
-    uint16_t sendlen;         
+    uint16_t sendlen;
 
     /** The number of bytes left to be read. */
-    uint16_t readlen;         
+    uint16_t readlen;
 
     /** Pointer to next free byte in the read buffer*/
-    uint8_t *ptr;          
+    uint8_t *ptr;
 
     /** Number of bytes left (empty) in the read buffer */
-    uint16_t left;   
+    uint16_t left;
 
     /** The state of the socket. */
-    enum PBSocketState sock_state;   
+    enum PBSocketState sock_state;
 
     /** Number of bytes to read - given by the user */
-    unsigned len;          
+    unsigned len;
 
     /** Indicates whether we are receiving chunked or regular HTTP
      * response
@@ -99,10 +99,10 @@ struct pubnub_ {
     struct pubnub_pal pal;
 
     struct pubnub_options {
-        /** Indicates whether to use blocking I/O. Ignored if 
+        /** Indicates whether to use blocking I/O. Ignored if
             choosing between blocking and non-blocking is not supported
             on a platform. Would be ifdef-ed out, but then it would be
-            possible for this struct to have no members which is 
+            possible for this struct to have no members which is
             prohibited by the ISO C standard.
         */
         bool use_blocking_io : 1;
@@ -165,7 +165,7 @@ void pbntf_lost_socket(pubnub_t *pb, pb_socket_t socket);
 
 
 /** Internal function. Checks if the given pubnub context pointer
-    is valid. 
+    is valid.
 */
 bool pb_valid_ctx_ptr(pubnub_t const *pb);
 

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -133,6 +133,8 @@ struct pubnub_ {
 #if PUBNUB_TIMERS_API
     /** Duration of the transaction timeout, in milliseconds */
     int transaction_timeout_ms;
+    /** Duration of the connection timeout, in seconds */
+    int connection_timeout_s;
 
 #if defined(PUBNUB_CALLBACK_API)
     struct pubnub_ *previous;

--- a/core/pubnub_log.h
+++ b/core/pubnub_log.h
@@ -3,7 +3,7 @@
 #define	INC_PUBNUB_LOG
 
 
-/** @file pubnub_log.h 
+/** @file pubnub_log.h
     This is the "Log" API of the Pubnub client library.
     Designed for C-core's own use, but not restricted to it.
     Provides a reasonably-well-featured, yet small and efficient
@@ -93,7 +93,7 @@ enum pubnub_log_level {
 
 /** Helper macro to "watch" an enum like an integer.*/
 #define WATCH_ENUM(X) do { int x_ = (X); PUBNUB_LOG(PUBNUB_LOG_LEVEL_DEBUG, __FILE__ "(%d) in %s: `" #X "` = %d\n", __LINE__, __FUNCTION__, x_); } while (0)
-    
+
 /** Helper macro to "watch" a string (char pointer) */
 #define WATCH_STR(X) do { char const*s_ = (X); PUBNUB_LOG(PUBNUB_LOG_LEVEL_DEBUG, __FILE__ "(%d) in %s: `" #X "` = '%s'\n", __LINE__, __FUNCTION__, s_); } while (0)
 

--- a/core/pubnub_log.h
+++ b/core/pubnub_log.h
@@ -94,6 +94,9 @@ enum pubnub_log_level {
 /** Helper macro to "watch" an enum like an integer.*/
 #define WATCH_ENUM(X) do { int x_ = (X); PUBNUB_LOG(PUBNUB_LOG_LEVEL_DEBUG, __FILE__ "(%d) in %s: `" #X "` = %d\n", __LINE__, __FUNCTION__, x_); } while (0)
 
+/** Helper macro to "watch" an enum like an integer, but only log when it changes.*/
+#define WATCH_ENUM_ONCHANGE(X) do { static int enum_info_ ## __LINE__ = -666; int x_ = (X); if (x_ != enum_info_ ## __LINE__) { enum_info_ ## __LINE__ = x_; PUBNUB_LOG(PUBNUB_LOG_LEVEL_DEBUG, __FILE__ "(%d) in %s: `" #X "` = %d\n", __LINE__, __FUNCTION__, x_); } } while (0)
+
 /** Helper macro to "watch" a string (char pointer) */
 #define WATCH_STR(X) do { char const*s_ = (X); PUBNUB_LOG(PUBNUB_LOG_LEVEL_DEBUG, __FILE__ "(%d) in %s: `" #X "` = '%s'\n", __LINE__, __FUNCTION__, s_); } while (0)
 

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -95,7 +95,7 @@ int pbnc_fsm(struct pubnub_ *pb)
     PUBNUB_LOG_TRACE("pbnc_fsm()\t");
 
 next_state:
-    WATCH_ENUM(pb->state);
+    WATCH_ENUM_ONCHANGE(pb->state);
     switch (pb->state) {
     case PBS_NULL:
         break;

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -158,11 +158,26 @@ next_state:
         break;
     }
     case PBS_WAIT_CONNECT:
-        if (pbpal_connected(pb)) {
+    {
+        enum pbpal_resolv_n_connect_result rslv = pbpal_connected(pb);
+        WATCH_ENUM(rslv);
+        switch (rslv) {
+        case pbpal_resolv_resource_failure:
+        case pbpal_connect_resource_failure:
+        case pbpal_connect_failed:
+            pb->core.last_result = PNR_ADDR_RESOLUTION_FAILED;
+            pbntf_trans_outcome(pb);
+            return 0;
+        case pbpal_connect_success:
             pb->state = PBS_CONNECTED;
             goto next_state;
+        case pbpal_connect_wouldblock:
+        default:
+            pbntf_update_socket(pb, pb->pal.socket);
+            break;
         }
         break;
+    }
     case PBS_CONNECTED:
         pbpal_send_literal_str(pb, "GET ");
         pb->state = PBS_TX_GET;

--- a/core/pubnub_timers.c
+++ b/core/pubnub_timers.c
@@ -13,10 +13,23 @@ int pubnub_set_transaction_timeout(pubnub_t *p, int duration_ms)
     return 0;
 }
 
-
 int pubnub_transaction_timeout_get(pubnub_t *p)
 {
     PUBNUB_ASSERT_OPT(p != NULL);
     return p->transaction_timeout_ms;
+}
+
+int pubnub_set_connection_timeout(pubnub_t *p, int duration_s)
+{
+    PUBNUB_ASSERT_OPT(p != NULL);
+    PUBNUB_ASSERT_OPT(duration_s > 0);
+    p->connection_timeout_s = duration_s;
+    return 0;
+}
+
+int pubnub_connection_timeout_get(pubnub_t *p)
+{
+    PUBNUB_ASSERT_OPT(p != NULL);
+    return p->connection_timeout_s;
 }
 

--- a/core/pubnub_timers.h
+++ b/core/pubnub_timers.h
@@ -58,4 +58,30 @@ int pubnub_set_transaction_timeout(pubnub_t *p, int duration_ms);
 int pubnub_transaction_timeout_get(pubnub_t *p);
 
 
+/** Sets the connection timeout for the context. This will be
+    used for all subsequent connection establishments. If a transaction
+    is ongoing and its timeout can be changed, it will be, but if it can't,
+    that would not be reported as an error.
+
+    If timer support is available, pubnub_init() will set a default timeout,
+    which is configurable at compile time. So, if the default timeout is
+    fine with you, you don't have to call this function.
+
+    @pre Call this after pubnub_init() on the context
+    @pre duration_ms > 0
+    @param p The Context to set transaction timeout for
+    @param duration_s Duration of the timeout, in seconds
+
+    @return 0: OK, otherwise: error, timers not supported
+*/
+int pubnub_set_connection_timeout(pubnub_t *p, int duration_s);
+
+/** Returns the current connection timeout for the context.
+
+    @pre Call this after pubnub_init() on the context
+    @param p The Context for which to get the connection timeout
+    @return Current connection timeout, in seconds (should
+    always be > 0)
+*/
+int pubnub_connection_timeout_get(pubnub_t *p);
 #endif /* defined INC_PUBNUB_TIMERS_IO */

--- a/core/pubnub_timers.h
+++ b/core/pubnub_timers.h
@@ -6,7 +6,7 @@
 #include "pubnub_api_types.h"
 
 
-/** @file pubnub_timers.h 
+/** @file pubnub_timers.h
     This is the "Timer" API of the Pubnub client library.
     Functions here influence the way that Pubnub client library
     works with lower levels (the TCP/IP stack) with respect to
@@ -28,13 +28,13 @@
 
 /** Sets the transaction timeout for the context. This will be
     used for all subsequent transactions. If a transactions is ongoing
-    and its timeout can be changed, it will be, but if it can't, that 
+    and its timeout can be changed, it will be, but if it can't, that
     would not be reported as an error.
-    
+
     Pubnub SDKs, in general, distinguish the "subscribe" timeout and
-    other transactions, but, C-core doesn't, to save space, as most 
+    other transactions, but, C-core doesn't, to save space, as most
     contexts are either used for subscribe or for other transactions.
-    
+
     If timer support is available, pubnub_init() will set a default timeout,
     which is configurable at compile time. So, if the default timeout is
     fine with you, you don't have to call this function.
@@ -44,7 +44,7 @@
     @param p The Context to set transaction timeout for
     @param duration_ms Duration of the timeout, in milliseconds
 
-    @return 0: OK, otherwise: error, timers not supported  
+    @return 0: OK, otherwise: error, timers not supported
 */
 int pubnub_set_transaction_timeout(pubnub_t *p, int duration_ms);
 
@@ -56,5 +56,6 @@ int pubnub_set_transaction_timeout(pubnub_t *p, int duration_ms);
     always be > 0)
 */
 int pubnub_transaction_timeout_get(pubnub_t *p);
+
 
 #endif /* defined INC_PUBNUB_TIMERS_IO */

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -171,12 +171,34 @@ int pbpal_start_read_line(pubnub_t *pb)
 }
 
 
+static int pbpal_read(pubnub_t *pb, void *data, int len)
+{
+    if (!pb->options.use_blocking_io) {
+        fd_set read_set, write_set;
+        int socket;
+        struct timeval timev = { 0, 300000 };
+        FD_ZERO(&read_set);
+        FD_ZERO(&write_set);
+        BIO_get_fd(pb->pal.socket, &socket);
+        FD_SET(socket, &read_set);
+        if (BIO_should_write(pb->pal.socket)) {
+            FD_SET(socket, &write_set);
+        }
+        if(-1 == select(socket + 1, &read_set, &write_set, NULL, &timev)) {
+            PUBNUB_LOG_ERROR("select(%d) error: %s\n", socket, strerror(errno));
+            return -1;
+        }
+    }
+    return BIO_read(pb->pal.socket, data, len);
+}
+
+
 enum pubnub_res pbpal_line_read_status(pubnub_t *pb)
 {
     uint8_t c;
 
     if (pb->readlen == 0) {
-        int recvres = BIO_read(pb->pal.socket, pb->ptr, pb->left);
+        int recvres = pbpal_read(pb, pb->ptr, pb->left);
         if (recvres < 0) {
             /* This is error or connection close, but, since it is an
                unexpected close, we treat it like an error.
@@ -276,7 +298,7 @@ bool pbpal_read_over(pubnub_t *pb)
         if (to_read > pb->left) {
             to_read = pb->left;
         }
-        recvres = BIO_read(pb->pal.socket, pb->ptr, to_read);
+        recvres = pbpal_read(pb, pb->ptr, to_read);
         if (recvres <= 0) {
             /* This is error or connection close, which may be handled
                in some way...

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -196,14 +196,14 @@ enum pubnub_res pbpal_line_read_status(pubnub_t *pb)
         PUBNUB_LOG_TRACE("have new data of length=%d: %s\n", recvres, pb->ptr);
         pb->sock_state = STATE_READ_LINE;
         pb->readlen = recvres;
-    } 
+    }
 
     while (pb->left > 0 && pb->readlen > 0) {
         c = *pb->ptr++;
 
         --pb->readlen;
         --pb->left;
-        
+
         if (c == '\n') {
             int pbpal_read_len_ = pbpal_read_len(pb);
             PUBNUB_LOG_TRACE("\\n found: "); WATCH_INT(pbpal_read_len_); WATCH_USHORT(pb->readlen);
@@ -285,7 +285,7 @@ bool pbpal_read_over(pubnub_t *pb)
         }
         pb->sock_state = STATE_READ;
         pb->readlen = recvres;
-    } 
+    }
 
     to_read = pb->len;
     if (pb->readlen < to_read) {

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -151,7 +151,7 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
         return pbpal_resolv_resource_failure;
     }
 
-    PUBNUB_LOG_TRACE("pb=%p: Got BIO_new_ssl == %p\n", pb, pb->pal.socket);
+    PUBNUB_LOG_TRACE("pb=%p: Using BIO == %p\n", pb, pb->pal.socket);
 
     BIO_get_ssl(pb->pal.socket, &ssl);
     SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY); /* maybe not auto_retry? */

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -28,9 +28,9 @@ static enum pbpal_resolv_n_connect_result resolv_and_connect_wout_SSL(pubnub_t *
         return pbpal_resolv_resource_failure;
     }
     BIO_set_conn_port(pb->pal.socket, "http");
-    
+
     BIO_set_nbio(pb->pal.socket, !pb->options.use_blocking_io);
-    
+
     WATCH_ENUM(pb->options.use_blocking_io);
     if (BIO_do_connect(pb->pal.socket) <= 0) {
         if (BIO_should_retry(pb->pal.socket)) {
@@ -87,16 +87,16 @@ static int add_pubnub_cert(SSL_CTX *sslCtx)
 {
     X509 *cert;
     BIO *mem;
- 
+
     mem = BIO_new(BIO_s_mem());
     BIO_puts(mem, pubnub_cert);
     cert = PEM_read_bio_X509(mem, NULL, 0, NULL);
-    BIO_free(mem); 
-    
+    BIO_free(mem);
+
     // set certificate to sslCtx
     X509_STORE_add_cert(SSL_CTX_get_cert_store(sslCtx), cert);
     X509_free(cert);
-    
+
     /* In principle, it would be nice to use this instead, if we
        had a way to find out what is the file and/or path
        of the trusted root certificates. It would fix a problem
@@ -119,14 +119,14 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
     SSL *ssl;
     int rslt;
     char const* origin = PUBNUB_ORIGIN_SETTABLE ? pb->origin : PUBNUB_ORIGIN;
-        
+
     PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
     PUBNUB_ASSERT_OPT((pb->state == PBS_IDLE) || (pb->state == PBS_WAIT_CONNECT));
 
     if (!pb->options.useSSL) {
         return resolv_and_connect_wout_SSL(pb);
     }
-    
+
     if (NULL == pb->pal.ctx) {
         PUBNUB_LOG_TRACE("pb=%p: Don't have SSL_CTX\n", pb);
         pb->pal.ctx = SSL_CTX_new(SSLv23_client_method());
@@ -147,9 +147,9 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
         ERR_print_errors_fp(stderr);
         return pbpal_resolv_resource_failure;
     }
-    
+
     PUBNUB_LOG_TRACE("pb=%p: Got BIO_new_ssl == %p\n", pb, pb->pal.socket);
-    
+
     BIO_get_ssl(pb->pal.socket, &ssl);
     SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY); /* maybe not auto_retry? */
     if (pb->pal.session != NULL) {
@@ -232,7 +232,7 @@ bool pbpal_connected(pubnub_t *pb)
     int socket;
     int rslt;
     struct timeval timev = { 0, 300000 };
-    
+
     if (-1 == BIO_get_fd(pb->pal.socket, &socket)) {
         PUBNUB_LOG_ERROR("pbpal_connected(): Uninitialized BIO!\n");
         return false;

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -161,12 +161,14 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
 
     BIO_set_conn_hostname(pb->pal.socket, origin);
     BIO_set_conn_port(pb->pal.socket, "https");
-    if (pb->pal.ip_timeout && (pb->pal.ip_timeout < time(NULL))) {
-        pb->pal.ip_timeout = 0;
-    }
-    else if (pb->pal.session != NULL) {
-        PUBNUB_LOG_INFO("re-connect to IP: %d.%d.%d.%d\n", pb->pal.ip[0], pb->pal.ip[1], pb->pal.ip[2], pb->pal.ip[3]);
-        BIO_set_conn_ip(pb->pal.socket, pb->pal.ip);
+    if (0 != pb->pal.ip_timeout) {
+        if (pb->pal.ip_timeout < time(NULL)) {
+            pb->pal.ip_timeout = 0;
+        }
+        else {
+            PUBNUB_LOG_TRACE("re-connect to IP: %d.%d.%d.%d\n", pb->pal.ip[0], pb->pal.ip[1], pb->pal.ip[2], pb->pal.ip[3]);
+            BIO_set_conn_ip(pb->pal.socket, pb->pal.ip);
+        }
     }
 
     BIO_set_nbio(pb->pal.socket, !pb->options.use_blocking_io);
@@ -178,7 +180,7 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
             return pbpal_connect_wouldblock;
         }
         /* Expire the IP for the next connect */
-        pb->pal.ip_timeout = time(NULL) - 1;
+        pb->pal.ip_timeout = 0;
         ERR_print_errors_fp(stderr);
         BIO_free_all(pb->pal.socket);
         pb->pal.socket = NULL;

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -242,12 +242,13 @@ bool pbpal_connected(pubnub_t *pb)
     FD_SET(socket, &read_set);
     FD_SET(socket, &write_set);
     rslt = select(socket + 1, &read_set, &write_set, NULL, &timev);
-    if (SOCKET_ERROR == rslt) {
-        PUBNUB_LOG_ERROR("pbpal_connected(): select() Error!\n");
-        return false;
-    }
-    else if (rslt > 0) {
-        PUBNUB_LOG_TRACE("pbpal_connected(): select() event\n");
+    if (0 != rslt) {
+        if (SOCKET_ERROR == rslt) {
+            PUBNUB_LOG_ERROR("pbpal_connected(): select(%d) Error!\n", socket);
+        }
+        else {
+            PUBNUB_LOG_TRACE("pbpal_connected(): select() event\n");
+        }
         return pbpal_resolv_and_connect(pb) == pbpal_connect_success;
     }
     PUBNUB_LOG_TRACE("pbpal_connected(): no select() events\n");

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -236,7 +236,7 @@ enum pbpal_resolv_n_connect_result pbpal_check_resolv_and_connect(pubnub_t *pb)
 }
 
 
-bool pbpal_connected(pubnub_t *pb)
+enum pbpal_resolv_n_connect_result pbpal_connected(pubnub_t *pb)
 {
     fd_set read_set, write_set;
     int socket;
@@ -267,5 +267,5 @@ bool pbpal_connected(pubnub_t *pb)
             PUBNUB_LOG_TRACE("pbpal_connected(): no select(%d) events\n", socket);
         }
     }
-    return pbpal_resolv_and_connect(pb) == pbpal_connect_success;
+    return pbpal_resolv_and_connect(pb);
 }

--- a/openssl/pbpal_resolv_and_connect_openssl.c
+++ b/openssl/pbpal_resolv_and_connect_openssl.c
@@ -182,6 +182,10 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
         ERR_print_errors_fp(stderr);
         BIO_free_all(pb->pal.socket);
         pb->pal.socket = NULL;
+        if (pb->pal.session != NULL) {
+            SSL_SESSION_free(pb->pal.session);
+            pb->pal.session = NULL;
+        }
         PUBNUB_LOG_ERROR("BIO_do_connect failed\n");
         return pbpal_connect_failed;
     }

--- a/openssl/pubnub_config.h
+++ b/openssl/pubnub_config.h
@@ -76,6 +76,12 @@
     */
 #define PUBNUB_DEFAULT_TRANSACTION_TIMER    310000
 
+/** Duration of the connection timeout used during context initialization,
+    in seconds. Timeout duration in the context can be changed by the
+    user after initialization.
+    */
+#define PUBNUB_DEFAULT_CONNECTION_TIMER    15
+
 #define PUBNUB_HAVE_MD5 0
 #define PUBNUB_HAVE_SHA1 0
 

--- a/openssl/pubnub_config.h
+++ b/openssl/pubnub_config.h
@@ -71,7 +71,7 @@
 #define PUBNUB_ORIGIN_SETTABLE 1
 
 /** Duration of the transaction timeout set during context initialization,
-    in milliseconds. Timeout dration in the context can be changed by the 
+    in milliseconds. Timeout duration in the context can be changed by the
     user after initialization.
     */
 #define PUBNUB_DEFAULT_TRANSACTION_TIMER    310000

--- a/openssl/pubnub_internal.h
+++ b/openssl/pubnub_internal.h
@@ -16,7 +16,8 @@ struct pubnub_pal {
     SSL_CTX *ctx;
     SSL_SESSION *session;
     char ip[4];
-    long ip_timeout;
+    time_t ip_timeout;
+    time_t connect_timeout;
 };
 
 #ifdef _WIN32

--- a/openssl/pubnub_internal.h
+++ b/openssl/pubnub_internal.h
@@ -26,7 +26,7 @@ struct pubnub_pal {
     } while(0)
 
 #if _MSC_VER < 1900
-/** Microsoft C compiler (before VS2015) does not provide a 
+/** Microsoft C compiler (before VS2015) does not provide a
     standard-conforming snprintf(), so we bring our own.
     */
 int snprintf(char *buffer, size_t n, const char *format, ...);

--- a/posix/posix.mk
+++ b/posix/posix.mk
@@ -30,7 +30,7 @@ subscribe_publish_callback_sample: ../core/samples/subscribe_publish_callback_sa
 	$(CC) -o $@ -D PUBNUB_CALLBACK_API $(CFLAGS) ../core/samples/subscribe_publish_callback_sample.c ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c $(SOURCEFILES) $(LDLIBS)
 
 pubnub_fntest: ../core/fntest/pubnub_fntest.c ../core/fntest/pubnub_fntest_basic.c ../core/fntest/pubnub_fntest_medium.c fntest/pubnub_fntest_posix.c fntest/pubnub_fntest_runner.c $(SOURCEFILES)  ../core/pubnub_ntf_sync.c
-	$(CC) -o $@ $(CFLAGS) -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_TRACE ../core/fntest/pubnub_fntest.c ../core/fntest/pubnub_fntest_basic.c ../core/fntest/pubnub_fntest_medium.c  fntest/pubnub_fntest_posix.c fntest/pubnub_fntest_runner.c $(SOURCEFILES)  ../core/pubnub_ntf_sync.c $(LDLIBS) -lpthread
+	$(CC) -o $@ $(CFLAGS) -U PUBNUB_LOG_LEVEL -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_TRACE ../core/fntest/pubnub_fntest.c ../core/fntest/pubnub_fntest_basic.c ../core/fntest/pubnub_fntest_medium.c  fntest/pubnub_fntest_posix.c fntest/pubnub_fntest_runner.c $(SOURCEFILES)  ../core/pubnub_ntf_sync.c $(LDLIBS) -lpthread
 
 CONSOLE_SOURCEFILES=../core/samples/console/pubnub_console.c ../core/samples/console/pnc_helpers.c ../core/samples/console/pnc_readers.c ../core/samples/console/pnc_subscriptions.c
 

--- a/posix/posix.mk
+++ b/posix/posix.mk
@@ -1,4 +1,5 @@
 SOURCEFILES = ../core/pubnub_coreapi.c ../core/pubnub_coreapi_ex.c ../core/pubnub_ccore.c ../core/pubnub_netcore.c  ../lib/sockets/pbpal_sockets.c ../lib/sockets/pbpal_resolv_and_connect_sockets.c ../core/pubnub_alloc_std.c ../core/pubnub_assert_std.c ../core/pubnub_generate_uuid.c ../core/pubnub_blocking_io.c ../core/pubnub_timers.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c  pubnub_version_posix.c  pubnub_generate_uuid_posix.c pbpal_posix_blocking_io.c
+HEADERS = $(wildcard ../core/*.h) $(wildcard ./*.h)
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
@@ -17,27 +18,27 @@ CFLAGS =-g -I ../core -I . -I fntest -I ../core/fntest -Wall -D PUBNUB_THREADSAF
 all: pubnub_sync_sample cancel_subscribe_sync_sample pubnub_callback_sample subscribe_publish_callback_sample pubnub_fntest pubnub_console_sync pubnub_console_callback
 
 
-pubnub_sync_sample: ../core/samples/pubnub_sync_sample.c $(SOURCEFILES) ../core/pubnub_ntf_sync.c
+pubnub_sync_sample: ../core/samples/pubnub_sync_sample.c $(SOURCEFILES) ../core/pubnub_ntf_sync.c $(HEADERS)
 	$(CC) -o $@ $(CFLAGS) ../core/samples/pubnub_sync_sample.c ../core/pubnub_ntf_sync.c $(SOURCEFILES) $(LDLIBS)
 
-cancel_subscribe_sync_sample: ../core/samples/cancel_subscribe_sync_sample.c $(SOURCEFILES) ../core/pubnub_ntf_sync.c
+cancel_subscribe_sync_sample: ../core/samples/cancel_subscribe_sync_sample.c $(SOURCEFILES) ../core/pubnub_ntf_sync.c $(HEADERS)
 	$(CC) -o $@ $(CFLAGS) ../core/samples/cancel_subscribe_sync_sample.c ../core/pubnub_ntf_sync.c $(SOURCEFILES) $(LDLIBS)
 
-pubnub_callback_sample: ../core/samples/pubnub_callback_sample.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c ../lib/sockets/pbpal_adns_sockets.c
+pubnub_callback_sample: ../core/samples/pubnub_callback_sample.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c ../lib/sockets/pbpal_adns_sockets.c $(HEADERS)
 	$(CC) -o $@ -D PUBNUB_CALLBACK_API $(CFLAGS) -D PUBNUB_USE_ADNS=1 ../core/samples/pubnub_callback_sample.c ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c ../lib/sockets/pbpal_adns_sockets.c $(SOURCEFILES) $(LDLIBS)
 
-subscribe_publish_callback_sample: ../core/samples/subscribe_publish_callback_sample.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c
+subscribe_publish_callback_sample: ../core/samples/subscribe_publish_callback_sample.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c $(HEADERS)
 	$(CC) -o $@ -D PUBNUB_CALLBACK_API $(CFLAGS) ../core/samples/subscribe_publish_callback_sample.c ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c $(SOURCEFILES) $(LDLIBS)
 
-pubnub_fntest: ../core/fntest/pubnub_fntest.c ../core/fntest/pubnub_fntest_basic.c ../core/fntest/pubnub_fntest_medium.c fntest/pubnub_fntest_posix.c fntest/pubnub_fntest_runner.c $(SOURCEFILES)  ../core/pubnub_ntf_sync.c
+pubnub_fntest: ../core/fntest/pubnub_fntest.c ../core/fntest/pubnub_fntest_basic.c ../core/fntest/pubnub_fntest_medium.c fntest/pubnub_fntest_posix.c fntest/pubnub_fntest_runner.c $(SOURCEFILES)  ../core/pubnub_ntf_sync.c $(HEADERS)
 	$(CC) -o $@ $(CFLAGS) -U PUBNUB_LOG_LEVEL -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_TRACE ../core/fntest/pubnub_fntest.c ../core/fntest/pubnub_fntest_basic.c ../core/fntest/pubnub_fntest_medium.c  fntest/pubnub_fntest_posix.c fntest/pubnub_fntest_runner.c $(SOURCEFILES)  ../core/pubnub_ntf_sync.c $(LDLIBS) -lpthread
 
 CONSOLE_SOURCEFILES=../core/samples/console/pubnub_console.c ../core/samples/console/pnc_helpers.c ../core/samples/console/pnc_readers.c ../core/samples/console/pnc_subscriptions.c
 
-pubnub_console_sync: $(CONSOLE_SOURCEFILES) ../core/samples/console/pnc_ops_sync.c  $(SOURCEFILES) ../core/pubnub_ntf_sync.c 
+pubnub_console_sync: $(CONSOLE_SOURCEFILES) ../core/samples/console/pnc_ops_sync.c  $(SOURCEFILES) ../core/pubnub_ntf_sync.c  $(HEADERS)
 	$(CC) -o $@ $(CFLAGS) $(CONSOLE_SOURCEFILES) ../core/samples/console/pnc_ops_sync.c  $(SOURCEFILES) ../core/pubnub_ntf_sync.c $(LDLIBS)
 
-pubnub_console_callback: $(CONSOLE_SOURCEFILES) ../core/samples/console/pnc_ops_callback.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c
+pubnub_console_callback: $(CONSOLE_SOURCEFILES) ../core/samples/console/pnc_ops_callback.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c $(HEADERS)
 	$(CC) -o $@ $(CFLAGS) -D PUBNUB_CALLBACK_API $(CONSOLE_SOURCEFILES) ../core/samples/console/pnc_ops_callback.c $(SOURCEFILES) ../core/pubnub_timer_list.c pubnub_ntf_callback_posix.c pubnub_get_native_socket.c $(LDLIBS)
 
 


### PR DESCRIPTION
This PR contains multiple improvements:

- add the possibility to specify a connection-timeout for OpenSSL
- improve the error handling
- improve earlier patches

All changes have only been tested for the OpenSSL target. This changeset also contains an API change of `pbpal_connected()`, which hasn't been implemented for all the other targets besides OpenSSL.

To be able to use the connection-timeout one has to enable non-blocking sockets and use the synchronous API.