### PR TITLE
Auto heartbeat posix

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: 2.11.1
+version: 2.12.0
 scm: github.com/pubnub/c-core
 changelog:
+  - version: v2.12.0
+    date: Nov 15, 2019
+    changes:
+      - type: enhancement
+        text: Support automatic sending of heartbeat messages (only on POSIX, callback, for now).
   - version: v2.11.1
     date: Oct 25, 2019
     changes:

--- a/core/pbauto_heartbeat_sync.c
+++ b/core/pbauto_heartbeat_sync.c
@@ -1,0 +1,75 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#include "pubnub_assert.h"
+#include "pubnub_api_types.h"
+
+#include <stddef.h>
+
+struct pubnub_;
+
+/** A pubnub context. An opaque data structure that holds all the data
+    needed for a context.
+ */
+typedef struct pubnub_ pubnub_t;
+
+int pubnub_enable_auto_heartbeat(pubnub_t* pb, size_t period_sec)
+{
+    PUBNUB_UNUSED(pb);
+    return 0;
+}
+
+int pubnub_set_heartbeat_period(pubnub_t* pb, size_t period_sec)
+{
+    PUBNUB_UNUSED(pb);
+    return 0;
+}
+
+void pubnub_disable_auto_heartbeat(pubnub_t* pb)
+{
+    PUBNUB_UNUSED(pb);
+}
+
+bool pubnub_is_auto_heartbeat_enabled(pubnub_t* pb)
+{
+    PUBNUB_UNUSED(pb);
+    return false;
+}
+
+void pubnub_heartbeat_free_thumpers(void)
+{
+    return;
+}
+
+void pbauto_heartbeat_read_channelInfo(pubnub_t const* pb,
+                                       char const** channel,
+                                       char const** channel_group)
+{
+    PUBNUB_UNUSED(pb);
+}
+
+void pbauto_heartbeat_transaction_ongoing(pubnub_t const* pb)
+{
+    PUBNUB_UNUSED(pb);
+}
+
+void pbauto_heartbeat_start_timer(pubnub_t const* pb)
+{
+    PUBNUB_UNUSED(pb);
+}
+
+void pbauto_heartbeat_free_channelInfo(pubnub_t* pb)
+{
+    PUBNUB_UNUSED(pb);
+}
+
+enum pubnub_res pbauto_heartbeat_prepare_channels_and_ch_groups(pubnub_t* pb,
+                                                                char const** channel,
+                                                                char const** channel_group)
+{
+    PUBNUB_UNUSED(pb);
+    return PNR_OK;
+}
+
+void pbauto_heartbeat_stop(void)
+{
+    return;
+}

--- a/core/pbcc_advanced_history.c
+++ b/core/pbcc_advanced_history.c
@@ -3,6 +3,7 @@
 
 #if PUBNUB_USE_ADVANCED_HISTORY
 #include "pubnub_memory_block.h"
+#include "pubnub_server_limits.h"
 #include "pubnub_advanced_history.h"
 #include "pubnub_version.h"
 #include "pubnub_json_parse.h"

--- a/core/pubnub_actions_api.h
+++ b/core/pubnub_actions_api.h
@@ -23,15 +23,15 @@
     @return #PNR_STARTED on success, an error otherwise
   */
 enum pubnub_res pubnub_add_message_action(pubnub_t* pb,
-                                  char const* channel,
-                                  char const* message_timetoken,
-                                  enum pubnub_action_type actype,
-                                  char const* value);
+                                          char const* channel,
+                                          char const* message_timetoken,
+                                          enum pubnub_action_type actype,
+                                          char const* value);
 
 
 /** Searches the response(if previous transaction on the @p pb context had been
-    pubnub_add_action and was accomplished successfully) and retrieves timetoken of a message
-    action was added on.
+    pubnub_add_message_action and was accomplished successfully) and retrieves timetoken of
+    a message action was added on.
     If key expected is not found, preconditions(about right transaction) were not fulfilled,
     or error was encountered,
     returned structure has 0 'size' field and NULL 'ptr' field.
@@ -43,7 +43,7 @@ pubnub_chamebl_t pubnub_get_message_timetoken(pubnub_t* pb);
 
 
 /** Searches the response(if previous transaction on the @p pb context had been
-    pubnub_add_action and was accomplished successfully) and retrieves timetoken of a
+    pubnub_add_message_action and was accomplished successfully) and retrieves timetoken of a
     resently added action.
     If key expected is not found, preconditions were not fulfilled, or error was encountered,
     returned structure has 0 'size' field and NULL 'ptr' field.
@@ -68,16 +68,16 @@ pubnub_chamebl_t pubnub_get_message_action_timetoken(pubnub_t* pb);
     @return #PNR_STARTED on success, an error otherwise
   */
 enum pubnub_res pubnub_remove_message_action(pubnub_t* pb,
-                                     char const* channel,
-                                     pubnub_chamebl_t message_timetoken,
-                                     pubnub_chamebl_t action_timetoken);
+                                             char const* channel,
+                                             pubnub_chamebl_t message_timetoken,
+                                             pubnub_chamebl_t action_timetoken);
 
 
 /** Initiates transaction that returns all actions added on a given @p channel between @p start
     and @p end action timetoken.
     The response to this transaction can be partial and than it contains the hyperlink string
     value to the rest.
-    @see pubnub_get_actions_more()
+    @see pubnub_get_message_actions_more()
     If there is no actions data, nor error description in the response it is considered
     format error.
     @param pb The pubnub context. Can't be NULL
@@ -92,10 +92,10 @@ enum pubnub_res pubnub_remove_message_action(pubnub_t* pb,
     @return #PNR_STARTED on success, an error otherwise
   */
 enum pubnub_res pubnub_get_message_actions(pubnub_t* pb,
-                                   char const* channel,
-                                   char const* start,
-                                   char const* end,
-                                   size_t limit);
+                                           char const* channel,
+                                           char const* start,
+                                           char const* end,
+                                           size_t limit);
 
 
 /** This function expects previous transaction to be the one for reading the actions and
@@ -119,7 +119,7 @@ enum pubnub_res pubnub_get_message_actions_more(pubnub_t* pb);
     and @p end message timetoken.
     The response to this transaction can be partial and than it contains the hyperlink string
     value to the rest.
-    @see pubnub_history_with_actions_more()
+    @see pubnub_history_with_message_actions_more()
     If there is no actions data, nor error description in the response it is considered
     format error.
     @param pb The pubnub context. Can't be NULL
@@ -134,10 +134,10 @@ enum pubnub_res pubnub_get_message_actions_more(pubnub_t* pb);
     @return #PNR_STARTED on success, an error otherwise
   */
 enum pubnub_res pubnub_history_with_message_actions(pubnub_t* pb,
-                                            char const* channel,
-                                            char const* start,
-                                            char const* end,
-                                            size_t limit);
+                                                    char const* channel,
+                                                    char const* start,
+                                                    char const* end,
+                                                    size_t limit);
 
 
 /** This function expects previous transaction to be the one for reading the history with
@@ -147,7 +147,7 @@ enum pubnub_res pubnub_history_with_message_actions(pubnub_t* pb,
     in the existing response context buffer which it uses for obtaining another
     part of the server response. Anotherwords, once the hyperlink is found in the existing
     response it is used for initiating new request and function than behaves as
-    pubnub_history_with_actions().
+    pubnub_history_with_message_actions().
     If there is no hyperlink encountered in the previous transaction response it
     returns success: PNR_GOT_ALL_ACTIONS meaning that the answer is complete.
     @param pb The pubnub context containing response buffer to be searched. Can't be NULL

--- a/core/pubnub_alloc_static.c
+++ b/core/pubnub_alloc_static.c
@@ -69,6 +69,8 @@ int pubnub_free(pubnub_t *pb)
     pbnc_stop(pb, PNR_CANCELLED);
     if (PBS_IDLE == pb->state) {
         PUBNUB_LOG_TRACE("pubnub_free(%p) PBS_IDLE\n", pb);
+        pubnub_disable_auto_heartbeat(pb);
+        pbauto_heartbeat_free_channelInfo(pb);
         pb->state = PBS_NULL;
 #if defined(PUBNUB_CALLBACK_API)
         pbntf_requeue_for_processing(pb);

--- a/core/pubnub_alloc_std.c
+++ b/core/pubnub_alloc_std.c
@@ -144,6 +144,8 @@ int pubnub_free(pubnub_t* pb)
     pbnc_stop(pb, PNR_CANCELLED);
     if (PBS_IDLE == pb->state) {
         PUBNUB_LOG_TRACE("pubnub_free(%p) PBS_IDLE\n", pb);
+        pubnub_disable_auto_heartbeat(pb);
+        pbauto_heartbeat_free_channelInfo(pb);
         pb->state = PBS_NULL;
 #if defined(PUBNUB_CALLBACK_API)
         pbntf_requeue_for_processing(pb);

--- a/core/pubnub_api_types.h
+++ b/core/pubnub_api_types.h
@@ -95,6 +95,8 @@ enum pubnub_res {
     PNR_REPLY_TOO_BIG,
     /** An internal error in processing */
     PNR_INTERNAL_ERROR,
+    /** Ran out of dynamic memory */
+    PNR_OUT_OF_MEMORY,
     /** Encryption (and decryption) not supported */
     PNR_CRYPTO_NOT_SUPPORTED,
     /** Bad compression format or compressed data corrupted */

--- a/core/pubnub_auto_heartbeat.h
+++ b/core/pubnub_auto_heartbeat.h
@@ -1,0 +1,106 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#if !defined INC_PBAUTO_HEARTBEAT
+#define INC_PBAUTO_HEARTBEAT
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+/** Maximum number of auto heartbeat thumpers that can be used at one time */
+#define PUBNUB_MAX_HEARTBEAT_THUMPERS 16
+#define UNASSIGNED PUBNUB_MAX_HEARTBEAT_THUMPERS
+
+
+/** Pubnub context fields for saving subscribed channels and channel groups
+  */
+#define M_channelInfo()                                       \
+    struct {                                                  \
+        char* channel;                                        \
+        char* channel_group;                                  \
+    } channelInfo;
+
+/** Pubnub context fields for heartbeat info used by the module for keeping presence.
+ */
+#define M_heartbeatInfo() unsigned thumperIndex;
+
+/** Enables periodical heartbeats that keep presence on subscribed channels and channel
+    groups for uuid provided in @p pb context and sets chosen heartbeat period.
+    Initially auto heartbeat on @p pb context is disabled.
+
+    This module keeps presence by performing pubnub_heartbeat() transaction periodicaly
+    with uuid given whenever subscription on @p pb context is not in progress and
+    auto heartbeat is enabled. This process is independent from anything user
+    may be doing with the context when its not subscribing(, or heartbeating).
+
+    If the uuid(or any other relevant data, like dns server, or proxy) is changed at
+    some point, the module will update it automatically in its heartbeats.
+    The same goes if the uuid leaves some of the channels, or channel groups.
+
+    @param pb The pubnub context. Can't be NULL
+    @param period_sec Auto heartbeat thumping period in seconds
+    @return 0 on success, -1 otherwise
+  */
+int pubnub_enable_auto_heartbeat(pubnub_t* pb, size_t period_sec);
+
+/** Changes auto heartbeat thumping period. If auto heartbeat is desabled on
+    the @p pb context the period wan't be changed and function returns error.
+    @param pb The pubnub context. Can't be NULL
+    @param period_sec Auto heartbeat thumping period in seconds
+    @return 0 on success, -1 otherwise
+  */
+int pubnub_set_heartbeat_period(pubnub_t* pb, size_t period_sec);
+
+/** Disables auto heartbeat on the @p pb context.
+  */
+void pubnub_disable_auto_heartbeat(pubnub_t* pb);
+
+/** Returns if auto heartbeat is enabled on the @p pb context.
+  */
+bool pubnub_is_auto_heartbeat_enabled(pubnub_t* pb);
+
+/** Releases all allocated heartbeat thumpers.
+  */
+void pubnub_heartbeat_free_thumpers(void);
+
+/** Reads channel and channel groups saved(subscribed on)
+  */
+void pbauto_heartbeat_read_channelInfo(pubnub_t const* pb,
+                                       char const** channel,
+                                       char const** channel_group);
+
+/** Gives notice to auto heartbeat module that subscribe, or heartbeat transaction has begun */
+void pbauto_heartbeat_transaction_ongoing(pubnub_t const* pb);
+
+/** Starts auto heartbeat timer, if auto heartbeat is enabled, when subscribe transaction
+    is finished.
+  */
+void pbauto_heartbeat_start_timer(pubnub_t const* pb);
+
+/** Releases allocated strings for subscribed channels and channel groups
+  */
+void pbauto_heartbeat_free_channelInfo(pubnub_t* pb);
+
+/** Preparess channels and channel groups, to be used in request url.
+  */
+enum pubnub_res pbauto_heartbeat_prepare_channels_and_ch_groups(pubnub_t* pb,
+                                                                char const** channel,
+                                                                char const** channel_group);
+
+/** Stops auto heartbeat thread */
+void pbauto_heartbeat_stop(void);
+
+#else
+#define M_channelInfo()
+#define M_heartbeatInfo()
+#define pubnub_enable_auto_heartbeat(pb, period_sec) -1
+#define pubnub_set_heartbeat_period(pb, period_sec) -1
+#define pubnub_disable_auto_heartbeat(pb)
+#define pubnub_is_auto_heartbeat_enabled(pb) false
+#define pubnub_heartbeat_free_thumpers()
+#define pbauto_heartbeat_read_channelInfo(pb, channel, channel_group)
+#define pbauto_heartbeat_transaction_ongoing(pb)
+#define pbauto_heartbeat_start_timer(pb)
+#define pbauto_heartbeat_free_channelInfo(pb)
+#define pbauto_heartbeat_prepare_channels_and_ch_groups(pb, addr_channel, addr_channel_group) PNR_OK
+#define pbauto_heartbeat_stop()
+#endif /* PUBNUB_USE_AUTO_HEARTBEAT */
+
+#endif /* !defined INC_PBAUTO_HEARTBEAT */
+

