### PR TITLE
Fix handling of DNS retries and stale HTTP kept alive

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: 2.12.3
+version: 2.12.4
 scm: github.com/pubnub/c-core
 changelog:
+  - version: v2.12.4
+    date: Jan 31, 2020
+    changes:
+      - type: bug
+        text: Properly handle DNS retries and stale HTTP Kept-Alive connections
   - version: v2.12.3
     date: Jan 16, 2020
     changes:

--- a/core/pbpal_ntf_callback_handle_timer_list.c
+++ b/core/pbpal_ntf_callback_handle_timer_list.c
@@ -37,8 +37,8 @@ void pbpal_remove_timer_safe(pubnub_t* to_remove, pubnub_t** from_head)
     PUBNUB_ASSERT_OPT(from_head != NULL);
 
     if (PUBNUB_TIMERS_API) {
-        if ((*from_head != NULL) && ((to_remove->previous != NULL) || (to_remove->next != NULL)
-            || (to_remove == *from_head))) {
+        if ((to_remove->previous != NULL) || (to_remove->next != NULL)
+            || (to_remove == *from_head)) {
             *from_head = pubnub_timer_list_remove(*from_head, to_remove);
         }
         else {

--- a/core/pubnub_alloc_std.c
+++ b/core/pubnub_alloc_std.c
@@ -137,7 +137,7 @@ int pubnub_free(pubnub_t* pb)
 {
     int result = -1;
 
-    PUBNUB_ASSERT(check_ctx_ptr(pb));
+    PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
 
     PUBNUB_LOG_TRACE("pubnub_free(%p)\n", pb);
 

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -790,7 +790,6 @@ AfterEach(single_context_pubnub)
         expect(pbpal_closed, when(pb, equals(pbp)), returns(true));
         expect(pbpal_forget, when(pb, equals(pbp)));
     }
-    expect(pbntf_trans_outcome, when(pb, equals(pbp)));
     expect(pbpal_free, when(pb, equals(pbp)));
     attest(pubnub_free(pbp), equals(0));
     free_m_msgs(m_string_msg_array);

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -789,6 +789,7 @@ AfterEach(single_context_pubnub)
         expect(pbpal_close, when(pb, equals(pbp)), returns(0));
         expect(pbpal_closed, when(pb, equals(pbp)), returns(true));
         expect(pbpal_forget, when(pb, equals(pbp)));
+        expect(pbntf_trans_outcome, when(pb, equals(pbp)));
     }
     expect(pbpal_free, when(pb, equals(pbp)));
     attest(pubnub_free(pbp), equals(0));

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -1303,7 +1303,9 @@ next_state:
         }
         break;
     case PBS_WAIT_CANCEL_DNS:
+#if PUBNUB_NEED_RETRY_AFTER_CLOSE
         pb->flags.retry_after_close = true;
+#endif
         close_connection(pb);
         goto next_state;
     case PBS_KEEP_ALIVE_IDLE:

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -1412,7 +1412,6 @@ void pbnc_stop(struct pubnub_* pbp, enum pubnub_res outcome_to_report)
         PUBNUB_LOG_ERROR("pbnc_stop(pbp=%p) got called in NULL state\n", pbp);
         break;
     case PBS_IDLE:
-        pbntf_trans_outcome(pbp, PBS_IDLE);
         pbp->trans = PBTT_NONE;
         break;
     case PBS_KEEP_ALIVE_IDLE:

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -458,6 +458,10 @@ static char const* pbnc_state2str(enum pubnub_state e)
         return "PBS_KEEP_ALIVE_READY";
     case PBS_KEEP_ALIVE_WAIT_CLOSE:
         return "PBS_KEEP_ALIVE_WAIT_CLOSE";
+    case PBS_WAIT_CANCEL_DNS:
+        return "PBS_WAIT_CANCEL_DNS";
+    case PBS_WAIT_CANCEL_KEEPALIVE:
+        return "PBS_WAIT_CANCEL_KEEPALIVE";
     default:
         return "Unknown enum pubnub_state";
     }
