### PR TITLE
fix assertion fail after 24 days (32 bit variant)

### DIFF
--- a/posix/msstopwatch_monotonic_clock.c
+++ b/posix/msstopwatch_monotonic_clock.c
@@ -15,10 +15,12 @@ static int32_t msclock(void)
 {
     struct timespec ts;
     if (0 == monotonic_clock_get_time(&ts)) {
-        return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+        /* 32 bit overflows after 2,147,483,648 / 1000 / 24 / 3600 = 24,855 days	*/
+        int32_t ret = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+        return !ret ? -1 : ret;
     }
     else {
-        return -1;
+        return 0;
     }
 }
 
@@ -32,13 +34,13 @@ pbmsref_t pbms_start(void)
 
 void pbms_stop(pbmsref_t* psw)
 {
-    psw->t_ref = -1;
+    psw->t_ref = 0;
 }
 
 
 bool pbms_active(pbmsref_t stopwatch)
 {
-    return stopwatch.t_ref > -1;
+    return stopwatch.t_ref != 0;
 }
 
 


### PR DESCRIPTION
```
24 days =	2 073 600 000 milliseconds
int32 max =	2 147 483 647
25 days =	2 160 000 000 milliseconds
```

This variant fixes the problem of the overrun after 24 days.
It does so by not giving back the "uninitialized value" (0) on accident.

On edge cases it makes measurements wrong by +-1ms.
Also there is a rollover after 24 days.  With 32 bit this cannot be circumvented.

Why 0 as uninitialized value?  Because this copes well with "static" initialization.

Why -1 and not 1 as the alternate value when accidentally hitting 0?
Because -1 is a more descriptive "I am on the edge" than just 1.