--- a/core/pubnub_ccore_limits.h
+++ b/core/pubnub_ccore_limits.h
@@ -1,0 +1,12 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#if !defined INC_PUBNUB_CCORE_LIMITS
+#define      INC_PUBNUB_CCORE_LIMITS
+
+/** Minimal duration of the transaction timer, in milliseconds. You
+ * can't set less than this.
+ */
+#if !defined PUBNUB_MIN_TRANSACTION_TIMER
+#define PUBNUB_MIN_TRANSACTION_TIMER 10000
+#endif
+
+#endif /* !defined INC_PUBNUB_CCORE_LIMITS */

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -3,6 +3,7 @@
 #include "cgreen/mocks.h"
 
 #include "pubnub_internal.h"
+#include "pubnub_server_limits.h"
 #include "pubnub_pubsubapi.h"
 #include "pubnub_coreapi.h"
 #if PUBNUB_USE_ADVANCED_HISTORY

--- a/core/pubnub_coreapi.h
+++ b/core/pubnub_coreapi.h
@@ -51,6 +51,11 @@ typedef struct pubnub_char_mem_block pubnub_chamebl_t;
     subscribe to another in the same context to avoid loosing
     messages. Also, it is useful for tracking presence.
 
+    When auto heartbeat is enabled at compile time both @p channel
+    and channel groups could be passed as NULL which suggests default
+    behaviour in which case transaction uses channel and channel groups
+    that are already subscribed and leaves all of them.
+
     You can't leave if a transaction is in progress on the context.
 
     @param p The Pubnub context. Can't be NULL.  
@@ -115,6 +120,11 @@ enum pubnub_res pubnub_history(pubnub_t *p, const char *channel, unsigned count,
     channel_group.  This actually means "initiate a heartbeat
     transaction". It can be thought of as an update against the
     "presence database".
+
+    When auto heartbeat is enabled at compile time both @p channel
+    and @p channel_group could be passed as NULL which suggests default
+    behaviour in which case transaction uses channel and channel groups
+    that are already subscribed.
 
     If transaction is successful, the response will be a available
     via pubnub_get() as one message, a JSON object. Following keys

--- a/core/pubnub_coreapi_ex.h
+++ b/core/pubnub_coreapi_ex.h
@@ -110,6 +110,11 @@ struct pubnub_subscribe_options pubnub_subscribe_defopts(void);
 /** The extended subscribe. Basically the same as pubnub_subscribe()
     but with options (except @p channel) given in @p opts.
 
+    When auto heartbeat is enabled at compile time both @p channel
+    and channel groups could be passed as NULL which suggests default
+    behaviour(unless it is uuid's very first subscription) in which case
+    transaction uses channel and channel groups that are already subscribed.
+
     Basic usage:
 
         struct pubnub_subscribe_options opt = pubnub_subscribe_defopts();

--- a/core/pubnub_helper.c
+++ b/core/pubnub_helper.c
@@ -64,6 +64,7 @@ char const* pubnub_res_2_string(enum pubnub_res e)
     case PNR_CHANNEL_REGISTRY_ERROR: return "A transaction related to channel registry failed";
     case PNR_REPLY_TOO_BIG: return "Reply from Pubnub too big to fit in buffer";
     case PNR_INTERNAL_ERROR: return "Internal error in processing";
+    case PNR_OUT_OF_MEMORY: return "Ran out of dynamic memory";
     case PNR_CRYPTO_NOT_SUPPORTED: return "Encryption/decryption not supported";
     case PNR_BAD_COMPRESSION_FORMAT: return "Bad data compression format";
     case PNR_INVALID_PARAMETERS: return "Invalid function parameters";
@@ -132,6 +133,7 @@ enum pubnub_tribool pubnub_should_retry(enum pubnub_res e)
     case PNR_CHANNEL_REGISTRY_ERROR: return pbccFalse; /* Fix the error reported */
     case PNR_REPLY_TOO_BIG: return pbccFalse; /* Rebuild with bigger buffer */
     case PNR_INTERNAL_ERROR: return pbccFalse; /* Sorry, something went wrong... */
+    case PNR_OUT_OF_MEMORY: return pbccFalse; /* Try memory optimization */
     case PNR_CRYPTO_NOT_SUPPORTED: return pbccFalse; /* Use a platform that supports encryption, say OpenSSL */
     case PNR_BAD_COMPRESSION_FORMAT: return pbccNotSet; /* If bad compressing was transient, a retry might help */
     case PNR_INVALID_PARAMETERS: return pbccFalse; /* Check and fix invalid parameters */

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -51,6 +51,11 @@
 #define PUBNUB_USE_ACTIONS_API 0
 #endif
 
+#if !defined(PUBNUB_USE_AUTO_HEARTBEAT)
+#define PUBNUB_USE_AUTO_HEARTBEAT 0
+#endif
+#include "core/pubnub_auto_heartbeat.h"
+
 #if !defined(PUBNUB_PROXY_API)
 #define PUBNUB_PROXY_API 0
 #elif PUBNUB_PROXY_API
@@ -388,7 +393,17 @@ struct pubnub_ {
     struct pubnub_multi_addresses spare_addresses;
 #endif
 #endif /* defined(PUBNUB_CALLBACK_API) */
+
+    /** Subscribed channels and channel groups saved.
+        Exist when auto heartbeat support is enabled.
+      */
+    M_channelInfo()
     
+    /** Pubnub context fields for heartbeat info used by the module for keeping presence.
+        Exist when auto heartbeat support is enabled.
+      */
+    M_heartbeatInfo()
+
 #if PUBNUB_PROXY_API
 
     /** The type (protocol) of the proxy to use */

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -154,6 +154,7 @@ static bool should_keep_alive(struct pubnub_* pb, enum pubnub_res rslt)
 #endif
         switch (rslt) {
         case PNR_ADDR_RESOLUTION_FAILED:
+        case PNR_WAIT_CONNECT_TIMEOUT:
         case PNR_CONNECT_FAILED:
         case PNR_CONNECTION_TIMEOUT:
         case PNR_TIMEOUT:
@@ -329,7 +330,10 @@ static enum pubnub_res parse_pubnub_result(struct pubnub_* pb)
                            pbres,
                            pb->core.http_reply);
     }
-
+    else {
+        pbauto_heartbeat_start_timer(pb);
+    }
+    
     return pbres;
 }
 
@@ -1016,6 +1020,7 @@ next_state:
         }
         break;
     case PBS_RX_HTTP_VER:
