### PR TITLE
Support system name servers in async DNS client

### DIFF
--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -84,6 +84,13 @@ static void prepare_port_and_hostname(pubnub_t*    pb,
 
 
 #ifdef PUBNUB_CALLBACK_API
+
+static void get_default_dns_ip(struct pubnub_ipv4_address *addr) {
+    if (pubnub_dns_read_system_servers_ipv4(addr, 1) != 1) {
+        inet_pton(AF_INET, PUBNUB_DEFAULT_DNS_SERVER, addr);
+    }
+}
+
 #if PUBNUB_SET_DNS_SERVERS
 #if PUBNUB_CHANGE_DNS_SERVERS
 static void get_dns_ip(struct pbdns_servers_check* dns_check, struct sockaddr* addr)
@@ -104,7 +111,7 @@ static void get_dns_ip(struct pbdns_servers_check* dns_check, struct sockaddr* a
 #if PUBNUB_USE_IPV6
             addr->sa_family = AF_INET6;
 #else
-            inet_pton(AF_INET, PUBNUB_DEFAULT_DNS_SERVER, p);
+            get_default_dns_ip((struct pubnub_ipv4_address*)p);
 #endif /* PUBNUB_USE_IPV6 */
         }
     }
@@ -119,7 +126,7 @@ static void get_dns_ip(struct pbdns_servers_check* dns_check, struct sockaddr* a
                 || (dns_check->dns_server_check & dns_check->dns_mask)) {
                 dns_check->dns_mask <<= 1;
                 addr->sa_family = AF_INET;
-                inet_pton(AF_INET, PUBNUB_DEFAULT_DNS_SERVER, p);
+                get_default_dns_ip((struct pubnub_ipv4_address*)p);
             }
         }
     }
@@ -139,7 +146,7 @@ static void get_dns_ip(struct sockaddr* addr)
 #if PUBNUB_USE_IPV6
         addr->sa_family = AF_INET6;
 #else
-        inet_pton(AF_INET, PUBNUB_DEFAULT_DNS_SERVER, p);
+        get_default_dns_ip((struct pubnub_ipv4_address*)p);
 #endif /* PUBNUB_USE_IPV6 */
     }
     if (AF_INET6 == addr->sa_family) {
@@ -148,7 +155,7 @@ static void get_dns_ip(struct sockaddr* addr)
             && (pubnub_get_dns_secondary_server_ipv6((struct pubnub_ipv6_address*)pv6)
                 == -1)) {
             addr->sa_family = AF_INET;
-            inet_pton(AF_INET, PUBNUB_DEFAULT_DNS_SERVER, p);
+            get_default_dns_ip((struct pubnub_ipv4_address*)p);
         }
     }
 }
@@ -157,9 +164,8 @@ static void get_dns_ip(struct sockaddr* addr)
 static void get_dns_ip(struct sockaddr* addr)
 {
     addr->sa_family = AF_INET;
-    inet_pton(AF_INET,
-              PUBNUB_DEFAULT_DNS_SERVER,
-              &(((struct sockaddr_in*)addr)->sin_addr.s_addr));
+    struct pubnub_ipv4_address* p = &(((struct sockaddr_in*)addr)->sin_addr.s_addr));
+    get_default_dns_ip(p);
 }
 #endif /* PUBNUB_SET_DNS_SERVERS */
 

--- a/windows/pubnub_dns_system_servers.c
+++ b/windows/pubnub_dns_system_servers.c
@@ -59,12 +59,11 @@ int pubnub_dns_read_system_servers_ipv4(struct pubnub_ipv4_address* o_ipv4, size
     }
     else {
         PUBNUB_LOG_ERROR("GetNetworkParams failed with error: %d\n", dwRetVal);
+        FREE(pFixedInfo);
         return -1;
     }
 
-    if (pFixedInfo) {
-        FREE(pFixedInfo);
-    }
+    FREE(pFixedInfo);
 
     return j;
 }


### PR DESCRIPTION
This is an alternative to #120.

The name server is chosen with the following precedence:

1. The server specified with `pubnub_dns_set_primary_server_ipv4()` (assumes `PUBNUB_SET_DNS_SERVERS` is set, which is the default)
2. The server specified with `pubnub_dns_set_secondary_server_ipv4()` (assumes `PUBNUB_SET_DNS_SERVERS` is set, which is the default)
3. The server configured by the system (e.g. DHCP or manually)
4. The hardcoded default server (usually `8.8.8.8`)

If any step fails to find a server, it will try the next in the precedence list. Step 4 always succeeds.

When `PUBNUB_SET_DNS_SERVERS` is _not_ set, the name server configured on the system is always chosen first.

This patch also fixes a minor memory leak in the Windows-specific name server lookup function when an error occurs.