### PR TITLE
Missing UUID query param

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "3.4.2"
+version: "3.4.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2022-07-05
+    version: v3.4.3
+    changes:
+      - type: bug
+        text: "Removed extra parenthesis in get_dns_ip function code."
+      - type: bug
+        text: "Added uuid query param to history, set/get state, wherenow, channel-group operations."
   - date: 2022-04-25
     version: v3.4.2
     changes:
@@ -613,7 +620,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"
@@ -679,7 +686,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"
@@ -745,7 +752,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"
@@ -807,7 +814,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"
@@ -868,7 +875,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"
@@ -924,7 +931,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"
@@ -977,7 +984,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.4.2
+            location: https://github.com/pubnub/c-core/releases/tag/v3.4.3
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v3.4.3
+July 05 2022
+
+#### Fixed
+- Removed extra parenthesis in get_dns_ip function code.
+- Added uuid query param to history, set/get state, wherenow, channel-group operations.
+
 ## v3.4.2
 April 25 2022
 

--- a/core/pubnub_ccore.c
+++ b/core/pubnub_ccore.c
@@ -218,6 +218,7 @@ enum pubnub_res pbcc_history_prep(struct pbcc_context* pb,
                                   char const*          end)
 {
     char const* const uname = pubnub_uname();
+    char const* uuid = pbcc_uuid_get(pb);
     enum pubnub_res rslt = PNR_OK;
 
     pb->http_content_len = 0;
@@ -231,6 +232,7 @@ enum pubnub_res pbcc_history_prep(struct pbcc_context* pb,
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
+    if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
     char cnt_buf[sizeof(int) * 4 + 1];
     sprintf(cnt_buf, "%d", count);
     if (count) { ADD_URL_PARAM(qparam, count, cnt_buf); }
@@ -374,6 +376,7 @@ enum pubnub_res pbcc_where_now_prep(struct pbcc_context* pb, const char* uuid)
 {
     PUBNUB_ASSERT_OPT(uuid != NULL);
     enum pubnub_res rslt = PNR_OK;
+    char const* pb_uuid = pbcc_uuid_get(pb);
 
     pb->http_content_len = 0;
     pb->msg_ofs = pb->msg_end = 0;
@@ -385,6 +388,7 @@ enum pubnub_res pbcc_where_now_prep(struct pbcc_context* pb, const char* uuid)
                                 uuid);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (pb_uuid) { ADD_URL_PARAM(qparam, uuid, pb_uuid); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
     ADD_TS_TO_URL_PARAM();
@@ -416,6 +420,7 @@ enum pubnub_res pbcc_set_state_prep(struct pbcc_context* pb,
     PUBNUB_ASSERT_OPT(uuid != NULL);
     PUBNUB_ASSERT_OPT(state != NULL);
     enum pubnub_res rslt = PNR_OK;
+    char const* pb_uuid = pbcc_uuid_get(pb);
 
     if (NULL == channel) {
         if (NULL == channel_group) {
@@ -440,6 +445,7 @@ enum pubnub_res pbcc_set_state_prep(struct pbcc_context* pb,
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
+    if (pb_uuid) { ADD_URL_PARAM(qparam, uuid, pb_uuid); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
     ADD_TS_TO_URL_PARAM();
@@ -470,6 +476,7 @@ enum pubnub_res pbcc_state_get_prep(struct pbcc_context* pb,
 {
     PUBNUB_ASSERT_OPT(uuid != NULL);
     enum pubnub_res rslt = PNR_OK;
+    char const* pb_uuid = pbcc_uuid_get(pb);
 
     if (NULL == channel) {
         if (NULL == channel_group) {
@@ -493,6 +500,7 @@ enum pubnub_res pbcc_state_get_prep(struct pbcc_context* pb,
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
+    if (pb_uuid) { ADD_URL_PARAM(qparam, uuid, pb_uuid); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
     ADD_TS_TO_URL_PARAM();
@@ -520,6 +528,7 @@ enum pubnub_res pbcc_remove_channel_group_prep(struct pbcc_context* pb,
 {
     PUBNUB_ASSERT_OPT(channel_group != NULL);
     enum pubnub_res rslt = PNR_OK;
+    char const* uuid = pbcc_uuid_get(pb);
 
     pb->http_buf_len = snprintf(
         pb->http_buf,
@@ -530,6 +539,7 @@ enum pubnub_res pbcc_remove_channel_group_prep(struct pbcc_context* pb,
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
     ADD_TS_TO_URL_PARAM();
@@ -558,6 +568,7 @@ enum pubnub_res pbcc_channel_registry_prep(struct pbcc_context* pb,
 {
     PUBNUB_ASSERT_OPT(channel_group != NULL);
     enum pubnub_res rslt = PNR_OK;
+    char const* uuid = pbcc_uuid_get(pb);
 
     pb->http_buf_len = snprintf(
         pb->http_buf,
@@ -568,6 +579,7 @@ enum pubnub_res pbcc_channel_registry_prep(struct pbcc_context* pb,
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
 
     if (NULL != param) {
         PUBNUB_ASSERT_OPT(channel != NULL);

--- a/core/pubnub_ccore.c
+++ b/core/pubnub_ccore.c
@@ -269,6 +269,7 @@ enum pubnub_res pbcc_heartbeat_prep(struct pbcc_context* pb,
                                     const char*          channel_group)
 {
     char const* uuid = pbcc_uuid_get(pb);
+    char const* const uname = pubnub_uname();
     enum pubnub_res rslt = PNR_OK;
 
     if (NULL == channel) {
@@ -293,7 +294,7 @@ enum pubnub_res pbcc_heartbeat_prep(struct pbcc_context* pb,
                                   sizeof pb->http_buf - pb->http_buf_len,
                                   "/heartbeat");
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
     if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
 #if PUBNUB_CRYPTO_API
@@ -376,6 +377,7 @@ enum pubnub_res pbcc_where_now_prep(struct pbcc_context* pb, const char* uuid)
 {
     PUBNUB_ASSERT_OPT(uuid != NULL);
     enum pubnub_res rslt = PNR_OK;
+    char const* const uname = pubnub_uname();
     char const* pb_uuid = pbcc_uuid_get(pb);
 
     pb->http_content_len = 0;
@@ -387,7 +389,7 @@ enum pubnub_res pbcc_where_now_prep(struct pbcc_context* pb, const char* uuid)
                                 pb->subscribe_key,
                                 uuid);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (pb_uuid) { ADD_URL_PARAM(qparam, uuid, pb_uuid); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
@@ -421,6 +423,7 @@ enum pubnub_res pbcc_set_state_prep(struct pbcc_context* pb,
     PUBNUB_ASSERT_OPT(state != NULL);
     enum pubnub_res rslt = PNR_OK;
     char const* pb_uuid = pbcc_uuid_get(pb);
+    char const* const uname = pubnub_uname();
 
     if (NULL == channel) {
         if (NULL == channel_group) {
@@ -443,7 +446,7 @@ enum pubnub_res pbcc_set_state_prep(struct pbcc_context* pb,
                                  uuid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
     if (pb_uuid) { ADD_URL_PARAM(qparam, uuid, pb_uuid); }
 #if PUBNUB_CRYPTO_API
@@ -477,6 +480,7 @@ enum pubnub_res pbcc_state_get_prep(struct pbcc_context* pb,
     PUBNUB_ASSERT_OPT(uuid != NULL);
     enum pubnub_res rslt = PNR_OK;
     char const* pb_uuid = pbcc_uuid_get(pb);
+    char const* const uname = pubnub_uname();
 
     if (NULL == channel) {
         if (NULL == channel_group) {
@@ -498,7 +502,7 @@ enum pubnub_res pbcc_state_get_prep(struct pbcc_context* pb,
                                  "/uuid/%s",
                                  uuid);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
     if (pb_uuid) { ADD_URL_PARAM(qparam, uuid, pb_uuid); }
 #if PUBNUB_CRYPTO_API
@@ -529,6 +533,7 @@ enum pubnub_res pbcc_remove_channel_group_prep(struct pbcc_context* pb,
     PUBNUB_ASSERT_OPT(channel_group != NULL);
     enum pubnub_res rslt = PNR_OK;
     char const* uuid = pbcc_uuid_get(pb);
+    char const* const uname = pubnub_uname();
 
     pb->http_buf_len = snprintf(
         pb->http_buf,
@@ -538,7 +543,7 @@ enum pubnub_res pbcc_remove_channel_group_prep(struct pbcc_context* pb,
         channel_group);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
@@ -569,6 +574,7 @@ enum pubnub_res pbcc_channel_registry_prep(struct pbcc_context* pb,
     PUBNUB_ASSERT_OPT(channel_group != NULL);
     enum pubnub_res rslt = PNR_OK;
     char const* uuid = pbcc_uuid_get(pb);
+    char const* const uname = pubnub_uname();
 
     pb->http_buf_len = snprintf(
         pb->http_buf,
@@ -578,7 +584,7 @@ enum pubnub_res pbcc_channel_registry_prep(struct pbcc_context* pb,
         channel_group);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
 
     if (NULL != param) {

--- a/core/pubnub_ccore_pubsub.c
+++ b/core/pubnub_ccore_pubsub.c
@@ -626,6 +626,7 @@ enum pubnub_res pbcc_subscribe_prep(struct pbcc_context* p,
                                     unsigned*            heartbeat)
 {
     char const* uuid = pbcc_uuid_get(p);
+    char const* const uname = pubnub_uname();
     enum pubnub_res rslt = PNR_OK;
 
     if (NULL == channel) {
@@ -649,7 +650,7 @@ enum pubnub_res pbcc_subscribe_prep(struct pbcc_context* p,
                                 "/0/%s",
                                 p->timetoken);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
     if (uuid) { ADD_URL_PARAM(qparam, uuid, uuid); }
     if (p->state) { ADD_URL_PARAM(qparam, state, p->state); }

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -1934,7 +1934,7 @@ Ensure(single_context_pubnub, set_state)
     pubnub_set_uuid(pbp, "universal");
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/ch/uuid/"
-                             "universal/data?pnsdk=unit-test-0.1&state=%7B%7D");
+                             "universal/data?pnsdk=unit-test-0.1&uuid=universal&state=%7B%7D");
     incoming("HTTP/1.1 200\r\nContent-Length: 67\r\n\r\n{\"status\": "
              "200,\"message\":\"OK\", \"service\": \"Presence\", "
              "\"payload\":{}}",
@@ -1954,7 +1954,7 @@ Ensure(single_context_pubnub, set_state)
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
     expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/ch/uuid/"
                              "shazalakazoo/"
-                             "data?pnsdk=unit-test-0.1&auth=auth-key&state=%7B%7D");
+                             "data?pnsdk=unit-test-0.1&uuid=universal&auth=auth-key&state=%7B%7D");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "63\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"payload\":{}}",
@@ -1975,7 +1975,7 @@ Ensure(single_context_pubnub, set_state)
     expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/,/uuid/"
                              "melwokee/"
                              "data?pnsdk=unit-test-0.1&channel-"
-                             "group=[gr1,gr2]&auth=authentic&state=%7BIOW%7D");
+                             "group=[gr1,gr2]&uuid=universal&auth=authentic&state=%7BIOW%7D");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "66\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"payload\":{IOW}}",
@@ -1997,7 +1997,7 @@ Ensure(single_context_pubnub, set_state)
     expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/[ch1,ch2]/"
                              "uuid/linda-darnell/"
                              "data?pnsdk=unit-test-0.1&channel-group="
-                             "[gr3,gr4]&auth=three&state=%7BI%7D");
+                             "[gr3,gr4]&uuid=universal&auth=three&state=%7BI%7D");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "64\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"payload\":{I}}",
@@ -2082,7 +2082,7 @@ Ensure(single_context_pubnub, set_state_set_auth_and_uuid)
     pubnub_set_uuid(pbp, "morgan");
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url("/v2/presence/sub-key/Xsub/channel/ch/uuid/morgan/"
-                             "data?pnsdk=unit-test-0.1&auth=portobello&state=%7B%22the_privateer%22%3A%22letter_of_marque%22%7D");
+                             "data?pnsdk=unit-test-0.1&uuid=morgan&auth=portobello&state=%7B%22the_privateer%22%3A%22letter_of_marque%22%7D");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "96\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"payload\":{\"the_privateer\":\"letter_of_"
@@ -2106,7 +2106,7 @@ Ensure(single_context_pubnub, set_state_bad_response)
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url(
         "/v2/presence/sub-key/Xsub/channel/ch/uuid/chili_peppers/"
-        "data?pnsdk=unit-test-0.1&state=%7B%22chili%22%3A%22red%22%7D");
+        "data?pnsdk=unit-test-0.1&uuid=chili_peppers&state=%7B%22chili%22%3A%22red%22%7D");
     incoming("HTTP/1.1 200\r\nContent-Length: 2\r\n\r\n<chiki, chiki bum, "
              "chiki bum]",
              NULL);
@@ -2128,7 +2128,7 @@ Ensure(single_context_pubnub, state_get_1channel)
     pubnub_set_uuid(pbp, "speedy");
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url(
-        "/v2/presence/sub-key/subY/channel/ch/uuid/speedy?pnsdk=unit-test-0.1");
+        "/v2/presence/sub-key/subY/channel/ch/uuid/speedy?pnsdk=unit-test-0.1&uuid=speedy");
     incoming("HTTP/1.1 200\r\nContent-Length: 76\r\n\r\n{\"status\": "
              "200,\"message\":\"OK\", \"service\": \"Presence\", "
              "\"payload\":{\"running\"}}",
@@ -2147,7 +2147,7 @@ Ensure(single_context_pubnub, state_get_1channel)
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
     expect_outgoing_with_url("/v2/presence/sub-key/subY/channel/ch/uuid/"
-                             "brza_fotografija?pnsdk=unit-test-0.1&auth=auth-"
+                             "brza_fotografija?pnsdk=unit-test-0.1&uuid=speedy&auth=auth-"
                              "key");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "72\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
@@ -2265,7 +2265,7 @@ Ensure(single_context_pubnub, state_get_bad_response)
     pubnub_set_uuid(pbp, "annoying");
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url("/v2/presence/sub-key/Xsub/channel/ch/uuid/"
-                             "annoying?pnsdk=unit-test-0.1");
+                             "annoying?pnsdk=unit-test-0.1&uuid=annoying");
     incoming("HTTP/1.1 200\r\nContent-Length: 18\r\n\r\n[incorrect answer]", NULL);
     expect(pbntf_lost_socket, when(pb, equals(pbp)));
     expect(pbntf_trans_outcome, when(pb, equals(pbp)));
@@ -2635,7 +2635,7 @@ Ensure(single_context_pubnub, where_now_set_uuid)
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url(
         "/v2/presence/sub-key/sub-her/uuid/50fb7a0b-1688-45b9-9f27-ea83308464d8"
-        "-ab3817df?pnsdk=unit-test-0.1");
+        "-ab3817df?pnsdk=unit-test-0.1&uuid=50fb7a0b-1688-45b9-9f27-ea83308464d8-ab3817df");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "100\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"Payload\":{\"channels\":[discovery,nat_geo,nature]"
@@ -2662,7 +2662,7 @@ Ensure(single_context_pubnub, where_now_set_auth)
     pubnub_set_auth(pbp, "big");
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url(
-        "/v2/presence/sub-key/sub-sea/uuid/whale?pnsdk=unit-test-0.1&auth=big");
+        "/v2/presence/sub-key/sub-sea/uuid/whale?pnsdk=unit-test-0.1&uuid=fish&auth=big");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "107\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"Payload\":{\"channels\":[first,second,third,"
@@ -2690,7 +2690,7 @@ Ensure(single_context_pubnub, where_now_in_progress_interrupted_and_accomplished
     pubnub_set_auth(pbp, "west");
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url(
-        "/v2/presence/sub-key/sub-good/uuid/bad?pnsdk=unit-test-0.1&auth=west");
+        "/v2/presence/sub-key/sub-good/uuid/bad?pnsdk=unit-test-0.1&uuid=man_with_no_name&auth=west");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "140\r\n\r\n{\"status\":200,\"message\":\"OK\",\"ser",
              NULL);
@@ -3964,7 +3964,7 @@ Ensure(single_context_pubnub, subscribe_gzip_response)
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
     expect_outgoing_with_url("/v2/presence/sub-key/sub-measurements/uuid/"
-                             "bird?pnsdk=unit-test-0.1&auth=weather-"
+                             "bird?pnsdk=unit-test-0.1&uuid=bird&auth=weather-"
                              "conditions");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "100\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"

--- a/core/pubnub_subscribe_with_state.c
+++ b/core/pubnub_subscribe_with_state.c
@@ -38,7 +38,8 @@ static enum pubnub_res pbcc_subscribe_with_state_prep(struct pbcc_context *p,
                                 "/0/%s",
                                 p->timetoken);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
-    if (pubnub_uname()) { ADD_URL_PARAM(qparam, pnsdk, pubnub_uname()); }
+    char const* const uname = pubnub_uname();
+    if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
     if (p->uuid) { ADD_URL_PARAM(qparam, uuid, p->uuid); }
     if (state) { APPEND_URL_PARAM(qparam, state, state); }

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "3.4.2"
+#define PUBNUB_SDK_VERSION "3.4.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -164,7 +164,7 @@ static void get_dns_ip(struct sockaddr* addr)
 static void get_dns_ip(struct sockaddr* addr)
 {
     addr->sa_family = AF_INET;
-    struct pubnub_ipv4_address* p = &(((struct sockaddr_in*)addr)->sin_addr.s_addr));
+    struct pubnub_ipv4_address* p = (struct pubnub_ipv4_address*)&(((struct sockaddr_in*)addr)->sin_addr.s_addr);
     get_default_dns_ip(p);
 }
 #endif /* PUBNUB_SET_DNS_SERVERS */


### PR DESCRIPTION

fix: Removed extra parenthesis in get_dns_ip function code

Removed extra parenthesis in get_dns_ip function code

fix: Added uuid query param to history, set/get state, wherenow, channel-group operations

Added uuid query param to history, set/get state, wherenow, channel-group operations

