### PR TITLE
Fetch history not accepting 0 or 1 as Boolean values

### DIFF
--- a/core/pubnub_ccore.c
+++ b/core/pubnub_ccore.c
@@ -177,8 +177,12 @@ enum pubnub_res pbcc_history_prep(struct pbcc_context* pb,
     APPEND_URL_PARAM_M(pb, "auth", pb->auth, '&');
     APPEND_URL_PARAM_UNSIGNED_M(pb, "count", count, '&');
     APPEND_URL_PARAM_BOOL_M(pb, "include_token", include_token, '&');
-    APPEND_URL_PARAM_BOOL_M(pb, "stringtoken", string_token, '&');
-    APPEND_URL_PARAM_BOOL_M(pb, "reverse", reverse, '&');
+    if ((string_token) != pbccNotSet) {
+        APPEND_URL_PARAM_BOOL_M(pb, "stringtoken", string_token, '&');
+    }
+    if ((reverse) != pbccNotSet) {
+        APPEND_URL_PARAM_BOOL_M(pb, "reverse", reverse, '&');
+    }
     APPEND_URL_PARAM_M(pb, "start", start, '&');
     APPEND_URL_PARAM_M(pb, "start", end, '&');
 


### PR DESCRIPTION
Hey guys, 
I had issues using pubnub_history_ex. Setting the arguments 'stringtoken' and 'reverse' to true had no effect. After investigating I found out that apparently the [PubNub REST API for fetching the history](https://www.pubnub.com/docs/pubnub-rest-api-documentation#history) wants to have only true and false as Boolean values, in the code those values were encoded as 1 and 0 however. Changing the macros for those two arguments from APPEND_URL_PARAM_TRIBOOL_M to APPEND_URL_PARAM_BOOL_M fixed the issue.