### PR TITLE
Fix some issues with encryption

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,17 @@
 name: c-core
 schema: 1
-version: "4.0.1"
+version: "4.0.2"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2022-11-15
+    version: v4.0.2
+    changes:
+      - type: bug
+        text: "Improved accuracy of the base64 encoding size what fixes buffer underflow in encryption module."
+      - type: bug
+        text: "Fixed undefined behaviours in `pubnub_encrypt_decrypt_iv_sample.c` by including some additional checks and variable initialisations."
+      - type: improvement
+        text: "Made same base for encrypt functions what makes codes easier to understand and maintain."
   - date: 2022-11-08
     version: v4.0.1
     changes:
@@ -653,7 +662,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"
@@ -719,7 +728,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"
@@ -785,7 +794,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"
@@ -847,7 +856,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"
@@ -908,7 +917,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"
@@ -964,7 +973,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"
@@ -1017,7 +1026,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v4.0.2
+November 15 2022
+
+#### Fixed
+- Improved accuracy of the base64 encoding size what fixes buffer underflow in encryption module.
+- Fixed undefined behaviours in `pubnub_encrypt_decrypt_iv_sample.c` by including some additional checks and variable initialisations.
+
+#### Modified
+- Made same base for encrypt functions what makes codes easier to understand and maintain.
+
 ## v4.0.1
 November 08 2022
 

--- a/core/pubnub_crypto.c
+++ b/core/pubnub_crypto.c
@@ -81,7 +81,7 @@ static int cipher_hash(char const* cipher_key, uint8_t hash[33])
     return 0;
 }
 
-static int memory_encrypt(pubnub_bymebl_t buffer, char* base64_str, size_t* n) 
+static int memory_encode(pubnub_bymebl_t buffer, char* base64_str, size_t* n) 
 {
 #if PUBNUB_RAND_INIT_VECTOR
     memmove(buffer.ptr + 16, buffer.ptr, buffer.size);

--- a/core/pubnub_crypto.c
+++ b/core/pubnub_crypto.c
@@ -522,8 +522,8 @@ unsigned char* mx_hmac_sha256(
 #endif
 
 int base64_max_size(int encode_this_many_bytes) {
-    // Base64 overhead is up to 36%, so we allocate an extra 40% + a null character
-    return (int)((float)encode_this_many_bytes * 1.4) + 1;
+    // Base64 overhead is up to 36%, so we allocate an extra 50% + a null character
+    return (int)((float)encode_this_many_bytes * 1.5) + 1;
 }
 
 int base64encode(char* result, int max_size, const void* b64_encode_this, int encode_this_many_bytes) {

--- a/core/pubnub_crypto.c
+++ b/core/pubnub_crypto.c
@@ -134,7 +134,7 @@ int pubnub_encrypt(char const* cipher_key, pubnub_bymebl_t msg, char* base64_str
         return -1;
     }
 
-    result = memory_encrypt(encrypted, base64_str, n);
+    result = memory_encode(encrypted, base64_str, n);
 
     free(encrypted.ptr);
 
@@ -157,7 +157,7 @@ int pubnub_encrypt_buffered(char const* cipher_key, pubnub_bymebl_t msg, char* b
         return -1;
     }
 
-    return memory_encrypt(buffer, base64_str, n);
+    return memory_encode(buffer, base64_str, n);
 }
 
 

--- a/core/pubnub_crypto.c
+++ b/core/pubnub_crypto.c
@@ -81,7 +81,7 @@ static int cipher_hash(char const* cipher_key, uint8_t hash[33])
     return 0;
 }
 
-static int memory_encode(pubnub_bymebl_t buffer, char* base64_str, size_t* n) 
+static int memory_encode(pubnub_bymebl_t buffer, char* base64_str, unsigned char* iv, size_t* n) 
 {
 #if PUBNUB_RAND_INIT_VECTOR
     memmove(buffer.ptr + 16, buffer.ptr, buffer.size);
@@ -134,7 +134,7 @@ int pubnub_encrypt(char const* cipher_key, pubnub_bymebl_t msg, char* base64_str
         return -1;
     }
 
-    result = memory_encode(encrypted, base64_str, n);
+    result = memory_encode(encrypted, base64_str, iv, n);
 
     free(encrypted.ptr);
 
@@ -157,7 +157,7 @@ int pubnub_encrypt_buffered(char const* cipher_key, pubnub_bymebl_t msg, char* b
         return -1;
     }
 
-    return memory_encode(buffer, base64_str, n);
+    return memory_encode(buffer, base64_str, iv, n);
 }
 
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.0.1"
+#define PUBNUB_SDK_VERSION "4.0.2"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/core/samples/pubnub_encrypt_decrypt_iv_sample.c
+++ b/core/samples/pubnub_encrypt_decrypt_iv_sample.c
@@ -57,7 +57,10 @@ int main()
     char noserialize_msg[7] = "yay!";
     printf("Message to be encrypted = %s\n",noserialize_msg);
     pubnub_bymebl_t no_serialize_data = { (uint8_t*)noserialize_msg, (size_t)strlen(noserialize_msg) };
-    pubnub_encrypt(cipher_key, no_serialize_data, noserializemsg_encrypted_str, &noserializemsg_size);
+    if (0 != pubnub_encrypt(cipher_key, no_serialize_data, noserializemsg_encrypted_str, &noserializemsg_size)) {
+        printf("pubnub_encrypt failed! %s %d", __FILE__, __LINE__);
+        return -1;
+    }
     printf("base64 message = %s (size = %d) \n", noserializemsg_encrypted_str, (int)noserializemsg_size);
     printf("\n ***************************************************** \n");
 

--- a/core/samples/pubnub_encrypt_decrypt_iv_sample.c
+++ b/core/samples/pubnub_encrypt_decrypt_iv_sample.c
@@ -61,6 +61,7 @@ int main()
         printf("pubnub_encrypt failed! %s %d", __FILE__, __LINE__);
         return -1;
     }
