### PR TITLE
fix crashing when parsing access tokens

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "4.0.2"
+version: "4.0.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2022-11-17
+    version: v4.0.3
+    changes:
+      - type: bug
+        text: "Fixed wrong pointer reallocation in string concatenation."
+      - type: bug
+        text: "Fixed allocation counter that was not taking to the account recursed allocations."
   - date: 2022-11-15
     version: v4.0.2
     changes:
@@ -662,7 +669,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"
@@ -728,7 +735,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"
@@ -794,7 +801,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"
@@ -856,7 +863,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"
@@ -917,7 +924,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"
@@ -973,7 +980,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"
@@ -1026,7 +1033,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v4.0.3
+November 17 2022
+
+#### Fixed
+- Fixed wrong pointer reallocation in string concatenation.
+- Fixed allocation counter that was not taking to the account recursed allocations.
+
 ## v4.0.2
 November 15 2022
 

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -207,13 +207,13 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
                 }
             }
             
-	        // TODO: check cbor docs to fix these flags 
+            // TODO: check cbor docs to fix these flags 
             if (strcmp((const char*)buf, "sig") == 0) {
                 sig_flag = true;
             } 
-	        if (strcmp((const char*)buf, "uuid") == 0) {
-                    uuid_flag = true;
-	        }
+            if (strcmp((const char*)buf, "uuid") == 0) {
+                uuid_flag = true;
+            }
 
             free(buf);
             continue;

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -100,13 +100,12 @@ pubnub_chamebl_t pubnub_get_grant_token(pubnub_t* pb)
     return result;
 }
 
-static unsigned int safe_alloc_strcat(char** destination, const char* source, unsigned int current_allocation_size) {
+static unsigned int safe_alloc_strcat(char** destination, const char* source, unsigned int alloc_size) {
     unsigned int concat_size = strlen(*destination) + strlen(source);
-
-    if (concat_size > current_allocation_size) {
-    	unsigned int new_allocation_size = (5 * current_allocation_size) / 4; // +20%
+    if (concat_size > alloc_size) {
+    	unsigned int new_allocation_size = (5 * alloc_size) / 4; // +20%
     	char* new_alloc = (char*)malloc(new_allocation_size);
-    	memmove(new_alloc, *destination, current_allocation_size);
+    	memmove(new_alloc, *destination, alloc_size);
 
     	free(*destination);
 
@@ -116,17 +115,18 @@ static unsigned int safe_alloc_strcat(char** destination, const char* source, un
 
     strcat(*destination, source);
 
-    return current_allocation_size;
+    return alloc_size;
 }
 
 static int currentNestLevel = 0;
+static unsigned int current_allocation_size = 0;
 static CborError data_recursion(CborValue* it, int nestingLevel, char** json_result, unsigned int init_allocation_size)
 {
+    current_allocation_size = init_allocation_size;
     bool containerEnd = false;
     bool sig_flag = false;
     bool uuid_flag = false;
 
-    unsigned int current_allocation_size = init_allocation_size;
     while (!cbor_value_at_end(it)) {
         CborError err;
         CborType type = cbor_value_get_type(it);
@@ -154,7 +154,7 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
             if (err) { return err; }
 
             current_allocation_size = safe_alloc_strcat(json_result, type == CborArrayType ? "]" : "}", current_allocation_size);
-
+            
             bool is_container = cbor_value_is_container(it);
             bool is_array = cbor_value_is_container(it);
             if (!is_container && !is_array && currentNestLevel == nestingLevel && cbor_value_get_type(it) != CborInvalidType) {
@@ -206,13 +206,15 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
                     free(buff_str);
                 }
             }
+            
+	        // TODO: check cbor docs to fix these flags 
             if (strcmp((const char*)buf, "sig") == 0) {
                 sig_flag = true;
             } 
-	    // TODO: why????
-	    if (strcmp((const char*)buf, "uuid") == 0) {
-                uuid_flag = true;
-	    }
+	        if (strcmp((const char*)buf, "uuid") == 0) {
+                    uuid_flag = true;
+	        }
+
             free(buf);
             continue;
         }

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.0.2"
+#define PUBNUB_SDK_VERSION "4.0.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/cpp/pubnub_common.hpp
+++ b/cpp/pubnub_common.hpp
@@ -1224,11 +1224,11 @@ public:
     /// @see pubnub_grant_token
     std::string parse_token(std::string const& token)
     {
-	char* parsed_token_chars = pubnub_parse_token(d_pb, token.c_str());
+    	char* parsed_token_chars = pubnub_parse_token(d_pb, token.c_str());
         std::string owned_parsed_token(parsed_token_chars);
-	
-	::free(parsed_token_chars);
-	return owned_parsed_token; 
+    	
+    	::free(parsed_token_chars);
+    	return owned_parsed_token; 
     }
 #endif
 


### PR DESCRIPTION
fix: wrong pointer management

Fixed wrong pointer reallocation in string concatenation

fix: token parsing allocation counter

Fixed allocation counter that was not taking to the account recursed allocations 