### PR TITLE
pubnub::futres must unregister its callback upon destruction.

### DIFF
--- a/cpp/pubnub_futres_cpp11.cpp
+++ b/cpp/pubnub_futres_cpp11.cpp
@@ -108,6 +108,7 @@ futres::futres(futres const &x) :
 
 futres::~futres() 
 {
+    (void)pubnub_register_callback(d_pb, NULL, NULL);
     delete d_pimpl;
 }
 

--- a/cpp/pubnub_futres_posix.cpp
+++ b/cpp/pubnub_futres_posix.cpp
@@ -138,6 +138,7 @@ futres::futres(futres const &x) :
 
 futres::~futres()
 {
+    (void)pubnub_register_callback(d_pb, NULL, NULL);
     delete d_pimpl;
 }
 

--- a/cpp/pubnub_futres_windows.cpp
+++ b/cpp/pubnub_futres_windows.cpp
@@ -121,6 +121,7 @@ futres::futres(futres const &x) :
 
 futres::~futres()
 {
+    (void)pubnub_register_callback(d_pb, NULL, NULL);
     delete d_pimpl;
 }
 


### PR DESCRIPTION
Neglecting to do so can cause other threads to crash; for example, if they call pubnub::context::cancel() while no transactions are in progress on that context.