### PR TITLE
Fix token memory leak

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,17 @@
 name: c-core
 schema: 1
-version: "3.5.1"
+version: "3.5.2"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2022-10-11
+    version: v3.5.2
+    changes:
+      - type: bug
+        text: "Fix memory leak in cpp `parse_token` method."
+      - type: bug
+        text: "Fix buffer overflow in core `pubnub_parse_token` function for some cases."
+      - type: bug
+        text: "Fix buffer overflow in core `pubnub_encrypt` function for randomized initial vector."
   - date: 2022-09-22
     version: v3.5.1
     changes:
@@ -632,7 +641,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"
@@ -698,7 +707,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"
@@ -764,7 +773,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"
@@ -826,7 +835,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"
@@ -887,7 +896,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"
@@ -943,7 +952,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"
@@ -996,7 +1005,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v3.5.1
+            location: https://github.com/pubnub/c-core/releases/tag/v3.5.2
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v3.5.2
+October 11 2022
+
+#### Fixed
+- Fix memory leak in cpp `parse_token` method.
+- Fix buffer overflow in core `pubnub_parse_token` function for some cases.
+- Fix buffer overflow in core `pubnub_encrypt` function for randomized initial vector.
+
 ## v3.5.1
 September 22 2022
 

--- a/core/pubnub_grant_token_api.h
+++ b/core/pubnub_grant_token_api.h
@@ -53,6 +53,11 @@ enum pubnub_res pubnub_grant_token(pubnub_t* pb, char const* perm_obj);
 
 pubnub_chamebl_t pubnub_get_grant_token(pubnub_t* pb);
 
+/** Parses the @p token and returns the json string.
+   
+    @see pubnub_grant_token
+    @return malloc allocated char pointer (must be passed to `free` to avoid a memory leak)
+*/
 char* pubnub_parse_token(pubnub_t* pb, char const* token);
 
 #endif /* !defined INC_PUBNUB_GRANT_TOKEN_API */

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "3.5.1"
+#define PUBNUB_SDK_VERSION "3.5.2"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/cpp/pubnub_common.hpp
+++ b/cpp/pubnub_common.hpp
@@ -1194,7 +1194,11 @@ public:
     /// @see pubnub_grant_token
     std::string parse_token(std::string const& token)
     {
-        return pubnub_parse_token(d_pb, token.c_str());
+	char* parsed_token_chars = pubnub_parse_token(d_pb, token.c_str());
+        std::string owned_parsed_token(parsed_token_chars);
+	
+	::free(parsed_token_chars);
+	return owned_parsed_token; 
     }
 #endif
 

--- a/lib/pb_strncasecmp.c
+++ b/lib/pb_strncasecmp.c
@@ -22,7 +22,7 @@ int pb_strncasecmp(const char *str1, const char *str2, size_t number_of_chars)
 	char* copied_strings[NUMBER_OF_STRINGS];
 
 	for (size_t s = 0; s < NUMBER_OF_STRINGS; s++) {
-		copied_strings[s] = strndup(strings[s], number_of_chars);
+		copied_strings[s] = (char*)strndup((char*)strings[s], number_of_chars);
 
 		for (size_t c = 0; c < number_of_chars; c++) {
 			copied_strings[s][c] = tolower(copied_strings[s][c]);
@@ -41,14 +41,14 @@ int pb_strncasecmp(const char *str1, const char *str2, size_t number_of_chars)
 #if defined(_MSC_VER)
 char* strndup(char* str, size_t number_of_chars)
 {
-	char *buffer = malloc(number_of_chars + 1);
+	char *buffer = (char*)malloc(number_of_chars + 1);
 
 	if (buffer != NULL) {
 		for (size_t c = 0; ((c < number_of_chars) && (str[c] != '\0')); c++) {
 			buffer[c] = str[c];
 		}
 
-		buffer[number_of_chars] = "\0";
+		buffer[number_of_chars] = '\0';
 	}
 
 	return buffer;

--- a/openssl/pbaes256.c
+++ b/openssl/pbaes256.c
@@ -4,6 +4,7 @@
 #include "core/pubnub_log.h"
 #include "core/pubnub_assert.h"
 
+#include "openssl/pubnub_config.h"
 #include <openssl/evp.h>
 #include <openssl/err.h>
 


### PR DESCRIPTION

fix: fix memory leak in cpp `parse_token` method

fix: fix buffer overflow in core `pubnub_parse_token` function for some cases

fix: fix buffer overflow in core `pubnub_encrypt` function for randomized initial vector