@@ -1298,6 +1302,10 @@ next_state:
             pbntf_trans_outcome(pb, PBS_IDLE);
         }
         break;
+    case PBS_WAIT_CANCEL_DNS:
+        pb->flags.retry_after_close = true;
+        close_connection(pb);
+        goto next_state;
     case PBS_KEEP_ALIVE_IDLE:
 #if PUBNUB_PROXY_API
         pb->proxy_saved_path_len     = 0;
@@ -1343,6 +1351,9 @@ next_state:
             goto next_state;
         }
         break;
+    case PBS_WAIT_CANCEL_KEEPALIVE:
+        pb->state = close_kept_alive_connection(pb);
+        goto next_state;
     default:
         PUBNUB_LOG_ERROR("pbnc_fsm(pb=%p): unhandled state: %s\n",
                          pb,
@@ -1377,8 +1388,7 @@ void pbnc_stop(struct pubnub_* pbp, enum pubnub_res outcome_to_report)
         if (PNR_TIMEOUT == outcome_to_report) {
             if ((pbp->state != PBS_WAIT_CONNECT) &&
                 (pbp->flags.sent_queries < PUBNUB_MAX_DNS_QUERIES)) {
-                pbp->flags.retry_after_close = true;
-                close_connection(pbp);
+                pbp->state = PBS_WAIT_CANCEL_DNS;
             }
             else {
                 pbp->core.last_result = (PBS_WAIT_CONNECT == pbp->state)
@@ -1411,11 +1421,7 @@ void pbnc_stop(struct pubnub_* pbp, enum pubnub_res outcome_to_report)
            up in PBS_KEEP_ALIVE_IDLE so previous *FALLTHROUHGH* is safe */
         if ((PNR_TIMEOUT == outcome_to_report)
             && (pbp->flags.started_while_kept_alive)) {
-            /* Closing connection that was kept alive is always done with
-               intention to reestablish it anew and don't lose current
-               transaction.
-            */
-            pbp->state = close_kept_alive_connection(pbp);
+            pbp->state = PBS_WAIT_CANCEL_KEEPALIVE;
             pbntf_requeue_for_processing(pbp);
             break;
         }

--- a/core/pubnub_netcore.h
+++ b/core/pubnub_netcore.h
@@ -99,7 +99,17 @@ enum pubnub_state {
         are awating for it to be actually closed before starting the transaction
         via a new connection.
      */
-    PBS_KEEP_ALIVE_WAIT_CLOSE
+    PBS_KEEP_ALIVE_WAIT_CLOSE,
+    /** Waiting to cancel (close 'connection'/socket) if DNS fails due
+     * to timeout, when we want to try again (but first close the
+     * socket, to have a fresh start, maybe it failed because the
+     * socket became corrupt).
+     */
+    PBS_WAIT_CANCEL_DNS,
+    /** Waiting to cancel (close connection) if the transaction timeout
+     * ocurred while in HTTP Keep-Alive.
+     */
+    PBS_WAIT_CANCEL_KEEPALIVE
 };
 
 

--- a/core/pubnub_proxy_unit_test.c
+++ b/core/pubnub_proxy_unit_test.c
@@ -450,7 +450,6 @@ AfterEach(single_context_pubnub) {
         expect(pbpal_forget, when(pb, equals(pbp)));
         expect(pbntf_trans_outcome, when(pb, equals(pbp)));
     }
-    expect(pbntf_trans_outcome, when(pb, equals(pbp)));
     expect(pbntf_requeue_for_processing, when(pb, equals(pbp)));
     if (state_not_idle) {
         attest(pubnub_free(pbp), equals(-1));

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "2.12.2"
+#define PUBNUB_SDK_VERSION "2.12.4"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
Bottom line is that `pbnc_stop()` was not designed to handle
anything itself, only to "setup the stage" for the FSM to
handle things.  Unfortunately, in these two scenarios, some
handling had "slipped in".