### PR TITLE
PubNub SDK 2.12.5 Release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: 2.12.4
+version: "2.12.5"
 scm: github.com/pubnub/c-core
 changelog:
+  - version: v2.12.5
+    date: Apr 8, 2020
+    changes:
+      - type: improvement
+        text: "Dynamically allocate memory for `uuid` in `pubnub_set_uuid` function."
   - version: v2.12.4
     date: Jan 31, 2020
     changes:

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "2.12.4"
+#define PUBNUB_SDK_VERSION "2.12.5"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
## 🌟: use dynamic allocation for 'uuid'

Dynamically allocate memory for `uuid` in `pubnub_set_uuid` function.
