### PR TITLE
Adds support for HTTP Pipelining in Pubnub Qt SDK.

### DIFF
--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -42,6 +42,7 @@ pubnub_qt::pubnub_qt(QString pubkey, QString keysub)
     , d_transaction_timed_out(false)
     , d_transactionTimer(new QTimer(this))
     , d_use_http_keep_alive(true)
+    , d_use_http_pipelining(false)
     , d_mutex(QMutex::Recursive)
 {
     pbcc_init(d_context.data(), d_pubkey.data(), d_keysub.data());
@@ -75,6 +76,9 @@ pubnub_res pubnub_qt::startRequest(pubnub_res result, pubnub_trans transaction)
         QNetworkRequest req(url);
         if (!d_use_http_keep_alive) {
             req.setRawHeader("Connection", "Close");
+        }
+        if (d_use_http_pipelining) {
+            req.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
         }
         if (PBTT_PUBLISH == transaction) {
             switch (d_publish_method) {
@@ -606,6 +610,20 @@ int pubnub_qt::transaction_timeout_get()
 {
     QMutexLocker lk(&d_mutex);
     return d_transaction_timeout_duration_ms;
+}
+
+
+void pubnub_qt::set_use_http_pipelining(bool use)
+{
+    QMutexLocker lk(&d_mutex);
+    d_use_http_pipelining = use;
+}
+
+
+bool pubnub_qt::use_http_pipelining_get()
+{
+    QMutexLocker lk(&d_mutex);
+    return d_use_http_pipelining;
 }
 
 

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -808,6 +808,15 @@ public:
     /** Returns the current transaction duration, in milliseconds. */
     int transaction_timeout_get();
 
+    /** Sets QNetworkManager to use HTTP pipelining to reuse TCP socket.
+     * @param use The usage of the http pipelining.
+     * @note HTTP Pipelining is disabled by default.
+     */
+    void set_use_http_pipelining(bool use);
+
+    /** Returns true if HTTP pipelining is set, false otherwise. */
+    bool use_http_pipelining_get();
+
 private slots:
     void httpFinished();
     void transactionTimeout();
@@ -873,6 +882,9 @@ private:
 
     /// To Keep-Alive or not to Keep-Alive
     bool d_use_http_keep_alive;
+
+    /// Allow HTTP Pipelining (TCP connection reuse)
+    bool d_use_http_pipelining;
 
     ///  publish transaction method
     enum pubnub_publish_method d_publish_method;


### PR DESCRIPTION
This PR allows the SDK client to allow HTTP Pipelining[1] on the QNetworkManager. 

By default, QNetworkManager has this option set at `false`[2]. The proposed implementation respects this by defaulting to `false` as well. 

This should also be working just fine with Pubnub's servers[3].

### Refs
1. https://en.wikipedia.org/wiki/HTTP_pipelining
2. `QNetworkRequest::HttpPipeliningAllowedAttribute`, https://doc.qt.io/qt-5/qnetworkrequest.html
3. https://support.pubnub.com/support/discussions/topics/14000006318