+        pbauto_heartbeat_transaction_ongoing(pb);
         pbrslt = pbpal_line_read_status(pb);
         PUBNUB_LOG_TRACE("pb=%p PBS_RX_HTTP_VER: pbrslt=%d\n", pb, pbrslt);
         switch (pbrslt) {

--- a/core/pubnub_proxy_NTLM_test.c
+++ b/core/pubnub_proxy_NTLM_test.c
@@ -1,3 +1,7 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#include "pubnub_internal.h"
+
+#include "pubnub_version_internal.h"
 #include "pubnub_pubsubapi.h"
 #include "pubnub_coreapi.h"
 #include "pubnub_assert.h"
@@ -5,8 +9,6 @@
 #include "pubnub_log.h"
 
 #include "pbpal.h"
-#include "pubnub_internal.h"
-#include "pubnub_version_internal.h"
 #include "pubnub_test_helper.h"
 #include "pubnub_proxy.h"
 

--- a/core/pubnub_proxy_unit_test.c
+++ b/core/pubnub_proxy_unit_test.c
@@ -2,8 +2,9 @@
 #include "cgreen/cgreen.h"
 #include "cgreen/mocks.h"
 
-#include "pubnub_test_helper.h"
+#include "pubnub_internal.h"
 #include "pubnub_version_internal.h"
+#include "pubnub_test_helper.h"
 #include "pubnub_pubsubapi.h"
 #include "pubnub_coreapi.h"
 #include "pubnub_assert.h"
@@ -11,7 +12,6 @@
 #include "pubnub_log.h"
 
 #include "pbpal.h"
-#include "pubnub_internal.h"
 #include "pubnub_keep_alive.h"
 #include "pubnub_proxy.h"
 #include "pubnub_json_parse.h"

--- a/core/pubnub_pubsubapi.h
+++ b/core/pubnub_pubsubapi.h
@@ -217,6 +217,11 @@ char const* pubnub_get_channel(pubnub_t* pb);
     ways: if @p channel_group is NULL, then @p channel cannot be NULL
     and you will subscribe only to the channel(s).
 
+    When auto heartbeat is enabled at compile time both @p channel
+    and @p channel_group could be passed as NULL which suggests default
+    behaviour(unless it is uuid's very first subscription) in which case
+    transaction uses channel and channel groups that are already subscribed.
+
     You can't subscribe if a transaction is in progress on the context.
 
     Also, you can't subscribe if there are unread messages in the

--- a/core/pubnub_server_limits.h
+++ b/core/pubnub_server_limits.h
@@ -1,0 +1,14 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#if !defined INC_PUBNUB_SERVER_LIMITS
+#define      INC_PUBNUB_SERVER_LIMITS
+
+/** Minimal presence heartbeat interval supported by
+    Pubnub, in seconds.
+*/
+#define PUBNUB_MINIMAL_HEARTBEAT_INTERVAL 270
+
+/** The maximum channel name length */
+#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
+
+#endif /* !defined INC_PUBNUB_SERVER_LIMITS */
+

--- a/core/pubnub_subscribe_v2.c
+++ b/core/pubnub_subscribe_v2.c
@@ -1,6 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
 #include "pubnub_internal.h"
 
+#include "pubnub_server_limits.h"
 #include "pubnub_subscribe_v2.h"
 #include "pbcc_subscribe_v2.h"
 #include "pubnub_ccore_pubsub.h"
@@ -11,12 +12,6 @@
 #include "pubnub_json_parse.h"
 
 #include "pbpal.h"
-
-
-/** Minimal presence heartbeat interval supported by
-    Pubnub, in seconds.
-*/
-#define PUBNUB_MINIMAL_HEARTBEAT_INTERVAL 270
 
 
 struct pubnub_subscribe_v2_options pubnub_subscribe_v2_defopts(void)
@@ -41,6 +36,10 @@ enum pubnub_res pubnub_subscribe_v2(pubnub_t*                          p,
     if (!pbnc_can_start_transaction(p)) {
         pubnub_mutex_unlock(p->monitor);
         return PNR_IN_PROGRESS;
+    }
+    rslt = pbauto_heartbeat_prepare_channels_and_ch_groups(p, &channel, &opt.channel_group);
+    if (rslt != PNR_OK) {
+        return rslt;
     }
 
     rslt = pbcc_subscribe_v2_prep(

--- a/core/pubnub_subscribe_v2.h
+++ b/core/pubnub_subscribe_v2.h
@@ -61,6 +61,11 @@ struct pubnub_subscribe_v2_options pubnub_subscribe_v2_defopts(void);
     pubnub_get_v2() - keep in mind that it can provide you with
     channel and channel group info.
 
+    When auto heartbeat is enabled at compile time both @p channel
+    and channel groups could be passed as NULL which suggests default
+    behaviour(unless it is uuid's very first subscription) in which case
+    transaction uses channel and channel groups that are already subscribed.
+
     Basic usage:
 
         struct pubnub_subscribe_v2_options opt = pubnub_subscribe_v2_defopts();

--- a/core/pubnub_subscribe_with_state.c
+++ b/core/pubnub_subscribe_with_state.c
@@ -1,8 +1,8 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
-#include "pubnub_coreapi.h"
-
-#include "pubnub_netcore.h"
 #include "pubnub_internal.h"
+
+#include "pubnub_coreapi.h"
+#include "pubnub_netcore.h"
 #include "pubnub_assert.h"
 #include "pubnub_version.h"
 #include "pubnub_url_encode.h"
@@ -49,7 +49,10 @@ static enum pubnub_res pbcc_subscribe_with_state_prep(struct pbcc_context *p,
 }
 
 
-enum pubnub_res pubnub_subscribe_with_state(pubnub_t *p, const char *channel, const char *channel_group, char const *state)
+enum pubnub_res pubnub_subscribe_with_state(pubnub_t *p,
+                                            const char *channel,
+                                            const char *channel_group,
+                                            char const *state)
 {
     enum pubnub_res rslt;
 
@@ -59,6 +62,10 @@ enum pubnub_res pubnub_subscribe_with_state(pubnub_t *p, const char *channel, co
     if (!pbnc_can_start_transaction(pb)) {
         pubnub_mutex_unlock(p->monitor);
         return PNR_IN_PROGRESS;
+    }
+    rslt = pbauto_heartbeat_prepare_channels_and_ch_groups(p, &channel, &channel_group);
+    if (rslt != PNR_OK) {
+        return rslt;
     }
     
     rslt = pbcc_subscribe_with_state_prep(&p->core, channel, channel_group, state);

--- a/core/pubnub_subscribe_with_state.h
+++ b/core/pubnub_subscribe_with_state.h
@@ -18,6 +18,11 @@
     various subtle differences in behavior when subscribing with state
     (as opposed to "regular" subscribing without state).
 
+    When auto heartbeat is enabled at compile time both @p channel
+    and @p channel_group could be passed as NULL which suggests default
+    behaviour(unless it is uuid's very first subscription) in which case
+    transaction uses channel and channel groups that are already subscribed.
+
     It is in all aspects quite similar to pubnub_subscribe(), except that
     the caller should provide a JSON object @p state.
 

--- a/core/pubnub_timers.c
+++ b/core/pubnub_timers.c
@@ -1,9 +1,9 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
-#include "pubnub_timers.h"
+#include "pubnub_internal.h"
 
+#include "pubnub_timers.h"
 #include "pubnub_assert.h"
 #include "pubnub_log.h"
-#include "pubnub_internal.h"
 
 
 int pubnub_set_transaction_timeout(pubnub_t* p, int duration_ms)

--- a/core/pubnub_timers.h
+++ b/core/pubnub_timers.h
@@ -4,6 +4,7 @@
 
 
 #include "pubnub_api_types.h"
+#include "pubnub_ccore_limits.h"
 
 
 /** @file pubnub_timers.h

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "2.11.1"
+#define PUBNUB_SDK_VERSION "2.12.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/core/test/pubnub_config.h
+++ b/core/test/pubnub_config.h
@@ -57,9 +57,6 @@
 */
 #define PUBNUB_ORIGIN  "pubsub.pubnub.com"
 
-/** The maximum channel name length */
-#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
-
 /** The maximum length (in characters) of the host name of the proxy
     that will be saved in the Pubnub context.
 */

--- a/cpp/posix.mk
+++ b/cpp/posix.mk
@@ -32,38 +32,40 @@ ifndef USE_ACTIONS_API
 USE_ACTIONS_API = 1
 endif
 
+ifndef USE_AUTO_HEARTBEAT
+USE_AUTO_HEARTBEAT = 1
+endif
+
 ifeq ($(USE_PROXY), 1)
 SOURCEFILES += ../core/pubnub_proxy.c ../core/pubnub_proxy_core.c ../core/pbhttp_digest.c ../core/pbntlm_core.c ../core/pbntlm_packer_std.c
 endif
 
 ifeq ($(USE_GZIP_COMPRESSION), 1)
 SOURCEFILES += ../lib/miniz/miniz_tdef.c ../lib/miniz/miniz.c ../lib/pbcrc32.c ../core/pbgzip_compress.c
-OBJFILES += miniz_tdef.o miniz.o pbcrc32.o pbgzip_compress.o
 endif
 
 ifeq ($(RECEIVE_GZIP_RESPONSE), 1)
 SOURCEFILES += ../lib/miniz/miniz_tinfl.c ../core/pbgzip_decompress.c
-OBJFILES += miniz_tinfl.o pbgzip_decompress.o
 endif
 
 ifeq ($(USE_SUBSCRIBE_V2), 1)
 SOURCEFILES += ../core/pbcc_subscribe_v2.c ../core/pubnub_subscribe_v2.c 
-OBJFILES += pbcc_subscribe_v2.o pubnub_subscribe_v2.o
 endif
 
 ifeq ($(USE_ADVANCED_HISTORY), 1)
 SOURCEFILES += ../core/pbcc_advanced_history.c ../core/pubnub_advanced_history.c
-OBJFILES += pbcc_advanced_history.o pubnub_advanced_history.o
 endif
 
 ifeq ($(USE_OBJECTS_API), 1)
 SOURCEFILES += ../core/pbcc_objects_api.c ../core/pubnub_objects_api.c
-OBJFILES += pbcc_objects_api.o pubnub_objects_api.o
 endif
 
 ifeq ($(USE_ACTIONS_API), 1)
 SOURCEFILES += ../core/pbcc_actions_api.c ../core/pubnub_actions_api.c
-OBJFILES += pbcc_actions_api.o pubnub_actions_api.o
+endif
+
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SOURCEFILES += ../lib/pbstr_remove_from_list.c
 endif
 
 OS := $(shell uname)
@@ -75,7 +77,7 @@ SOURCEFILES += ../posix/monotonic_clock_get_time_posix.c
 LDLIBS=-lrt -lpthread
 endif
 
-CFLAGS =-g -I .. -I ../posix -I . -Wall -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API)
+CFLAGS =-g -I .. -I ../posix -I . -Wall -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API) -D PUBNUB_USE_AUTO_HEARTBEAT=$(USE_AUTO_HEARTBEAT)
 # -g enables debugging, remove to get a smaller executable
 
 
@@ -85,17 +87,23 @@ cpp98: pubnub_sync_sample pubnub_callback_sample cancel_subscribe_sync_sample su
 
 cpp11: pubnub_callback_cpp11_sample futres_nesting_callback_cpp11 fntest_runner pubnub_callback_cpp11_subloop_sample
 
-pubnub_sync_sample: samples/pubnub_sample.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/pubnub_sample.cpp ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+SYNC_INTF_SOURCEFILES=../core/pubnub_ntf_sync.c ../core/srand_from_pubnub_time.c
 
-cancel_subscribe_sync_sample: samples/cancel_subscribe_sync_sample.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/cancel_subscribe_sync_sample.cpp ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SYNC_INTF_SOURCEFILES += ../core/pbauto_heartbeat_sync.c
+endif
 
-futres_nesting_sync: samples/futres_nesting.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/futres_nesting.cpp ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+pubnub_sync_sample: samples/pubnub_sample.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/pubnub_sample.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
 
-pubnub_sync_subloop_sample: samples/pubnub_subloop_sample.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/pubnub_subloop_sample.cpp ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+cancel_subscribe_sync_sample: samples/cancel_subscribe_sync_sample.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/cancel_subscribe_sync_sample.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+
+futres_nesting_sync: samples/futres_nesting.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/futres_nesting.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+
+pubnub_sync_subloop_sample: samples/pubnub_subloop_sample.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS)  -x c++ samples/pubnub_subloop_sample.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
 
 ##
 # The socket poller module to use. You should use the `poll` poller, it
@@ -104,10 +112,8 @@ pubnub_sync_subloop_sample: samples/pubnub_subloop_sample.cpp $(SOURCEFILES) ../
 # WSAPoll() has some weird differences to poll().  The names are the
 # same until the last `_`, then it's `poll` vs `select`.
 SOCKET_POLLER_C=../lib/sockets/pbpal_ntf_callback_poller_poll.c
-SOCKET_POLLER_OBJ=pbpal_ntf_callback_poller_poll.o
 
 CALLBACK_INTF_SOURCEFILES= ../posix/pubnub_ntf_callback_posix.c ../posix/pubnub_get_native_socket.c ../core/pubnub_timer_list.c ../lib/sockets/pbpal_adns_sockets.c ../lib/pubnub_dns_codec.c $(SOCKET_POLLER_C)  ../core/pbpal_ntf_callback_queue.c ../core/pbpal_ntf_callback_admin.c ../core/pbpal_ntf_callback_handle_timer_list.c  ../core/pubnub_callback_subscribe_loop.c
-CALLBACK_INTF_OBJFILES=pubnub_ntf_callback_posix.o pubnub_get_native_socket.o pubnub_timer_list.o pbpal_adns_sockets.o pubnub_dns_codec.o $(SOCKET_POLLER_OBJ) pbpal_ntf_callback_queue.o pbpal_ntf_callback_admin.o pbpal_ntf_callback_handle_timer_list.o pubnub_callback_subscribe_loop.o
 
 ifndef USE_DNS_SERVERS
 USE_DNS_SERVERS = 1
@@ -119,12 +125,14 @@ endif
 
 ifeq ($(USE_DNS_SERVERS), 1)
 CALLBACK_INTF_SOURCEFILES += ../core/pubnub_dns_servers.c ../posix/pubnub_dns_system_servers.c ../lib/pubnub_parse_ipv4_addr.c
-CALLBACK_INTF_OBJFILES += pubnub_dns_servers.o pubnub_dns_system_servers.o pubnub_parse_ipv4_addr.o
 endif
 
 ifeq ($(USE_IPV6), 1)
 CALLBACK_INTF_SOURCEFILES += ../lib/pubnub_parse_ipv6_addr.c
-CALLBACK_INTF_OBJFILES += pubnub_parse_ipv6_addr.o
+endif
+
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+CALLBACK_INTF_SOURCEFILES += ../posix/pbauto_heartbeat_callback_posix.c
 endif
 
 CFLAGS_CALLBACK = -D PUBNUB_USE_IPV6=$(USE_IPV6) -D PUBNUB_SET_DNS_SERVERS=$(USE_DNS_SERVERS)
@@ -150,8 +158,8 @@ pubnub_callback_subloop_sample: samples/pubnub_subloop_sample.cpp $(SOURCEFILES)
 pubnub_callback_cpp11_subloop_sample: samples/pubnub_subloop_sample.cpp $(SOURCEFILES) $(CALLBACK_INTF_SOURCEFILES) pubnub_futres_cpp11.cpp
 	$(CXX) -o $@ -std=c++11 -D PUBNUB_CALLBACK_API $(CFLAGS) $(CFLAGS_CALLBACK) -x c++  samples/pubnub_subloop_sample.cpp $(CALLBACK_INTF_SOURCEFILES) pubnub_futres_cpp11.cpp $(SOURCEFILES) $(LDLIBS)
 
-fntest_runner: fntest/pubnub_fntest_runner.cpp $(SOURCEFILES)  ../core/pubnub_ntf_sync.c ../core/srand_from_pubnub_time.c pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp
-	$(CXX) -o $@ -std=c++11 -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING $(CFLAGS) -x c++ fntest/pubnub_fntest_runner.cpp ../core/pubnub_ntf_sync.c ../core/srand_from_pubnub_time.c pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp $(SOURCEFILES) $(LDLIBS) 
+fntest_runner: fntest/pubnub_fntest_runner.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp
+	$(CXX) -o $@ -std=c++11 -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING $(CFLAGS) -x c++ fntest/pubnub_fntest_runner.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp $(SOURCEFILES) $(LDLIBS) 
 
 
 clean:

--- a/cpp/posix_openssl.mk
+++ b/cpp/posix_openssl.mk
@@ -32,41 +32,43 @@ ifndef USE_ACTIONS_API
 USE_ACTIONS_API = 1
 endif
 
+ifndef USE_AUTO_HEARTBEAT
+USE_AUTO_HEARTBEAT = 1
+endif
+
 ifeq ($(USE_PROXY), 1)
 SOURCEFILES += ../core/pubnub_proxy.c ../core/pubnub_proxy_core.c ../core/pbhttp_digest.c ../core/pbntlm_core.c ../core/pbntlm_packer_std.c
 endif
 
 ifeq ($(USE_GZIP_COMPRESSION), 1)
 SOURCEFILES += ../lib/miniz/miniz_tdef.c ../lib/miniz/miniz.c ../lib/pbcrc32.c ../core/pbgzip_compress.c
-OBJFILES += miniz_tdef.o miniz.o pbcrc32.o pbgzip_compress.o
 endif
 
 ifeq ($(RECEIVE_GZIP_RESPONSE), 1)
 SOURCEFILES += ../lib/miniz/miniz_tinfl.c ../core/pbgzip_decompress.c
-OBJFILES += miniz_tinfl.o pbgzip_decompress.o
 endif
 
 ifeq ($(USE_SUBSCRIBE_V2), 1)
 SOURCEFILES += ../core/pbcc_subscribe_v2.c ../core/pubnub_subscribe_v2.c 
-OBJFILES += pbcc_subscribe_v2.o pubnub_subscribe_v2.o 
 endif
 
 ifeq ($(USE_ADVANCED_HISTORY), 1)
 SOURCEFILES += ../core/pbcc_advanced_history.c ../core/pubnub_advanced_history.c
-OBJFILES += pbcc_advanced_history.o pubnub_advanced_history.o
 endif
 
 ifeq ($(USE_OBJECTS_API), 1)
 SOURCEFILES += ../core/pbcc_objects_api.c ../core/pubnub_objects_api.c
-OBJFILES += pbcc_objects_api.o pubnub_objects_api.o
 endif
 
 ifeq ($(USE_ACTIONS_API), 1)
 SOURCEFILES += ../core/pbcc_actions_api.c ../core/pubnub_actions_api.c
-OBJFILES += pbcc_actions_api.o pubnub_actions_api.o
 endif
 
-CFLAGS =-g -I .. -I . -I ../openssl -Wall -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API)
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SOURCEFILES += ../lib/pbstr_remove_from_list.c
+endif
+
+CFLAGS =-g -I .. -I . -I ../openssl -Wall -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API) -D PUBNUB_USE_AUTO_HEARTBEAT=$(USE_AUTO_HEARTBEAT)
 # -g enables debugging, remove to get a smaller executable
 
 OS := $(shell uname)
@@ -82,18 +84,23 @@ endif
 
 all: openssl/pubnub_sync_sample openssl/pubnub_callback_sample openssl/pubnub_callback_cpp11_sample openssl/cancel_subscribe_sync_sample openssl/subscribe_publish_callback_sample openssl/futres_nesting_sync openssl/fntest_runner openssl/futres_nesting_callback openssl/futres_nesting_callback_cpp11
 
+SYNC_INTF_SOURCEFILES=../core/pubnub_ntf_sync.c ../core/srand_from_pubnub_time.c
 
-openssl/pubnub_sync_sample: samples/pubnub_sample.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS) -x c++ samples/pubnub_sample.cpp ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SYNC_INTF_SOURCEFILES += ../core/pbauto_heartbeat_sync.c
+endif
 
-openssl/cancel_subscribe_sync_sample: samples/cancel_subscribe_sync_sample.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS) -x c++ samples/cancel_subscribe_sync_sample.cpp  ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+openssl/pubnub_sync_sample: samples/pubnub_sample.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS) -x c++ samples/pubnub_sample.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
 
