### PR TITLE
fix assertion fail after 24 days

### DIFF
--- a/lib/msstopwatch/msstopwatch.h
+++ b/lib/msstopwatch/msstopwatch.h
@@ -29,8 +29,8 @@
 #include <stdbool.h>
 
 
-typedef struct { int32_t t_ref; } pbmsref_t;
-typedef int32_t pbms_t;
+typedef struct { int64_t t_ref; } pbmsref_t;
+typedef int32_t pbms_t;		/* Warning!  Overflows after 24d 20h 31m	*/
 
 /** Starts a stopwatch. The result has no particular meaning, 
     is only to be used as the parameter of pbms_elapsed().

--- a/posix/msstopwatch_monotonic_clock.c
+++ b/posix/msstopwatch_monotonic_clock.c
@@ -11,10 +11,11 @@
     clock like POSIX clock_gettime(CLOCK_MONOTONIC,...);
 */
 
-static int32_t msclock(void)
+static int64_t msclock(void)
 {
     struct timespec ts;
     if (0 == monotonic_clock_get_time(&ts)) {
+        /* 32 bit overflows after 2,147,483,648 / 1000 / 24 / 3600 = 24,855 days	*/
         return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
     }
     else {


### PR DESCRIPTION
```
24 days =	2 073 600 000 milliseconds
int32 max =	2 147 483 647
25 days =	2 160 000 000 milliseconds
```

Hence we need an int64_t to store the clock value