### PR TITLE
Add set_transaction_timeout and transaction_timeout_get Qt implementations

### DIFF
--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -590,6 +590,25 @@ void pubnub_qt::set_ssl_options(ssl_opts options)
 }
 
 
+int pubnub_qt::set_transaction_timeout(int duration_ms)
+{
+    if (duration_ms > 0) {
+        QMutexLocker lk(&d_mutex);
+        d_transaction_timeout_duration_ms = duration_ms;
+        return 0;
+    }
+
+    return -1;
+}
+
+
+int pubnub_qt::transaction_timeout_get()
+{
+    QMutexLocker lk(&d_mutex);
+    return d_transaction_timeout_duration_ms;
+}
+
+
 void pubnub_qt::set_origin(QString const& origin)
 {
     QMutexLocker lk(&d_mutex);


### PR DESCRIPTION
Sometimes it is useful to modify the default timeout duration which is 10s by default.
The headers appeared to offer the functionality, but it was missing.  This PR offers an implementation.

Sample usage: 
```
pubnub_qt r;
r.set_transaction_timeout(5000); // OK; This will return 0 and sets the transaction
int timeout_s = r.transaction_timeout_get(); // Returns 5000;
r.publish(...); 

// ... 
r.set_transaction_timeout(-20); // Not OK; This will return -1 and keep the previous transaction timeout.
```