-openssl/futres_nesting_sync: samples/futres_nesting.cpp $(SOURCEFILES) ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp
-	$(CXX) -o $@ $(CFLAGS) -x c++ samples/futres_nesting.cpp ../core/pubnub_ntf_sync.c pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+openssl/cancel_subscribe_sync_sample: samples/cancel_subscribe_sync_sample.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES)  pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS) -x c++ samples/cancel_subscribe_sync_sample.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
 
-openssl/fntest_runner: fntest/pubnub_fntest_runner.cpp $(SOURCEFILES)  ../core/pubnub_ntf_sync.c ../core/srand_from_pubnub_time.c pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp
-	$(CXX) -o $@ --std=c++11 $(CFLAGS) -x c++ fntest/pubnub_fntest_runner.cpp ../core/pubnub_ntf_sync.c ../core/srand_from_pubnub_time.c pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp $(SOURCEFILES) $(LDLIBS) 
+openssl/futres_nesting_sync: samples/futres_nesting.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp
+	$(CXX) -o $@ $(CFLAGS) -x c++ samples/futres_nesting.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp $(SOURCEFILES) $(LDLIBS)
+
+openssl/fntest_runner: fntest/pubnub_fntest_runner.cpp $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp
+	$(CXX) -o $@ --std=c++11 $(CFLAGS) -x c++ fntest/pubnub_fntest_runner.cpp $(SYNC_INTF_SOURCEFILES) pubnub_futres_sync.cpp fntest/pubnub_fntest.cpp fntest/pubnub_fntest_basic.cpp fntest/pubnub_fntest_medium.cpp $(SOURCEFILES) $(LDLIBS) 
 
 ##
 # The socket poller module to use. You should use the `poll` poller it
@@ -102,10 +109,8 @@ openssl/fntest_runner: fntest/pubnub_fntest_runner.cpp $(SOURCEFILES)  ../core/p
 # WSAPoll() has some weird differences to poll().  The names are the
 # same until the last `_`, then it's `poll` vs `select.
 SOCKET_POLLER_C=../lib/sockets/pbpal_ntf_callback_poller_poll.c
-SOCKET_POLLER_OBJ=pbpal_ntf_callback_poller_poll.o
 
 CALLBACK_INTF_SOURCEFILES= ../openssl/pubnub_ntf_callback_posix.c ../openssl/pubnub_get_native_socket.c ../core/pubnub_timer_list.c ../lib/sockets/pbpal_adns_sockets.c ../lib/pubnub_dns_codec.c $(SOCKET_POLLER_C) ../core/pbpal_ntf_callback_queue.c ../core/pbpal_ntf_callback_admin.c ../core/pbpal_ntf_callback_handle_timer_list.c  ../core/pubnub_callback_subscribe_loop.c
-CALLBACK_INTF_OBJFILES= pubnub_ntf_callback_posix.o pubnub_get_native_socket.o pubnub_timer_list.o pbpal_adns_sockets.o pubnub_dns_codec.o $(SOCKET_POLLER_OBJ) pbpal_ntf_callback_queue.o pbpal_ntf_callback_admin.o pbpal_ntf_callback_handle_timer_list.o pubnub_callback_subscribe_loop.o
 
 ifndef USE_DNS_SERVERS
 USE_DNS_SERVERS = 1
@@ -117,12 +122,14 @@ endif
 
 ifeq ($(USE_DNS_SERVERS), 1)
 CALLBACK_INTF_SOURCEFILES += ../core/pubnub_dns_servers.c ../posix/pubnub_dns_system_servers.c ../lib/pubnub_parse_ipv4_addr.c
-CALLBACK_INTF_OBJFILES += pubnub_dns_servers.o pubnub_dns_system_servers.o pubnub_parse_ipv4_addr.o
 endif
 
 ifeq ($(USE_IPV6), 1)
 CALLBACK_INTF_SOURCEFILES += ../lib/pubnub_parse_ipv6_addr.c
-CALLBACK_INTF_OBJFILES += pubnub_parse_ipv6_addr.o
+endif
+
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+CALLBACK_INTF_SOURCEFILES += ../openssl/pbauto_heartbeat_callback_posix.c
 endif
 
 CFLAGS_CALLBACK = -D PUBNUB_USE_IPV6=$(USE_IPV6) -D PUBNUB_SET_DNS_SERVERS=$(USE_DNS_SERVERS)

--- a/cpp/pubnub_common.hpp
+++ b/cpp/pubnub_common.hpp
@@ -40,6 +40,7 @@ extern "C" {
 #if PUBNUB_USE_ACTIONS_API
 #include "core/pubnub_actions_api.h"
 #endif
+#include "core/pubnub_auto_heartbeat.h"
 #if PUBNUB_USE_EXTERN_C
 }
 #endif
@@ -1337,9 +1338,9 @@ public:
     /// user reactions on a published messages.
     /// @see pubnub_add_message_action
     futres add_message_action(std::string const& channel,
-                      std::string const& message_timetoken,
-                      enum pubnub_action_type actype,
-                      std::string const& value)
+                              std::string const& message_timetoken,
+                              enum pubnub_action_type actype,
+                              std::string const& value)
     {
         return doit(pubnub_add_message_action(
                         d_pb, 
@@ -1358,7 +1359,7 @@ public:
     }
 
     /// Returns action timetoken if previous transaction had been add_action()
-    /// @see pubnub_get_action_timetoken()
+    /// @see pubnub_get_message_action_timetoken()
     std::string get_message_action_timetoken()
     {
         pubnub_chamebl_t result = pubnub_get_message_action_timetoken(d_pb);
@@ -1369,8 +1370,8 @@ public:
     /// published message.
     /// @see pubnub_remove_message_action()
     futres remove_message_action(std::string const& channel,
-                         std::string const& message_timetoken,
-                         std::string const& action_timetoken)
+                                 std::string const& message_timetoken,
+                                 std::string const& action_timetoken)
     {
         return doit(pubnub_remove_message_action(
                         d_pb,
@@ -1383,9 +1384,9 @@ public:
     /// between @p start and @p end action timetoken.
     /// @see pubnub_get_message_actions()
     futres get_message_actions(std::string const& channel,
-                       std::string const& start,
-                       std::string const& end,
-                       size_t limit=0)
+                               std::string const& start,
+                               std::string const& end,
+                               size_t limit=0)
     {
         return doit(pubnub_get_message_actions(
                         d_pb,
@@ -1395,7 +1396,7 @@ public:
                         limit));
     }
 
-    /// @see pubnub_get_actions_more()
+    /// @see pubnub_get_message_actions_more()
     futres get_message_actions_more()
     {
         return doit(pubnub_get_message_actions_more(d_pb));
@@ -1403,11 +1404,11 @@ public:
 
     /// Initiates transaction that returns all actions added on a given @p channel
     /// between @p start and @p end message timetoken.
-    /// @see pubnub_history_with_actions()
+    /// @see pubnub_history_with_message_actions()
     futres history_with_message_actions(std::string const& channel,
-                                 std::string const& start,
-                                 std::string const& end,
-                                 size_t limit=0)
+                                        std::string const& start,
+                                        std::string const& end,
+                                        size_t limit=0)
     {
         return doit(pubnub_history_with_message_actions(
                         d_pb,
@@ -1417,12 +1418,52 @@ public:
                         limit));
     }
 
-    /// @see pubnub_history_with_actions_more()
+    /// @see pubnub_history_with_message_actions_more()
     futres history_with_message_actions_more()
     {
         return doit(pubnub_history_with_message_actions_more(d_pb));
     }
 #endif /* PUBNUB_USE_ACTIONS_API */
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+    /// Enables keeping presence on subscribed channels and channel groups
+    /// @see pubnub_enable_auto_heartbeat()
+    int enable_auto_heartbeat(size_t period_sec)
+    {
+        return pubnub_enable_auto_heartbeat(d_pb, period_sec);
+    }
+
+    /// Sets(changes) heartbeat period for keeping presence on subscribed channels
+    /// and channel groups.
+    /// @see pubnub_set_heartbeat_period()
+    int set_heartbeat_period(size_t period_sec)
+    {
+        return pubnub_set_heartbeat_period(d_pb, period_sec);
+    }
+
+    /// Disables keeping presence on subscribed channels and channel groups
+    /// @see pubnub_disable_auto_heartbeat()
+    void disable_auto_heartbeat()
+    {
+        pubnub_disable_auto_heartbeat(d_pb);
+    }
+
+    /// Returns whether(, or not) auto heartbeat on subscribed channels and channel
+    /// groups is enabled
+    /// @see pubnub_is_auto_heartbeat_enabled()
+    bool is_auto_heartbeat_enabled()
+    {
+        return pubnub_is_auto_heartbeat_enabled(d_pb);
+    }
+
+    /// Releases all allocated heartbeat thumpers.
+    /// Done on any object of the class, once, suffices.
+    /// @see pubnub_heartbeat_free_thumpers()
+    void heartbeat_free_thumpers()
+    {
+        pubnub_heartbeat_free_thumpers();
+    }
+#endif /* PUBNUB_USE_AUTO_HEARTBEAT */
     
     /// Return the HTTP code (result) of the last transaction.
     /// @see pubnub_last_http_code

--- a/lib/pb_strnlen_s.h
+++ b/lib/pb_strnlen_s.h
@@ -17,4 +17,4 @@
   */
 size_t pb_strnlen_s(const char *str, size_t strsz);
 
-#endif /* INC_Pb_STRNLEN_S */
+#endif /* INC_PB_STRNLEN_S */

--- a/lib/pbstr_remove_from_list.c
+++ b/lib/pbstr_remove_from_list.c
@@ -1,0 +1,79 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#include "lib/pb_strnlen_s.h"
+#include "core/pubnub_assert.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define PUBNUB_MAX_OBJECT_LENGTH 30000
+
+/** Removes all instances of @p member in comma separated list @p list
+  */
+static void remove_member(char* list, const char* member, size_t member_len)
+{
+    char* l_start;
+    char* l_end;
+
+    PUBNUB_ASSERT_OPT(list != NULL);
+
+    l_end = list + pb_strnlen_s(list, PUBNUB_MAX_OBJECT_LENGTH);
+    for (l_start = list; l_start < l_end;) {
+        char* l_ch_end = (char*)memchr(l_start, ',', l_end - l_start);
+
+        if (NULL == l_ch_end) {
+            l_ch_end = l_end;
+        }
+        if (((size_t)(l_ch_end - l_start) == member_len) &&
+            (memcmp(l_start, member, member_len) == 0)) {
+            size_t rest = l_end - l_ch_end + 1;
+            if (rest > 1) {
+                /* Moves everything behind next comma including string end */
+                memmove(l_start, l_ch_end + 1, rest);
+                l_end -= l_ch_end + 1 - l_start;
+            }
+            else {
+                /* Erases last comma if any */
+                l_start[-(l_start > list)] = '\0';
+            }
+        }
+        l_start = l_ch_end + 1;
+    }
+}
+
+
+void pbstr_remove_from_list(char* list, const char* leave_list)
+{
+    const char* ll_start;
+    const char* ll_end;
+    
+    PUBNUB_ASSERT_OPT(list != NULL);
+    PUBNUB_ASSERT_OPT(leave_list != NULL);
+
+    ll_end = leave_list + pb_strnlen_s(leave_list, PUBNUB_MAX_OBJECT_LENGTH);
+    for (ll_start = leave_list; ll_start < ll_end;) {            
+        const char* ch_end = (const char*)memchr(ll_start, ',', ll_end - ll_start);
+        if (NULL == ch_end) {
+            ch_end = ll_end;
+        }
+        remove_member(list, ll_start, ch_end - ll_start);
+        if ('\0' == *list) {
+            break;
+        }
+        ll_start = ch_end + 1;
+    }
+}
+
+
+void pbstr_free_if_empty(char** list)
+{
+    char* l; 
+
+    PUBNUB_ASSERT_OPT(list != NULL);
+    l = *list;
+    PUBNUB_ASSERT_OPT(l != NULL);
+    
+    if ('\0' == *l) {
+        free(l);
+        *list = NULL;
+    }
+}

--- a/lib/pbstr_remove_from_list.h
+++ b/lib/pbstr_remove_from_list.h
@@ -1,0 +1,14 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#if !defined INC_PBSTR_REMOVE_FROM_LIST
+#define INC_PBSTR_REMOVE_FROM_LIST
+
+/** Removes members of comma separated @p leave_list from comma separated @p list.
+  */
+void pbstr_remove_from_list(char* list, const char* leave_list);
+
+/** Called only if list is allocated dinamically.
+    Frees memory if list string is empty.
+  */
+void pbstr_free_if_empty(char** list);
+
+#endif /* !defined INC_PBSTR_REMOVE_FROM_LIST */

--- a/openssl/pbauto_heartbeat_callback_posix.c
+++ b/openssl/pbauto_heartbeat_callback_posix.c
@@ -1,0 +1,1 @@
+../posix/pbauto_heartbeat_callback_posix.c

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -130,6 +130,9 @@ void pbpal_init(pubnub_t* pb)
     pb->ssl_userPEMcert             = NULL;
     pb->sock_state                  = STATE_NONE;
     buf_setup(pb);
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+    pbpal_multiple_addresses_reset_counters(&pb->spare_addresses);
+#endif
 }
 
 

--- a/openssl/posix.mk
+++ b/openssl/posix.mk
@@ -34,6 +34,10 @@ ifndef USE_ACTIONS_API
 USE_ACTIONS_API = 1
 endif
 
+ifndef USE_AUTO_HEARTBEAT
+USE_AUTO_HEARTBEAT = 1
+endif
+
 ifeq ($(USE_PROXY), 1)
 SOURCEFILES += ../core/pubnub_proxy.c ../core/pubnub_proxy_core.c ../core/pbhttp_digest.c ../core/pbntlm_core.c ../core/pbntlm_packer_std.c
 OBJFILES += pubnub_proxy.o pubnub_proxy_core.o pbhttp_digest.o pbntlm_core.o pbntlm_packer_std.o
@@ -69,7 +73,12 @@ SOURCEFILES += ../core/pbcc_actions_api.c ../core/pubnub_actions_api.c
 OBJFILES += pbcc_actions_api.o pubnub_actions_api.o
 endif
 
-CFLAGS = -g -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -Wall -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API)
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SOURCEFILES += ../lib/pbstr_remove_from_list.c
+OBJFILES += pbstr_remove_from_list.o
+endif
+
+CFLAGS = -g -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -Wall -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API) -D PUBNUB_USE_AUTO_HEARTBEAT=$(USE_AUTO_HEARTBEAT)
 # -g enables debugging, remove to get a smaller executable
 # -fsanitize=address Use AddressSanitizer
 # -fsanitize=thread Use ThreadSanitizer
@@ -94,6 +103,11 @@ all: pubnub_sync_sample metadata cancel_subscribe_sync_sample pubnub_sync_subloo
 SYNC_INTF_SOURCEFILES=../core/pubnub_ntf_sync.c ../core/pubnub_sync_subscribe_loop.c ../core/srand_from_pubnub_time.c
 SYNC_INTF_OBJFILES=pubnub_ntf_sync.o pubnub_sync_subscribe_loop.o srand_from_pubnub_time.o
 
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SYNC_INTF_SOURCEFILES += ../core/pbauto_heartbeat_sync.c
+SYNC_INTF_OBJFILES += pbauto_heartbeat_sync.o
+endif
+
 pubnub_sync.a : $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES)
 	$(CC) -c $(CFLAGS) $(INCLUDES) $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES)
 	ar rcs pubnub_sync.a $(OBJFILES) $(SYNC_INTF_OBJFILES)
