### PR TITLE
Fixed reference to SSL_CTX member of pubnub_pal

### DIFF
--- a/openssl/pbpal_add_system_certs_windows.c
+++ b/openssl/pbpal_add_system_certs_windows.c
@@ -5,12 +5,14 @@
 
 #include "openssl/x509.h"
 
+#include <windows.h>
+
 #include <wincrypt.h>
 
 
 int pbpal_add_system_certs(pubnub_t* pb)
 {
-    X509_STORE *cert_store = SSL_CTX_get_cert_store(pb->pal.sslCtx)
+    X509_STORE *cert_store = SSL_CTX_get_cert_store(pb->pal.ctx);
     HCERTSTORE hStore = CertOpenSystemStore(NULL, L"ROOT");
     PCCERT_CONTEXT pContext = NULL;
 


### PR DESCRIPTION
- The SSL_CTX member of pubnub_pal is called ctx instead of sslCtx.
- Semicolon was needed
- wincrypt needs windows.h