+    
     printf("base64 message = %s (size = %d) \n", noserializemsg_encrypted_str, (int)noserializemsg_size);
     printf("\n ***************************************************** \n");
 
@@ -84,7 +85,11 @@ int main()
     char msg1[5] = "yay!";
     pubnub_bymebl_t msg_data = { (uint8_t*)msg1, (size_t)strlen(msg1) };
     pubnub_bymebl_t buff_data = { (uint8_t*)malloc(2000), 2000};
-    pubnub_encrypt_buffered(cipher_key, msg_data, msg_encrypted_str, &msg_size, buff_data);
+    if (0 != pubnub_encrypt_buffered(cipher_key, msg_data, msg_encrypted_str, &msg_size, buff_data)) {
+        printf("pubnub_encrypt_buffered failed! %s %d", __FILE__, __LINE__);
+        return -1;
+    }
+
     printf("base64 message = %s (size = %d) \n", msg_encrypted_str, (int)msg_size);
     printf("\n ***************************************************** \n");
 

--- a/core/samples/pubnub_encrypt_decrypt_iv_sample.c
+++ b/core/samples/pubnub_encrypt_decrypt_iv_sample.c
@@ -53,7 +53,7 @@ int main()
 
     /*  pubnub_encrypt   */
     char noserializemsg_encrypted_str[256];
-    size_t noserializemsg_size;
+    size_t noserializemsg_size = 256;
     char noserialize_msg[7] = "yay!";
     printf("Message to be encrypted = %s\n",noserialize_msg);
     pubnub_bymebl_t no_serialize_data = { (uint8_t*)noserialize_msg, (size_t)strlen(noserialize_msg) };
@@ -81,7 +81,7 @@ int main()
 
     /*  pubnub_encrypt_buffered   */
     char msg_encrypted_str[256];
-    size_t msg_size;
+    size_t msg_size = 256;
     char msg1[5] = "yay!";
     pubnub_bymebl_t msg_data = { (uint8_t*)msg1, (size_t)strlen(msg1) };
     pubnub_bymebl_t buff_data = { (uint8_t*)malloc(2000), 2000};


### PR DESCRIPTION
fix: Fixed buffer underflow in encryption

Improved accuracy of the base64 encoding size what fixes buffer underflow in encryption module

fix: Fixed undefined behaviours in `pubnub_encrypt_decrypt_iv_sample.c`

Fixed undefined behaviours in `pubnub_encrypt_decrypt_iv_sample.c` by including some additional checks and variable initialisations

refactor: Made same base for encrypt functions

Made same base for encrypt functions what makes codes easier to understand and maintain