@@ -117,6 +131,11 @@ endif
 ifeq ($(USE_IPV6), 1)
 CALLBACK_INTF_SOURCEFILES += ../lib/pubnub_parse_ipv6_addr.c
 CALLBACK_INTF_OBJFILES += pubnub_parse_ipv6_addr.o
+endif
+
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+CALLBACK_INTF_SOURCEFILES += pbauto_heartbeat_callback_posix.c
+CALLBACK_INTF_OBJFILES += pbauto_heartbeat_callback_posix.o
 endif
 
 CFLAGS_CALLBACK = -D PUBNUB_USE_IPV6=$(USE_IPV6) -D PUBNUB_SET_DNS_SERVERS=$(USE_DNS_SERVERS)

--- a/openssl/pubnub_config.h
+++ b/openssl/pubnub_config.h
@@ -81,11 +81,6 @@
     */
 #define PUBNUB_DEFAULT_WAIT_CONNECT_TIMER    10000
 
-/** Mininmal duration of the transaction timer, in milliseconds. You
- * can't set less than this.
- */
-#define PUBNUB_MIN_TRANSACTION_TIMER 10000
-
 /** Mininmal duration of the 'wait_connect_TCP_socket' timer, in milliseconds.
  *  You can't set less than this.
  */
@@ -160,9 +155,6 @@
 #define PUBNUB_COMPRESSED_MAXLEN 32000
 #endif
 
-/** The maximum channel name length */
-#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
-
 /** The maximum length (in characters) of the host name of the proxy
     that will be saved in the Pubnub context.
 */
@@ -210,5 +202,15 @@
 #define PUBNUB_USE_ACTIONS_API 1
 #endif
 
+#if !defined _WIN32
+#if !defined(PUBNUB_USE_AUTO_HEARTBEAT)
+/** If true (!=0) will enable using the Auto Heartbeat Thumps(beats), which is a feature
+    that enables keeping presence of the given uuids on channels and channel groups during
+    longer periods without subscription.
+    This gives more freedom to the user while coding whom, othrewise, should take care of
+    these things all by himself using pubnub_heartbeat() transaction */
+#define PUBNUB_USE_AUTO_HEARTBEAT 1
+#endif
+#endif /* !defined _WIN32 */
 
 #endif /* !defined INC_PUBNUB_CONFIG */

