### PR TITLE
Ensure we only attempt to remove timer in the list

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,11 @@ schema: 1
 version: 2.12.3
 scm: github.com/pubnub/c-core
 changelog:
+  - version: v2.12.4
+    date: Jan 20, 2020
+    changes:
+      - type: bug
+        text: Fix crash while handling network timeouts with multiple contexts
   - version: v2.12.3
     date: Jan 16, 2020
     changes:

--- a/core/pbpal_ntf_callback_handle_timer_list.c
+++ b/core/pbpal_ntf_callback_handle_timer_list.c
@@ -31,14 +31,25 @@ void pbntf_handle_timer_list(int ms_elapsed, pubnub_t** head)
 }
 
 
+static bool contains(pubnub_t* head, pubnub_t* element) {
+    while (head != NULL) {
+        if (head == element) {
+            return true;
+        }
+
+        head = head->next;
+    }
+
+    return false;
+}
+
 void pbpal_remove_timer_safe(pubnub_t* to_remove, pubnub_t** from_head)
 {
     PUBNUB_ASSERT_OPT(to_remove != NULL);
     PUBNUB_ASSERT_OPT(from_head != NULL);
 
     if (PUBNUB_TIMERS_API) {
-        if ((*from_head != NULL) && ((to_remove->previous != NULL) || (to_remove->next != NULL)
-            || (to_remove == *from_head))) {
+        if ((*from_head != NULL) && contains(*from_head, to_remove)) {
             *from_head = pubnub_timer_list_remove(*from_head, to_remove);
         }
         else {

--- a/core/pbpal_ntf_callback_handle_timer_list.c
+++ b/core/pbpal_ntf_callback_handle_timer_list.c
@@ -21,9 +21,12 @@ void pbntf_handle_timer_list(int ms_elapsed, pubnub_t** head)
 
         pubnub_mutex_lock(expired->monitor);
         next = expired->next;
+
+        if (next != NULL) {
+            next->previous = expired->next = NULL;
+        }
+
         pbnc_stop(expired, PNR_TIMEOUT);
-        expired->next     = NULL;
-        expired->previous = NULL;
         pubnub_mutex_unlock(expired->monitor);
 
         expired = next;

--- a/freertos/pubnub_ntf_callback_freertos.c
+++ b/freertos/pubnub_ntf_callback_freertos.c
@@ -161,10 +161,12 @@ void socket_watcher_task(void *arg)
 
                     next = expired->next;
 
+                    if (next != NULL) {
+                        next->previous = expired->next = NULL;
+                    }
+
                     pbnc_stop(expired, PNR_TIMEOUT);
 
-                    expired->previous = NULL;
-                    expired->next = NULL;
                     pubnub_mutex_lock(expired->monitor);
 
                     expired = next;

--- a/microchip_harmony/pubnub_ntf_harmony.c
+++ b/microchip_harmony/pubnub_ntf_harmony.c
@@ -77,7 +77,7 @@ void pubnub_task(void)
     if (0 == s_tick_prev) {
         s_tick_prev = SYS_TMR_TickCountGet();
     }
-    
+
     if (m_watcher.apb_size > 0) {
         pubnub_t **ppbp;
         uint32_t tick_now = SYS_TMR_TickCountGet();
@@ -129,10 +129,22 @@ void pbntf_update_socket(pubnub_t *pb, pb_socket_t socket)
     PUBNUB_UNUSED(socket);
 }
 
+static bool contains(pubnub_t* head, pubnub_t* element)
+{
+    while (head != NULL) {
+        if (head == element) {
+            return true;
+        }
+
+        head = head->next;
+    }
+
+    return false;
+}
+
 static void remove_timer_safe(pubnub_t *to_remove)
 {
-    if ((to_remove->previous != NULL) || (to_remove->next != NULL) 
-        || (to_remove == m_watcher.timer_head)) {
+    if ((m_watcher.timer_head != NULL) && contains(m_watcher.timer_head, to_remove)) {
         m_watcher.timer_head = pubnub_timer_list_remove(m_watcher.timer_head, to_remove);
     }
 }

--- a/microchip_harmony/pubnub_ntf_harmony.c
+++ b/microchip_harmony/pubnub_ntf_harmony.c
@@ -91,10 +91,12 @@ void pubnub_task(void)
             while (expired != NULL) {
                 pubnub_t *next = expired->next;
 
+                if (next != NULL) {
+                    next->previous = expired->next = NULL;
+                }
+
                 pbnc_stop(expired, PNR_TIMEOUT);
 
-                expired->previous = NULL;
-                expired->next = NULL;
                 expired = next;
             }
             s_tick_prev = tick_now;


### PR DESCRIPTION
Before attempting to remove a timer from the list, check that it's actually in that list rather than another. This could potentially happen e.g., due to callbacks in the timer handling loop.