### PR TITLE
Unify thread safe macro

### DIFF
--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -12,6 +12,7 @@ extern "C" {
 
 #include "pubnub_qt.h"
 
+#include <QMutexLocker>
 #include <QtNetwork>
 
 /* Minimal acceptable message length difference, between unpacked and packed message, in percents */

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -92,11 +92,7 @@ public:
     void set_auth(QString const &auth);
 
     /** Returns the current auth key */
-    QString auth() const
-    {
-        QMutexLocker lk(&d_mutex);
-        return d_auth;
-    }
+    QString auth() const;
 
     /** Set the UUID to be used in this context.
      * After construction it is empty (null), thus not used.
@@ -124,10 +120,7 @@ public:
     void set_origin(QString const& origin);
 
     /** Returns the current origin */
-    QString const& origin() const {
-        QMutexLocker lk(&d_mutex);
-        return d_origin;
-    }
+    QString const& origin() const;
 
     /** Returns the string of an arrived message or other element of the
         response to an operation/transaction. Message(s) arrive on finish
@@ -161,7 +154,7 @@ public:
 
     /** Returns all (remaining) channels from a context */
     QStringList get_all_channels() const;
-    
+
     /** Cancels an ongoing API transaction. The outcome is not
      * guaranteed to be #PNR_CANCELLED like in other C-core based
      * APIs, because it depends on what Qt actually does with our
@@ -198,7 +191,7 @@ public:
      */
     pubnub_res publish(QString const &channel, QString const &message);
 
-    /** Function that initiates 'publish' transaction via POST method 
+    /** Function that initiates 'publish' transaction via POST method
         @param channel The string with the channel
         @param message The message to publish, expected to be in JSON format
 
@@ -405,7 +398,7 @@ public:
                        bool reverse,
                        QString const& end,
                        bool string_token);
-    
+
     /* In case the server reported en error in the response,
        we'll read the error message using this function
        @retval error_message on successfully read error message,
@@ -416,7 +409,7 @@ public:
     /* Get counts of received(unread) messages for each channel from
        @p channel list starting(in time) with @p timetoken(Meanning
        'initiates 'advanced history' message_counts operation/transaction')
-       
+
        If successful message will be available through get_channel_message_counts()
        in the map of channel_name-message_counts
        @return #PNR_STARTED on success, an error otherwise
@@ -426,7 +419,7 @@ public:
     /* Get counts of received(unread) messages for each channel from
        @p channel list starting(in time) with @p timetoken(Meanning
        'initiates 'advanced history' message_counts operation/transaction')
-       
+
        If successful message will be available through get_channel_message_counts()
        in the map of channel_name-message_counts
        @return #PNR_STARTED on success, an error otherwise
@@ -436,7 +429,7 @@ public:
     /* Get counts of received(unread) messages for each channel from
        @p channel list starting(in time) with @p channel_timetoken(per channel) list.
        (Meanning 'initiates 'advanced history' message_counts operation/transaction')
-       
+
        If successful message will be available through get_channel_message_counts()
        in the map of channel_name-message_counts
        @return #PNR_STARTED on success, an error otherwise
@@ -447,7 +440,7 @@ public:
     /* Get counts of received(unread) messages for each channel from
        @p channel list starting(in time) with @p channel_timetoken(per channel) list.
        (Meanning 'initiates 'advanced history' message_counts operation/transaction')
-       
+
        If successful message will be available through get_channel_message_counts()
        in the map of channel_name-message_counts
        @return #PNR_STARTED on success, an error otherwise
@@ -457,13 +450,13 @@ public:
 
     /* Starts 'advanced history' pubnub_message_counts transaction
        for unread messages on @p channel_timetokens(channel, ch_timetoken pairs)
-       
+
        If successful message will be available through get_channel_message_counts()
        in the map of channel_name-message_counts
        @return #PNR_STARTED on success, an error otherwise
      */
     pubnub_res message_counts(QVector<QPair<QString, QString>> const& channel_timetokens);
-    
+
     /* Extracts channel-message_count paired map from the response on
        'advanced history' pubnub_message_counts transaction.
        If there is no key "channels" in the response, or the corresponding
@@ -762,7 +755,7 @@ public:
      *  transaction was succesfull, will return 0.
      */
     int last_http_code() const;
-    
+
     /** Return the result string that Pubnub returned in the
      * reply to the last publish transaction. If the last
      * transaction was not a publish one, will return an
@@ -844,7 +837,7 @@ private:
 
     /// Qt's Reply (from a HTTP request)
     QScopedPointer<QNetworkReply> d_reply;
-    
+
     /// C-core context
     QScopedPointer<pbcc_context> d_context;
 
@@ -880,7 +873,9 @@ private:
     /// Message to publish via POST method
     QByteArray d_message_to_publish;
 
+#ifdef PUBNUB_THREADSAFE
     mutable QMutex d_mutex;
+#endif
 };
 
 

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -9,7 +9,6 @@
 #include <QStringList>
 #include <QDebug>
 #include <QJsonDocument>
-#include <QMutexLocker>
 #include <QMap>
 #include <QPair>
 


### PR DESCRIPTION
Allow complete control wether pubnub_qt implementation is thread safe or not through the existing macro KEEP_THREAD_SAFE. 