--- a/posix/pbauto_heartbeat_callback_posix.c
+++ b/posix/pbauto_heartbeat_callback_posix.c
@@ -1,0 +1,810 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#include "posix/monotonic_clock_get_time.h"
+#include "posix/pbtimespec_elapsed_ms.h"
+
+#include "pubnub_internal.h"
+#include "core/pubnub_alloc.h"
+#include "core/pubnub_ccore_limits.h"
+#include "core/pubnub_pubsubapi.h"
+#include "core/pubnub_coreapi.h"
+#include "core/pubnub_free_with_timeout.h"
+#include "lib/pb_strnlen_s.h"
+#include "core/pubnub_assert.h"
+#include "core/pubnub_log.h"
+#include "core/pbpal.h"
+#include "core/pubnub_helper.h"
+
+#include <pthread.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+
+#define PUBNUB_MIN_HEARTBEAT_PERIOD (PUBNUB_MIN_TRANSACTION_TIMER / UNIT_IN_MILLI)
+
+struct pubnub_heartbeat_data {
+    pubnub_t* pb;
+    pubnub_t* heartbeat_pb;
+    size_t period_sec;
+};
+
+struct HeartbeatWatcherData {
+    struct pubnub_heartbeat_data heartbeat_data[PUBNUB_MAX_HEARTBEAT_THUMPERS] pubnub_guarded_by(mutw);
+    unsigned thumpers_in_use pubnub_guarded_by(mutw);
+    /** Times left for each of the thumper timers in progress */
+    size_t heartbeat_timers[PUBNUB_MAX_HEARTBEAT_THUMPERS] pubnub_guarded_by(timerlock);
+    /** Array of thumper indexes whos auto heartbeat timers are active and running */
+    unsigned timer_index_array[PUBNUB_MAX_HEARTBEAT_THUMPERS] pubnub_guarded_by(timerlock);
+    /** Number of active thumper timers */
+    unsigned active_timers pubnub_guarded_by(timerlock);
+    bool stop_heartbeat_watcher_thread pubnub_guarded_by(stoplock);
+    pthread_mutex_t mutw;
+    pthread_mutex_t timerlock;
+    pthread_mutex_t stoplock;
+    pthread_t       thread_id;
+};
+
+
+static struct HeartbeatWatcherData m_watcher;
+
+
+static void start_heartbeat_timer(unsigned thumper_index)
+{
+    size_t period_sec;
+    
+    PUBNUB_ASSERT_OPT(thumper_index < PUBNUB_MAX_HEARTBEAT_THUMPERS);
+    
+    PUBNUB_LOG_TRACE("--->start_heartbeat_timer(%u).\n", thumper_index);
+    pthread_mutex_lock(&m_watcher.mutw);
+    period_sec = m_watcher.heartbeat_data[thumper_index].period_sec;
+    pthread_mutex_unlock(&m_watcher.mutw);
+    
+    pthread_mutex_lock(&m_watcher.timerlock);
+    PUBNUB_ASSERT_OPT(m_watcher.active_timers < PUBNUB_MAX_HEARTBEAT_THUMPERS);
+    m_watcher.heartbeat_timers[thumper_index] = period_sec * UNIT_IN_MILLI;
+    m_watcher.timer_index_array[m_watcher.active_timers++] = thumper_index;
+    pthread_mutex_unlock(&m_watcher.timerlock);
+}
+
+
+static int copy_context_settings(pubnub_t* pb_clone, pubnub_t const* pb)
+{
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb_clone));
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+
+    pubnub_mutex_lock(pb_clone->monitor);
+    pb_clone->core.auth = pb->core.auth;
+    strcpy(pb_clone->core.uuid, pb->core.uuid);
+    if (PUBNUB_ORIGIN_SETTABLE) {
+        pb_clone->origin = pb->origin;
+    }
+#if PUBNUB_BLOCKING_IO_SETTABLE
+    pb_clone->options.use_blocking_io = pb->options.use_blocking_io;
+#endif /* PUBNUB_BLOCKING_IO_SETTABLE */
+    pb_clone->options.use_http_keep_alive = pb->options.use_http_keep_alive;
+#if PUBNUB_USE_IPV6 && defined(PUBNUB_CALLBACK_API)
+    pb_clone->options.ipv6_connectivity = pb->options.ipv6_connectivity;
+#endif
+#if PUBNUB_ADVANCED_KEEP_ALIVE
+    pb_clone->keep_alive.max = pb->keep_alive.max;
+    pb_clone->keep_alive.timeout = pb->keep_alive.timeout;
+#endif
+#if PUBNUB_PROXY_API
+    pb_clone->proxy_type = pb->proxy_type;
+    strcpy(pb_clone->proxy_hostname, pb->proxy_hostname);
+#if defined(PUBNUB_CALLBACK_API)
+    memcpy(&(pb_clone->proxy_ipv4_address),
+           &(pb->proxy_ipv4_address),
+           sizeof pb->proxy_ipv4_address);
+#if PUBNUB_USE_IPV6
+    memcpy(&(pb_clone->proxy_ipv6_address),
+           &(pb->proxy_ipv6_address),
+           sizeof pb->proxy_ipv6_address);
+#endif
+#endif /* defined(PUBNUB_CALLBACK_API) */
+    pb_clone->proxy_port        = pb->proxy_port;
+    pb_clone->proxy_auth_scheme = pb->proxy_auth_scheme;
+    pb_clone->proxy_auth_username = pb->proxy_auth_username;
+    pb_clone->proxy_auth_password = pb->proxy_auth_password;
+    strcpy(pb_clone->realm, pb->realm);
+#endif /* PUBNUB_PROXY_API */
+    pubnub_mutex_unlock(pb_clone->monitor);
+
+    return 0;
+}
+
+
+static bool pubsub_keys_changed(pubnub_t const* pb_clone, pubnub_t const* pb)
+{
+    return (pb_clone->core.publish_key != pb->core.publish_key) ||
+           (pb_clone->core.subscribe_key != pb->core.subscribe_key);
+}
+
+
+static void heartbeat_thump(pubnub_t* pb, pubnub_t* heartbeat_pb)
+{
+    char const* channel;
+    char const* channel_group;
+    bool keys_changed;
+
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(heartbeat_pb));
+
+    pubnub_mutex_lock(pb->monitor);    
+    pubnub_mutex_lock(heartbeat_pb->monitor);
+    keys_changed = pubsub_keys_changed(heartbeat_pb, pb);
+    pubnub_mutex_unlock(heartbeat_pb->monitor);
+        
+    if (keys_changed) {
+        pubnub_mutex_unlock(pb->monitor);
+        pubnub_cancel(heartbeat_pb);        
+        return;
+    }
+    channel = pb->channelInfo.channel;
+    channel_group = pb->channelInfo.channel_group;
+    if (((channel != NULL) && (pb_strnlen_s(channel, PUBNUB_MAX_OBJECT_LENGTH) > 0)) ||
+        ((channel_group != NULL) && (pb_strnlen_s(channel_group, PUBNUB_MAX_OBJECT_LENGTH) > 0))) {
+        enum pubnub_res res;
+        PUBNUB_LOG_TRACE("--->heartbeat_thump(pb=%p, heartbeat_pb=%p).\n", pb, heartbeat_pb);
+        copy_context_settings(heartbeat_pb, pb);
+        res = pubnub_heartbeat(heartbeat_pb, channel, channel_group);
+        if (res != PNR_STARTED) {
+            PUBNUB_LOG_ERROR("heartbeat_thump(pb=%p, heartbeat_pb) - "
+                             "pubnub_heartbeat(heartbeat_pb=%p) returned unexpected: %d('%s')\n",
+                             pb,
+                             heartbeat_pb,
+                             res,
+                             pubnub_res_2_string(res));
+        }
+    }
+    pubnub_mutex_unlock(pb->monitor);
+}
+
+
+static void auto_heartbeat_callback(pubnub_t*         heartbeat_pb,
+                                    enum pubnub_trans trans,
+                                    enum pubnub_res   result,
+                                    void*             user_data)
+{
+    unsigned thumper_index = heartbeat_pb->thumperIndex;
+    
+    PUBNUB_ASSERT_OPT((PBTT_HEARTBEAT == trans) || (PNR_CANCELLED == result));
+    
+    /* Maybe something should be done with this */
+    pubnub_get(heartbeat_pb);
+    
+    if (PNR_OK == result) {
+        /* Start heartbeat timer */
+        start_heartbeat_timer(thumper_index);
+    }
+    else {
+        pubnub_t* pb;
+        pthread_mutex_lock(&m_watcher.mutw);
+        pb = m_watcher.heartbeat_data[thumper_index].pb;
+        pthread_mutex_unlock(&m_watcher.mutw);
+
+        if (result != PNR_CANCELLED) {
+            PUBNUB_LOG_WARNING("punbub_heartbeat(heartbeat_pb=%p) failed with code: %d('%s') - "
+                               "will try again.\n",
+                               heartbeat_pb,
+                               result,
+                               pubnub_res_2_string(result));
+            /* Depending on the kind of error try thumping again */
+            heartbeat_thump(pb, heartbeat_pb);
+        }
+        else if (pb != NULL) {
+            pubnub_mutex_lock(pb->monitor);    
+            if (pubsub_keys_changed(heartbeat_pb, pb)) {
+                pubnub_init(heartbeat_pb, pb->core.publish_key, pb->core.subscribe_key);            
+                heartbeat_thump(pb, heartbeat_pb);
+            }
+            pubnub_mutex_unlock(pb->monitor);
+        }
+    }
+}
+
+
+static pubnub_t* init_new_thumper_pb(pubnub_t* pb, unsigned i)
+{
+    pubnub_t* pb_new;
+
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+
+    pb_new = pubnub_alloc();
+    if (NULL == pb_new) {
+        PUBNUB_LOG_ERROR("init_new_thumper_pb(pb = %p) - "
+                         "Failed to allocate clone heartbeat context!\n",
+                         pb);
+        return NULL;
+    }
+    pubnub_mutex_lock(pb->monitor);
+    pubnub_init(pb_new, pb->core.publish_key, pb->core.subscribe_key);
+    pubnub_mutex_unlock(pb->monitor);
+    
+    pubnub_mutex_lock(pb_new->monitor);
+    pb_new->thumperIndex = i;
+    pubnub_mutex_unlock(pb_new->monitor);
+        
+    return pb_new;
+}
+
+
+static void take_the_timer_out(unsigned* indexes, unsigned i, unsigned* active_timers)
+{
+    unsigned* timer_out = indexes + i;
+    --*active_timers;
+    memmove(timer_out, timer_out + 1, (*active_timers - i)*sizeof(unsigned));
+}
+
+
+static void handle_heartbeat_timers(int elapsed_ms)
+{
+    unsigned i;
+    unsigned* indexes = m_watcher.timer_index_array;
+    unsigned active_timers = m_watcher.active_timers;
+    
+    for (i = 0; i < active_timers;) {
+        unsigned thumper_index = indexes[i];
+        int remains_ms = m_watcher.heartbeat_timers[thumper_index] - elapsed_ms;
+        if (remains_ms <= 0) {
+            struct pubnub_heartbeat_data* thumper = &m_watcher.heartbeat_data[thumper_index];
+            pubnub_t* pb;
+            pubnub_t* heartbeat_pb;
+            
+            /* Taking out one that has expired */
+            take_the_timer_out(indexes, i, &active_timers);
+
+            pthread_mutex_lock(&m_watcher.mutw);
+            pb = thumper->pb;
+            heartbeat_pb = thumper->heartbeat_pb;
+            pthread_mutex_unlock(&m_watcher.mutw);
+
+            if (NULL == heartbeat_pb) {
+                heartbeat_pb = init_new_thumper_pb(pb, thumper_index);
+                if (NULL == heartbeat_pb) {
+                    continue;
+                }
+                pubnub_register_callback(heartbeat_pb, auto_heartbeat_callback, NULL);
+
+                pthread_mutex_lock(&m_watcher.mutw);
+                thumper->heartbeat_pb = heartbeat_pb;
+                pthread_mutex_unlock(&m_watcher.mutw);
+            }
+            /* Heartbeat thump */
+            heartbeat_thump(pb, heartbeat_pb);
+        }
+        else {
+            m_watcher.heartbeat_timers[thumper_index] = (size_t)remains_ms;
+            i++;
+        }
+    }
+    m_watcher.active_timers = active_timers;
+}
+
+
+static void* heartbeat_watcher_thread(void* arg)
+{
+    struct timespec const sleep_time = { 0, 1000000 };
+    struct timespec prev_timspec;
+    monotonic_clock_get_time(&prev_timspec);
+
+    for (;;) {
+        struct timespec timspec;
+        int elapsed;
+        bool stop_thread;
+        
+        pthread_mutex_lock(&m_watcher.stoplock);
+        stop_thread = m_watcher.stop_heartbeat_watcher_thread;
+        pthread_mutex_unlock(&m_watcher.stoplock);
+        if (stop_thread) {
+            break;
+        }
+        
+        nanosleep(&sleep_time, NULL);
+        monotonic_clock_get_time(&timspec);
+
+        elapsed = pbtimespec_elapsed_ms(prev_timspec, timspec);
+        if (elapsed > 0) {
+            pthread_mutex_lock(&m_watcher.timerlock);
+            handle_heartbeat_timers(elapsed);
+            pthread_mutex_unlock(&m_watcher.timerlock);
+            prev_timspec = timspec;
+        }
+    }
+
+    return NULL;
+}
+
+
+static int create_heartbeat_watcher_thread(void)
+{
+    int rslt;
+    
+#if defined(PUBNUB_CALLBACK_THREAD_STACK_SIZE_KB)                              \
+    && (PUBNUB_CALLBACK_THREAD_STACK_SIZE_KB > 0)
+    {
+        pthread_attr_t thread_attr;
+
+        rslt = pthread_attr_init(&thread_attr);
+        if (rslt != 0) {
+            PUBNUB_LOG_ERROR(
+                "create_heartbeat_watcher_thread() - "
+                "Failed to initialize thread attributes, error code: %d\n",
+                rslt);
+            return -1;
+        }
+        rslt = pthread_attr_setstacksize(
+            &thread_attr, PUBNUB_CALLBACK_THREAD_STACK_SIZE_KB * 1024);
+        if (rslt != 0) {
+            PUBNUB_LOG_ERROR(
+                "create_heartbeat_watcher_thread() - "
+                "Failed to set thread stack size to %d kb, error code: %d\n",
+                PUBNUB_CALLBACK_THREAD_STACK_SIZE_KB,
+                rslt);
+            pthread_attr_destroy(&thread_attr);
+            return -1;
+        }
+        rslt = pthread_create(
+            &m_watcher.thread_id, &thread_attr, heartbeat_watcher_thread, NULL);
+        if (rslt != 0) {
+            PUBNUB_LOG_ERROR(
+                "create_heartbeat_watcher_thread() - "
+                "Failed to create the auto heartbeat watcher thread, error code: %d\n",
+                rslt);
+            pthread_attr_destroy(&thread_attr);
+            return -1;
+        }
+    }
+#else
+    rslt =
+        pthread_create(&m_watcher.thread_id, NULL, heartbeat_watcher_thread, NULL);
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "create_heartbeat_watcher_thread() - "
+            "Failed to create the auto heartbeat watcher thread, error code: %d\n",
+            rslt);
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+
+static int auto_heartbeat_init(void)
+{
+    int                 rslt;
+    pthread_mutexattr_t attr;
+
+    rslt = pthread_mutexattr_init(&attr);
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "auto_heartbeat_init() - Failed to initialize mutex attributes, error code: %d\n",
+            rslt);
+        return -1;
+    }
+    rslt = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "auto_heartbeat_init() - Failed to set mutex attribute type, error code: %d\n",
+            rslt);
+        pthread_mutexattr_destroy(&attr);
+        return -1;
+    }
+    rslt = pthread_mutex_init(&m_watcher.stoplock, &attr);
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "auto_heartbeat_init() - Failed to initialize 'stoplock' mutex, error code: %d\n",
+            rslt);
+        pthread_mutexattr_destroy(&attr);
+        return -1;
+    }
+    rslt = pthread_mutex_init(&m_watcher.mutw, &attr);
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "auto_heartbeat_init() - Failed to initialize mutex, error code: %d\n",
+            rslt);
+        pthread_mutexattr_destroy(&attr);
+        pthread_mutex_destroy(&m_watcher.stoplock);
+        return -1;
+    }
+    rslt = pthread_mutex_init(&m_watcher.timerlock, &attr);
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "auto_heartbeat_init() - Failed to initialize mutex for heartbeat timers, "
+            "error code: %d\n",
+            rslt);
+        pthread_mutexattr_destroy(&attr);
+        pthread_mutex_destroy(&m_watcher.mutw);
+        pthread_mutex_destroy(&m_watcher.stoplock);
+        return -1;
+    }
+    m_watcher.stop_heartbeat_watcher_thread = false;
+    rslt = create_heartbeat_watcher_thread();
+    if (rslt != 0) {
+        PUBNUB_LOG_ERROR(
+            "auto_heartbeat_init() - create_heartbeat_watcher_thread() failed, "
+            "error code: %d\n",
+            rslt);
+        pthread_mutexattr_destroy(&attr);
+        pthread_mutex_destroy(&m_watcher.mutw);
+        pthread_mutex_destroy(&m_watcher.timerlock);
+        pthread_mutex_destroy(&m_watcher.stoplock);
+        return -1;
+    }
+
+    return 0;
+}
+
+
+/** Initializes auto heartbeat thumper for @p pb context and if its called for the first
+    time starts auto heartbeat watcher thread.
+  */
+static int form_heartbeat_thumper(pubnub_t* pb)
+{
+    unsigned i;
+    static bool s_began = false;
+    struct pubnub_heartbeat_data* heartbeat_data = m_watcher.heartbeat_data;
+
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+
+    if (!s_began) {
+        auto_heartbeat_init();
+        s_began = true;
+    }
+    
+    pthread_mutex_lock(&m_watcher.mutw);
+    if (m_watcher.thumpers_in_use >= PUBNUB_MAX_HEARTBEAT_THUMPERS) {
+        PUBNUB_LOG_WARNING("form_heartbeat_thumper(pb=%p) - No more heartbeat thumpers left: "
+                           "PUBNUB_MAX_HEARTBEAT_THUMPERS = %d\n"
+                           "thumpers_in_use = %u\n",
+                           pb,
+                           PUBNUB_MAX_HEARTBEAT_THUMPERS,
+                           m_watcher.thumpers_in_use);
+        pthread_mutex_unlock(&m_watcher.mutw);
+
+        return -1;
+    }
+    for (i = 0; i < PUBNUB_MAX_HEARTBEAT_THUMPERS; i++) {
+        struct pubnub_heartbeat_data* thumper = &heartbeat_data[i];
+        if (NULL == thumper->pb) {
+            pubnub_t* heartbeat_pb = thumper->heartbeat_pb;
+            if (NULL == heartbeat_pb) {
+                heartbeat_pb = init_new_thumper_pb(pb, i);
+                if (NULL == heartbeat_pb) {
+                    pthread_mutex_unlock(&m_watcher.mutw);
+                    return -1;
+                }
+                pubnub_register_callback(heartbeat_pb, auto_heartbeat_callback, NULL);
+                thumper->heartbeat_pb = heartbeat_pb;
+            }
+            pb->thumperIndex = i;
+            thumper->pb = pb;
+            thumper->period_sec = PUBNUB_MIN_HEARTBEAT_PERIOD;
+            m_watcher.thumpers_in_use++;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&m_watcher.mutw);
+
+    return 0;
+}
+
+
+int pubnub_set_heartbeat_period(pubnub_t* pb, size_t period_sec)
+{
+    PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
+    PUBNUB_ASSERT(period_sec > 0);
+
+    pubnub_mutex_lock(pb->monitor);
+    if (UNASSIGNED == pb->thumperIndex) {
+        pubnub_mutex_unlock(pb->monitor);
+        PUBNUB_LOG_ERROR("Error: pubnub_set_heartbeat_period(pb=%p) - "
+                         "Auto heartbeat is desabled.\n",
+                         pb);
+        return -1;
+    }
+    pthread_mutex_lock(&m_watcher.mutw);
+    m_watcher.heartbeat_data[pb->thumperIndex].period_sec =
+        period_sec < PUBNUB_MIN_HEARTBEAT_PERIOD ? PUBNUB_MIN_HEARTBEAT_PERIOD : period_sec;
+    pubnub_mutex_unlock(pb->monitor);
+    pthread_mutex_unlock(&m_watcher.mutw);
+
+    return 0;
+}
+
+
+int pubnub_enable_auto_heartbeat(pubnub_t* pb, size_t period_sec)
+{
+    PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
+    
+    pubnub_mutex_lock(pb->monitor);
+    if (UNASSIGNED == pb->thumperIndex) {
+        if (form_heartbeat_thumper(pb) != 0) {
+            pubnub_mutex_unlock(pb->monitor);
+            
+            return -1;
+        }
+    }
+    pubnub_mutex_unlock(pb->monitor);
+
+    return pubnub_set_heartbeat_period(pb, period_sec);
+}
+
+
+static void auto_heartbeat_stop_timer(unsigned thumper_index)
+{
+    unsigned i;
+    unsigned* indexes;
+    unsigned active_timers;
+
+    PUBNUB_ASSERT_OPT(thumper_index < PUBNUB_MAX_HEARTBEAT_THUMPERS);
+
+    pthread_mutex_lock(&m_watcher.timerlock);
+    active_timers = m_watcher.active_timers;
+    for (i = 0, indexes = m_watcher.timer_index_array; i < active_timers; i++) {
+        if (indexes[i] == thumper_index) {
+            /* Taking timer out */
+            take_the_timer_out(indexes, i, &active_timers);
+            m_watcher.active_timers = active_timers;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&m_watcher.timerlock);
+}
+
+
+static void stop_heartbeat(pubnub_t* heartbeat_pb, unsigned thumper_index)
+{
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(heartbeat_pb));
+
+    pubnub_mutex_lock(heartbeat_pb->monitor);
+    if (pbnc_can_start_transaction(heartbeat_pb)) {
+        auto_heartbeat_stop_timer(thumper_index);
+    }
+    else {
+        pubnub_cancel(heartbeat_pb);
+    }
+    pubnub_mutex_unlock(heartbeat_pb->monitor);
+}
+
+
+static void release_thumper(unsigned thumper_index)
+{
+    if (thumper_index < PUBNUB_MAX_HEARTBEAT_THUMPERS) {
+        struct pubnub_heartbeat_data* thumper;
+        pubnub_t* heartbeat_pb;
+        
+        pthread_mutex_lock(&m_watcher.mutw);
+        thumper = &m_watcher.heartbeat_data[thumper_index];
+        heartbeat_pb = thumper->heartbeat_pb;
+        thumper->pb = NULL;
+        --m_watcher.thumpers_in_use;
+        pthread_mutex_unlock(&m_watcher.mutw);
+        
+        stop_heartbeat(heartbeat_pb, thumper_index);
+    }
+}
+
+/** If it is a thumper pubnub context, it is exempted from some usual procedures. */
+static bool is_exempted(pubnub_t const* pb, unsigned thumper_index)
+{
+    pubnub_t const* pb_exempted;
+
+    pthread_mutex_lock(&m_watcher.mutw);
+    pb_exempted = m_watcher.heartbeat_data[thumper_index].heartbeat_pb;
+    pthread_mutex_unlock(&m_watcher.mutw);
+   
+    return (pb == pb_exempted);
+}
+
+
+void pubnub_disable_auto_heartbeat(pubnub_t* pb)
+{
+    PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
+    
+    pubnub_mutex_lock(pb->monitor);
+    if (is_exempted(pb, pb->thumperIndex)) {
+        pubnub_mutex_unlock(pb->monitor);
+        return;
+    }
+    release_thumper(pb->thumperIndex);
+    pb->thumperIndex = UNASSIGNED;
+    pubnub_mutex_unlock(pb->monitor);
+}
+
+
+bool pubnub_is_auto_heartbeat_enabled(pubnub_t* pb)
+{
+    bool rslt;
+
+    PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
+
+    pubnub_mutex_lock(pb->monitor);
+    rslt = (pb->thumperIndex != UNASSIGNED);
+    pubnub_mutex_unlock(pb->monitor);
+
+    return rslt;
+}
+
+
+void pbauto_heartbeat_free_channelInfo(pubnub_t* pb)
+{
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+
+    if (pb->channelInfo.channel != NULL) {
+        free(pb->channelInfo.channel);
+        pb->channelInfo.channel = NULL;
+    }
+    if (pb->channelInfo.channel_group != NULL) {
+        free(pb->channelInfo.channel_group);
+        pb->channelInfo.channel_group = NULL;
+    }
+}
+
+
+void pbauto_heartbeat_read_channelInfo(pubnub_t const* pb,
+                                       char const** channel,
+                                       char const** channel_group)
+{
+    PUBNUB_ASSERT_OPT(channel != NULL);
+    PUBNUB_ASSERT_OPT(channel_group != NULL);
+
+    *channel = pb->channelInfo.channel;
+    *channel_group = pb->channelInfo.channel_group;
+}
+
+
+static enum pubnub_res write_auto_heartbeat_channelInfo(pubnub_t* pb,
+                                                        char const* channel,
+                                                        char const* channel_group)
+{
+    PUBNUB_ASSERT_OPT((channel != NULL) || (channel_group != NULL));
+
+    pbauto_heartbeat_free_channelInfo(pb);    
+    if (channel != NULL) {
+        pb->channelInfo.channel = strndup(channel, PUBNUB_MAX_OBJECT_LENGTH);
+        if (NULL == pb->channelInfo.channel) {
+            PUBNUB_LOG_ERROR("Error: write_auto_heartbeat_info(pb=%p) - "
+                             "Failed to allocate memory for channel string duplicate: "
+                             "channel = '%s'\n",
+                             pb,
+                             channel);
+            return PNR_OUT_OF_MEMORY;
+        }
+    }
+    if (channel_group != NULL) {
+        pb->channelInfo.channel_group = strndup(channel_group, PUBNUB_MAX_OBJECT_LENGTH);
+        if (NULL == pb->channelInfo.channel_group) {
+            PUBNUB_LOG_ERROR("Error: write_auto_heartbeat_info(pb=%p) - "
+                             "Failed to allocate memory for channel_group string duplicate: "
+                             "channel_group = '%s'\n",
+                             pb,
+                             channel_group);
+            if (channel != NULL) {
+                free(pb->channelInfo.channel);
+                pb->channelInfo.channel = NULL;
+            }
+            return PNR_OUT_OF_MEMORY;
+        }
+    }
+    
+    return PNR_OK;
+}
+
+
+enum pubnub_res pbauto_heartbeat_prepare_channels_and_ch_groups(pubnub_t* pb,
+                                                                char const** channel,
+                                                                char const** channel_group)
+{
+    PUBNUB_ASSERT_OPT(channel != NULL);
+    PUBNUB_ASSERT_OPT(channel_group != NULL);
+
+    if ((NULL == *channel) && (NULL == *channel_group)) {
+        pbauto_heartbeat_read_channelInfo(pb, channel, channel_group);
+        return PNR_OK;
+    }
+    
+    return write_auto_heartbeat_channelInfo(pb, *channel, *channel_group);
+}
+
+
+void pbauto_heartbeat_start_timer(pubnub_t const* pb)
+{
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+
+    if (pb->thumperIndex != UNASSIGNED) {
+        switch (pb->trans) {
+        case PBTT_HEARTBEAT :
+            if (is_exempted(pb, pb->thumperIndex)) {
+                break;
+            }
+            /*FALLTHRU*/
+        case PBTT_SUBSCRIBE :
+        case PBTT_SUBSCRIBE_V2 :
+            start_heartbeat_timer(pb->thumperIndex);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+
+void pubnub_heartbeat_free_thumpers(void)
+{
+    unsigned i;
+    struct pubnub_heartbeat_data* heartbeat_data = m_watcher.heartbeat_data;
+    struct timespec const sleep_time = { 1, 0 };
+
+    for (i = 0; i < PUBNUB_MAX_HEARTBEAT_THUMPERS; i++) {
+        pubnub_t* heartbeat_pb;
+        
+        pthread_mutex_lock(&m_watcher.mutw);
+        heartbeat_pb = heartbeat_data[i].heartbeat_pb;
+        pthread_mutex_unlock(&m_watcher.mutw);
+        
+        if (heartbeat_pb != NULL) {
+            if (pubnub_free_with_timeout(heartbeat_pb, 1000) != 0) {
+                PUBNUB_LOG_ERROR("Error: pbauto_heartbeat_free_thumpers() - "
+                                 "Failed to free the Pubnub heartbeat %u. thumper context: "
+                                 "heartbeat_pb=%p\n",
+                                 i,
+                                 heartbeat_pb);
+            }
+            else {
+                PUBNUB_LOG_TRACE("pubnub_heartbeat_free_thumpers() - "
+                                 "%u. thumper(heartbeat_pb=%p) freed.\n",
+                                 i+1,
+                                 heartbeat_pb);
+                pthread_mutex_lock(&m_watcher.mutw);
+                heartbeat_data[i].heartbeat_pb = NULL;
+                pthread_mutex_unlock(&m_watcher.mutw);
+            }
+        }
+    }
+    /* Waits until the contexts are released from the processing queue */
+    nanosleep(&sleep_time, NULL);
+}
+
+
+static void stop_auto_heartbeat(unsigned thumper_index)
+{
+    pubnub_t* heartbeat_pb;
+
+    pthread_mutex_lock(&m_watcher.mutw);
+    heartbeat_pb = m_watcher.heartbeat_data[thumper_index].heartbeat_pb;
+    pthread_mutex_unlock(&m_watcher.mutw);
+
+    stop_heartbeat(heartbeat_pb, thumper_index);
+}
+
+
+void pbauto_heartbeat_transaction_ongoing(pubnub_t const* pb)
+{
+    PUBNUB_ASSERT_OPT(pb_valid_ctx_ptr(pb));
+
+    if (pb->thumperIndex != UNASSIGNED) {
+        switch (pb->trans) {
+        case PBTT_HEARTBEAT :
+            if (is_exempted(pb, pb->thumperIndex)) {
+                break;
+            }
+            /*FALLTHRU*/
+        case PBTT_SUBSCRIBE :
+        case PBTT_SUBSCRIBE_V2 :
+            stop_auto_heartbeat(pb->thumperIndex);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+
+void pbauto_heartbeat_stop(void)
+{
+    pthread_mutex_lock(&m_watcher.stoplock);
+    m_watcher.stop_heartbeat_watcher_thread = true;
+    pthread_mutex_unlock(&m_watcher.stoplock);
+}

--- a/posix/posix.mk
+++ b/posix/posix.mk
@@ -34,6 +34,10 @@ ifndef USE_ACTIONS_API
 USE_ACTIONS_API = 1
 endif
 
+ifndef USE_AUTO_HEARTBEAT
+USE_AUTO_HEARTBEAT = 1
+endif
+
 ifeq ($(USE_PROXY), 1)
 SOURCEFILES += ../core/pubnub_proxy.c ../core/pubnub_proxy_core.c ../core/pbhttp_digest.c ../core/pbntlm_core.c ../core/pbntlm_packer_std.c
 OBJFILES += pubnub_proxy.o pubnub_proxy_core.o pbhttp_digest.o pbntlm_core.o pbntlm_packer_std.o
@@ -69,6 +73,11 @@ SOURCEFILES += ../core/pbcc_actions_api.c ../core/pubnub_actions_api.c
 OBJFILES += pbcc_actions_api.o pubnub_actions_api.o
 endif
 
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SOURCEFILES += ../lib/pbstr_remove_from_list.c
+OBJFILES += pbstr_remove_from_list.o
+endif
+
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
 SOURCEFILES += monotonic_clock_get_time_darwin.c
@@ -80,7 +89,7 @@ OBJFILES += monotonic_clock_get_time_posix.o
 LDLIBS=-lrt -lpthread
 endif
 
-CFLAGS =-g -Wall -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API)
+CFLAGS =-g -Wall -D PUBNUB_THREADSAFE -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_ONLY_PUBSUB_API=$(ONLY_PUBSUB_API) -D PUBNUB_PROXY_API=$(USE_PROXY) -D PUBNUB_USE_GZIP_COMPRESSION=$(USE_GZIP_COMPRESSION) -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_SUBSCRIBE_V2=$(USE_SUBSCRIBE_V2) -D PUBNUB_USE_OBJECTS_API=$(USE_OBJECTS_API) -D PUBNUB_USE_ACTIONS_API=$(USE_ACTIONS_API) -D PUBNUB_USE_AUTO_HEARTBEAT=$(USE_AUTO_HEARTBEAT)
 # -g enables debugging, remove to get a smaller executable
 # -fsanitize-address Use AddressSanitizer
 
@@ -90,6 +99,11 @@ all: pubnub_sync_sample metadata cancel_subscribe_sync_sample pubnub_advanced_hi
 
 SYNC_INTF_SOURCEFILES=../core/pubnub_ntf_sync.c ../core/pubnub_sync_subscribe_loop.c ../core/srand_from_pubnub_time.c
 SYNC_INTF_OBJFILES=pubnub_ntf_sync.o pubnub_sync_subscribe_loop.o srand_from_pubnub_time.o
+
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+SYNC_INTF_SOURCEFILES += ../core/pbauto_heartbeat_sync.c
+SYNC_INTF_OBJFILES += pbauto_heartbeat_sync.o
+endif
 
 pubnub_sync.a : $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES)
 	$(CC) -c $(CFLAGS) $(INCLUDES) $(SOURCEFILES) $(SYNC_INTF_SOURCEFILES)
@@ -114,6 +128,11 @@ endif
 ifeq ($(USE_IPV6), 1)
 CALLBACK_INTF_SOURCEFILES += ../lib/pubnub_parse_ipv6_addr.c
 CALLBACK_INTF_OBJFILES += pubnub_parse_ipv6_addr.o
+endif
+
+ifeq ($(USE_AUTO_HEARTBEAT), 1)
+CALLBACK_INTF_SOURCEFILES += ../posix/pbauto_heartbeat_callback_posix.c
+CALLBACK_INTF_OBJFILES += pbauto_heartbeat_callback_posix.o
 endif
 
 CFLAGS_CALLBACK = -D PUBNUB_USE_IPV6=$(USE_IPV6) -D PUBNUB_SET_DNS_SERVERS=$(USE_DNS_SERVERS)

--- a/posix/pubnub_config.h
+++ b/posix/pubnub_config.h
@@ -76,11 +76,6 @@
     */
 #define PUBNUB_DEFAULT_WAIT_CONNECT_TIMER    10000
 
-/** Mininmal duration of the transaction timer, in milliseconds. You
- *  can't set less than this.
- */
-#define PUBNUB_MIN_TRANSACTION_TIMER 10000
-
 /** Mininmal duration of the 'wait_connect_TCP_socket' timer, in milliseconds.
  *  You can't set less than this.
  */
@@ -152,9 +147,6 @@
 #define PUBNUB_COMPRESSED_MAXLEN 32000
 #endif
 
-/** The maximum channel name length */
-#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
-
 /** The maximum length (in characters) of the host name of the proxy
     that will be saved in the Pubnub context.
 */
@@ -200,6 +192,15 @@
     of Rest API features that enables adding on, reading and removing actions
     from published messages */
 #define PUBNUB_USE_ACTIONS_API 1
+#endif
+
+#if !defined(PUBNUB_USE_AUTO_HEARTBEAT)
+/** If true (!=0) will enable using the Auto Heartbeat Thumps(beats), which is a feature
+    that enables keeping presence of the given uuids on channels and channel groups during
+    longer periods without subscription.
+    This gives more freedom to the user while coding whom, othrewise, should take care of
+    these things all by himself using pubnub_heartbeat() transaction */
+#define PUBNUB_USE_AUTO_HEARTBEAT 1
 #endif
 
 

--- a/posix/pubnub_ntf_callback_posix.c
+++ b/posix/pubnub_ntf_callback_posix.c
@@ -100,6 +100,8 @@ void* socket_watcher_thread(void* arg)
 
 void pubnub_stop(void)
 {
+    pbauto_heartbeat_stop();
+    
     pthread_mutex_lock(&m_watcher.stoplock);
     m_watcher.stop_socket_watcher_thread = true;
     pthread_mutex_unlock(&m_watcher.stoplock);

--- a/qt/pubnub_config.h
+++ b/qt/pubnub_config.h
@@ -37,14 +37,6 @@
 
 #define PUBNUB_HAVE_SHA1 0
 
-/** The maximum channel name length */
-#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
-
-/** Minimal presence heartbeat interval supported by
-    Pubnub, in seconds.
-*/
-#define PUBNUB_MINIMAL_HEARTBEAT_INTERVAL 270
-
 #if !defined(PUBNUB_USE_SUBSCRIBE_V2)
 /** If true (!=0) will enable using the subscribe v2 API, which
     provides filter expressions and more data about messages. */
@@ -71,11 +63,6 @@
     from published messages */
 #define PUBNUB_USE_ACTIONS_API 1
 #endif
-
-/** Mininmal duration of the transaction timer, in milliseconds. You
- * can't set less than this.
- */
-#define PUBNUB_MIN_TRANSACTION_TIMER 10000
 
 
 #endif /* !defined INC_PUBNUB_CONFIG */

--- a/qt/pubnub_internal.h
+++ b/qt/pubnub_internal.h
@@ -18,16 +18,6 @@ struct pubnub_pal {
 /** The way we use Qt, blocking I/O is not applicable */
 #define PUBNUB_BLOCKING_IO_SETTABLE 0
 
-/** The maximum channel name length */
-#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
-
-#if !defined(PUBNUB_USE_ADVANCED_HISTORY)
-/** If true (!=0) will enable using the advanced history API, which
-    provides more data about (unread) messages. */
-#define PUBNUB_USE_ADVANCED_HISTORY 1
-#endif
-
-
 #include "core/pubnub_internal_common.h"
 
 

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -1003,9 +1003,9 @@ pubnub_res pubnub_qt::remove_members(QString const& space_id,
 
 #if PUBNUB_USE_ACTIONS_API
 pubnub_res pubnub_qt::add_message_action(QString const& channel,
-                                 QString const& message_timetoken,
-                                 pubnub_action_type actype,
-                                 QString const& value)
+                                         QString const& message_timetoken,
+                                         pubnub_action_type actype,
+                                         QString const& value)
 {
     enum pubnub_res rslt;
     char obj_buffer[PUBNUB_BUF_MAXLEN];
@@ -1044,7 +1044,7 @@ QString pubnub_qt::get_message_timetoken()
 }
 
 
-QString pubnub_qt::get_action_timetoken()
+QString pubnub_qt::get_message_action_timetoken()
 {
     KEEP_THREAD_SAFE();
     if (d_trans != PBTT_ADD_ACTION) {
@@ -1056,8 +1056,8 @@ QString pubnub_qt::get_action_timetoken()
 
 
 pubnub_res pubnub_qt::remove_message_action(QString const& channel,
-                                    QString const& message_timetoken,
-                                    QString const& action_timetoken)
+                                            QString const& message_timetoken,
+                                            QString const& action_timetoken)
 {
     KEEP_THREAD_SAFE();
     return startRequest(
@@ -1070,9 +1070,9 @@ pubnub_res pubnub_qt::remove_message_action(QString const& channel,
 
 
 pubnub_res pubnub_qt::get_message_actions(QString const& channel,
-                                  QString const& start,
-                                  QString const& end,
-                                  size_t limit)
+                                          QString const& start,
+                                          QString const& end,
+                                          size_t limit)
 {
     KEEP_THREAD_SAFE();
     return startRequest(
@@ -1093,9 +1093,9 @@ pubnub_res pubnub_qt::get_message_actions_more()
 
 
 pubnub_res pubnub_qt::history_with_message_actions(QString const& channel,
-                                           QString const& start,
-                                           QString const& end,
-                                           size_t limit)
+                                                   QString const& start,
+                                                   QString const& end,
+                                                   size_t limit)
 {
     KEEP_THREAD_SAFE();
     return startRequest(

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -16,7 +16,9 @@
 #include <QPair>
 
 extern "C" {
+#include "core/pubnub_server_limits.h"
 #include "core/pubnub_api_types.h"
+#include "core/pubnub_ccore_limits.h"
 #include "core/pubnub_helper.h"
 #if PUBNUB_USE_SUBSCRIBE_V2
 #include "core/pbcc_subscribe_v2.h"
@@ -1752,36 +1754,36 @@ public:
         @return #PNR_STARTED on success, an error otherwise
       */
     pubnub_res add_message_action(QString const& channel,
-                          QString const& message_timetoken,
-                          pubnub_action_type actype,
-                          QString const& value);
+                                  QString const& message_timetoken,
+                                  pubnub_action_type actype,
+                                  QString const& value);
 
     /** Function receives 'Qt Json' document for @p value. Helpful if you're already using Qt
         support for Json in your code, ensuring that value you are passing is valid Json.
         @see add_message_action()
       */
     pubnub_res add_message_action(QString const& channel,
-                          QString const& message_timetoken,
-                          pubnub_action_type actype,
-                          QJsonDocument const& value) {
+                                  QString const& message_timetoken,
+                                  pubnub_action_type actype,
+                                  QJsonDocument const& value) {
         return add_message_action(channel, message_timetoken, actype, value.toJson());
     }
 
-    /** Searches the response, if previous transaction had been 'add_action' and was accomplished
-        successfully) and retrieves timetoken of a message action was added on.
+    /** Searches the response, if previous transaction had been 'add_message_action' and was
+        accomplished successfully) and retrieves timetoken of a message action was added on.
         If key expected is not found, preconditions(about right transaction) were not fulfilled,
         or error was encountered, returnes an empty string.
         @return Message timetoken value including its quotation marks
       */
     QString get_message_timetoken();
 
-    /** Searches the response, if previous transaction had been 'add_action' and was accomplished
-        successfully) and retrieves timetoken of a resently added action.
+    /** Searches the response, if previous transaction had been 'add_message_action' and was
+        accomplished successfully) and retrieves timetoken of a resently added action.
         If key expected is not found, preconditions were not fulfilled, or error was encountered,
         returnes an empty string.
         @return Action timetoken value including its quotation marks
       */
-    QString get_action_timetoken();
+    QString get_message_action_timetoken();
 
     /** Initiates transaction that deletes(removes) previously added action on a published message.
         If there is no success confirming data, nor error description in the response it is
@@ -1796,14 +1798,14 @@ public:
         @return #PNR_STARTED on success, an error otherwise
       */
     pubnub_res remove_message_action(QString const& channel,
-                             QString const& message_timetoken,
-                             QString const& action_timetoken);
+                                     QString const& message_timetoken,
+                                     QString const& action_timetoken);
 
     /** Initiates transaction that returns all actions added on a given @p channel between @p start
         and @p end action timetoken.
         The response to this transaction can be partial and than it contains the hyperlink string
         value to the rest.
-        @see get_actions_more()
+        @see get_message_actions_more()
         If there is no actions data, nor error description in the response it is considered
         format error.
         @param channel The channel on which actions are observed.
@@ -1817,9 +1819,9 @@ public:
         @return #PNR_STARTED on success, an error otherwise
       */
     pubnub_res get_message_actions(QString const& channel,
-                           QString const& start,
-                           QString const& end,
-                           size_t limit=0);
+                                   QString const& start,
+                                   QString const& end,
+                                   size_t limit=0);
 
     /** This function expects previous transaction to be the one for reading the actions and
         that it was successfully accomplished. If it is not the case, returns corresponding
@@ -1827,7 +1829,7 @@ public:
         When preconditions are fulfilled, it searches the hyperlink to the rest in the existing
         response buffer which it uses for obtaining another part of the server response.
         Anotherwords, once the hyperlink is found in the existing response it is used for
-        initiating new request and function than behaves, essentially, as get_actions().
+        initiating new request and function than behaves, essentially, as get_message_actions().
         If there is no hyperlink encountered in the previous transaction response it
         returns success: PNR_GOT_ALL_ACTIONS meaning that the answer is complete.
         @retval PNR_STARTED transaction successfully initiated.
@@ -1840,7 +1842,7 @@ public:
         and @p end message timetoken.
         The response to this transaction can be partial and than it contains the hyperlink string
         value to the rest.
-        @see history_with_actions_more()
+        @see history_with_message_actions_more()
         If there is no actions data, nor error description in the response it is considered
         format error.
         @param channel The channel on which actions are observed.
@@ -1854,9 +1856,9 @@ public:
         @return #PNR_STARTED on success, an error otherwise
       */
     pubnub_res history_with_message_actions(QString const& channel,
-                                    QString const& start,
-                                    QString const& end,
-                                    size_t limit=0);
+                                            QString const& start,
+                                            QString const& end,
+                                            size_t limit=0);
 
     /** This function expects previous transaction to be the one for reading the history with
         actions and that it was successfully accomplished. If it is not the case, returns
@@ -1864,7 +1866,7 @@ public:
         When preconditions are fulfilled it searches for the hyperlink to the rest of the answer
         in the existing response buffer which it uses for obtaining another part of the server
         response. Anotherwords, once the hyperlink is found in the existing response it is used
-        for initiating new request and function than behaves as history_with_actions().
+        for initiating new request and function than behaves as history_with_message_actions().
         If there is no hyperlink encountered in the previous transaction response it
         returns success: PNR_GOT_ALL_ACTIONS meaning that the answer is complete.
         @retval PNR_STARTED transaction successfully initiated.

--- a/windows/pubnub_config.h
+++ b/windows/pubnub_config.h
@@ -77,11 +77,6 @@
     */
 #define PUBNUB_DEFAULT_WAIT_CONNECT_TIMER    10000
 
-/** Mininmal duration of the transaction timer, in milliseconds. You
- *  can't set less than this.
- */
-#define PUBNUB_MIN_TRANSACTION_TIMER 10000
-
 /** Mininmal duration of the 'wait_connect_TCP_socket' timer, in milliseconds.
  *  You can't set less than this.
  */
@@ -146,9 +141,6 @@
 /* Maximum compressed message length allowed. Could be shortened by the user */
 #define PUBNUB_COMPRESSED_MAXLEN 32000
 #endif
-
-/** The maximum channel name length */
-#define PUBNUB_MAX_CHANNEL_NAME_LENGTH 92
 
 /** If true (!=0) will use Windows SSPI (for NTLM and such).
     Otherwise, will use own implementation, if available. */


### PR DESCRIPTION
User can now enable sending of heartbeat messages "in the background"
on the given context. These heartbeat messages will actually be sent
via a different context, so, won't prevent the user from sending using
her context anyway she sees fit. Heartbeat is sent according to the
latest subscribe() - if the user does a new subscribe() with new
channel/group, the heartbeats will be updated and sent accordingly.
