### PR TITLE
fix build with OpenSSL 3.0

### DIFF
--- a/core/pubnub_crypto.c
+++ b/core/pubnub_crypto.c
@@ -528,12 +528,12 @@ int base64_max_size(int encode_this_many_bytes) {
 
 int base64encode(char* result, int max_size, const void* b64_encode_this, int encode_this_many_bytes) {
     size_t buf_size = 4 * ((encode_this_many_bytes + 2)/3) + 1; // +1 for tailing 0
-    unsigned char *buf = calloc(buf_size, 1);
+    unsigned char *buf = (unsigned char*)calloc(buf_size, 1);
     if (!buf) {
         return -1;
     }
 
-    size_t size = EVP_EncodeBlock(buf, b64_encode_this, encode_this_many_bytes);
+    size_t size = EVP_EncodeBlock(buf, (const unsigned char*)b64_encode_this, encode_this_many_bytes);
     // size does not include tailing 0
     // https://www.openssl.org/docs/man3.0/man3/EVP_EncodeBlock.html
     if (size + 1 > (size_t)max_size) {

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -16,6 +16,7 @@
 
 #include <string.h>
 
+#include <openssl/opensslv.h>
 
 #define HTTP_PORT 80
 
@@ -96,7 +97,7 @@ static int pal_init(void)
 {
     static bool s_init = false;
     if (!s_init) {
-        #if !defined(__UWP__)
+        #if !defined(__UWP__) && (OPENSSL_VERSION_MAJOR < 3)
         ERR_load_BIO_strings(); //Per OpenSSL 3.0 this is deprecated. Allowing this stmt for non-UWP as it exists.
         #endif
         SSL_load_error_strings();


### PR DESCRIPTION
`ERR_load_BIO_strings()` is deprecated in OpenSSL 3.0. Low-level encoding primitives are also deprecated. `EVP_EncodeBlock()` is available in all currently supported OpenSSL releases.