### PR TITLE
Switch to blocking resolver

### DIFF
--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -411,8 +411,6 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
     hint.ai_canonname                                  = NULL;
     hint.ai_next                                       = NULL;
 
-    prepare_port_and_hostname(pb, &port, &origin);
-
 #ifdef PUBNUB_CALLBACK_API
 #if PUBNUB_PROXY_API
     if (0 != pb->proxy_ipv4_address.ipv4[0]) {


### PR DESCRIPTION
- This is the easiest way to allow using the system DNS resolver.
- If Windows has resolv.h, we might be able to use that with the async
  resolver to get the system name servers (usually configured by DHCP,
  but sometimes manually configured).
- We could also look into Windows-specific (winsock2?) APIs for querying
  name servers.