### PR TITLE
fix crashing parsing token for not valid values

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.0.3"
+version: "4.0.4"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2022-11-25
+    version: v4.0.4
+    changes:
+      - type: bug
+        text: "Fixed crashing parsing token for not valid values by logging an error and returning `NULL`."
   - date: 2022-11-17
     version: v4.0.3
     changes:
@@ -669,7 +674,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"
@@ -735,7 +740,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"
@@ -801,7 +806,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"
@@ -863,7 +868,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"
@@ -924,7 +929,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"
@@ -980,7 +985,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"
@@ -1033,7 +1038,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.3
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.0.4
+November 25 2022
+
+#### Fixed
+- Fixed crashing parsing token for not valid values by logging an error and returning `NULL`.
+
 ## v4.0.3
 November 17 2022
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,4 +1,4 @@
-PROJECT_SOURCEFILES = pubnub_pubsubapi.c pubnub_coreapi.c pubnub_ccore_pubsub.c pubnub_ccore.c pubnub_netcore.c pubnub_alloc_static.c pubnub_assert_std.c pubnub_json_parse.c pubnub_keep_alive.c pubnub_helper.c pubnub_url_encode.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c  
+PROJECT_SOURCEFILES = pubnub_pubsubapi.c pubnub_coreapi.c pubnub_ccore_pubsub.c pubnub_ccore.c pubnub_netcore.c pubnub_alloc_static.c pubnub_assert_std.c pubnub_json_parse.c pubnub_keep_alive.c pubnub_helper.c pubnub_url_encode.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../lib/base64/pbbase64.c
 
 all: pubnub_proxy_unittest pubnub_timer_list_unittest unittest
 
@@ -30,6 +30,10 @@ ifndef USE_FETCH_HISTORY
 USE_FETCH_HISTORY = 1
 endif
 
+ifndef USE_GRANT_TOKEN_API
+USE_GRANT_TOKEN_API = 1
+endif
+
 ifeq ($(RECEIVE_GZIP_RESPONSE), 1)
 PROJECT_SOURCEFILES += ../lib/miniz/miniz_tinfl.c pbgzip_decompress.c
 endif
@@ -42,7 +46,11 @@ ifeq ($(USE_FETCH_HISTORY), 1)
 PROJECT_SOURCEFILES += pbcc_fetch_history.c pubnub_fetch_history.c
 endif
 
-CFLAGS +=-g -D PUBNUB_ADVANCED_KEEP_ALIVE=1 -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_DYNAMIC_REPLY_BUFFER=1 -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -I. -I../ -I test -I../lib/base64 -I../lib/md5 -I../lib/miniz -I../cgreen/include
+ifeq ($(USE_GRANT_TOKEN_API), 1)
+PROJECT_SOURCEFILES +=  ../lib/cbor/cborparser.c ../lib/cbor/cborparser_dup_string.c pbcc_grant_token_api.c pubnub_grant_token_api.c
+endif
+
+CFLAGS +=-g -D PUBNUB_ADVANCED_KEEP_ALIVE=1 -D PUBNUB_LOG_LEVEL=PUBNUB_LOG_LEVEL_WARNING -D PUBNUB_DYNAMIC_REPLY_BUFFER=1 -D PUBNUB_RECEIVE_GZIP_RESPONSE=$(RECEIVE_GZIP_RESPONSE) -D PUBNUB_USE_GRANT_TOKEN_API=$(USE_GRANT_TOKEN_API) -I. -I../ -I test -I../lib/base64 -I../lib/md5 -I../lib/miniz -I../cgreen/include
 
 LDFLAGS=-L../cgreen/build/src
 
@@ -61,7 +69,7 @@ pubnub_timer_list_unittest: pubnub_timer_list.c pubnub_timer_list_unit_test.c
 	$(CGREEN_RUNNER) ./pubnub_timer_list_unit_test.so
 	#$(GCOVR) -r . --html --html-details -o coverage.html
 
-PROXY_PROJECT_SOURCEFILES = pubnub_proxy_core.c pubnub_proxy.c pbhttp_digest.c pbntlm_core.c pbntlm_packer_std.c pubnub_generate_uuid_v4_random_std.c ../lib/pubnub_parse_ipv4_addr.c ../lib/pubnub_parse_ipv6_addr.c ../lib/base64/pbbase64.c ../lib/md5/md5.c
+PROXY_PROJECT_SOURCEFILES = pubnub_proxy_core.c pubnub_proxy.c pbhttp_digest.c pbntlm_core.c pbntlm_packer_std.c pubnub_generate_uuid_v4_random_std.c ../lib/pubnub_parse_ipv4_addr.c ../lib/pubnub_parse_ipv6_addr.c  ../lib/md5/md5.c
 
 pubnub_proxy_unittest: $(PROJECT_SOURCEFILES) $(PROXY_PROJECT_SOURCEFILES) pubnub_proxy_unit_test.c
 	gcc -o pubnub_proxy_unit_test.so -shared $(CFLAGS) $(LDFLAGS) -D PUBNUB_CALLBACK_API -D PUBNUB_PROXY_API=1 -Wall $(COVERAGE_FLAGS) -fPIC $(PROJECT_SOURCEFILES) $(PROXY_PROJECT_SOURCEFILES) pubnub_proxy_unit_test.c -lcgreen -lm

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -5098,7 +5098,9 @@ Ensure(single_context_pubnub, illegal_context_fires_assert)
     expect_assert_in(pubnub_get_origin(NULL), "pubnub_pubsubapi.c");
     expect_assert_in(pubnub_free((pubnub_t*)((char*)pbp + 10000)),
                      "pubnub_alloc_static.c");
+#if PUBNUB_USE_ACTIONS_API
     expect_assert_in(pubnub_parse_token(pbp, NULL), "pubnub_grant_token_api.c");
+#endif
 #if PUBNUB_USE_ADVANCED_HISTORY
     expect_assert_in(pubnub_get_error_message(NULL, o_msg), "pubnub_advanced_history.c");
     expect_assert_in(pubnub_get_chan_msg_counts_size(NULL), "pubnub_advanced_history.c");

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -2,6 +2,7 @@
 #include "cgreen/cgreen.h"
 #include "cgreen/mocks.h"
 
+#include "core/pubnub_grant_token_api.h"
 #include "lib/pb_deprecated.h"
 #include "pubnub_internal.h"
 #include "pubnub_server_limits.h"
@@ -5023,6 +5024,16 @@ Ensure(single_context_pubnub, gzip_bad_compression_format)
            equals(PNR_BAD_COMPRESSION_FORMAT));
 }
 
+#if PUBNUB_USE_GRANT_TOKEN_API
+Ensure(single_context_pubnub, token_parsing_not_crashing_for_not_valid_values)
+{
+    pubnub_init(pbp, "looking-glass", "looking-glass");
+    pubnub_set_user_id(pbp, "test_id");
+
+    attest(pubnub_parse_token(pbp, "dummy data"), equals(NULL));  
+}
+#endif
+
 /* Verify ASSERT gets fired */
 
 Ensure(single_context_pubnub, illegal_context_fires_assert)
@@ -5085,6 +5096,7 @@ Ensure(single_context_pubnub, illegal_context_fires_assert)
     expect_assert_in(pubnub_get_origin(NULL), "pubnub_pubsubapi.c");
     expect_assert_in(pubnub_free((pubnub_t*)((char*)pbp + 10000)),
                      "pubnub_alloc_static.c");
+    expect_assert_in(pubnub_parse_token(pbp, NULL), "pubnub_grant_token_api.c");
 #if PUBNUB_USE_ADVANCED_HISTORY
     expect_assert_in(pubnub_get_error_message(NULL, o_msg), "pubnub_advanced_history.c");
     expect_assert_in(pubnub_get_chan_msg_counts_size(NULL), "pubnub_advanced_history.c");

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -2,7 +2,6 @@
 #include "cgreen/cgreen.h"
 #include "cgreen/mocks.h"
 
-#include "core/pubnub_grant_token_api.h"
 #include "lib/pb_deprecated.h"
 #include "pubnub_internal.h"
 #include "pubnub_server_limits.h"
@@ -11,6 +10,9 @@
 #if PUBNUB_USE_ADVANCED_HISTORY
 #include "pubnub_memory_block.h"
 #include "pubnub_advanced_history.h"
+#endif
+#if PUBNUB_USE_GRANT_TOKEN_API
+#include "pubnub_grant_token_api.h"
 #endif
 #include "pubnub_assert.h"
 #include "pubnub_alloc.h"

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -193,12 +193,21 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
                     pubnub_bymebl_t decoded_sig;
                     decoded_sig.size = n;
                     decoded_sig.ptr = buf;
-                    //TODO: error handling?
+
                     pubnub_bymebl_t encoded_sig = pbbase64_encode_alloc_std(decoded_sig);
-                    char base64_str[1000];
+                    if (encoded_sig.size == 0 && encoded_sig.ptr == NULL) {
+                        PUBNUB_LOG_WARNING("\"sig\" field coudn't be encoded! Leaving it empty!");
+
+                        encoded_sig.ptr = malloc(sizeof(char));
+                        encoded_sig.ptr[0] = '\0';
+                    }
+
+                    char base64_str[encoded_sig.size + 2];
                     sprintf(base64_str, "\"%s\"", encoded_sig.ptr);
+
                     free(encoded_sig.ptr);
                     current_allocation_size = safe_alloc_strcat(json_result, base64_str, current_allocation_size);
+
                     sig_flag = false;
                 }
                 else {

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -1,4 +1,5 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#include "core/pubnub_memory_block.h"
 #include "pubnub_internal.h"
 
 #include "core/pubnub_ccore.h"
@@ -15,7 +16,6 @@
 #include "core/pbpal.h"
 
 #include "lib/cbor/cbor.h"
-#include "core/pubnub_crypto.h"
 
 #include <ctype.h>
 #include <stdlib.h>
@@ -190,12 +190,14 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
             }
             else {
                 if (sig_flag) {
-                    int max_size = base64_max_size(n);
-                    char* sig_base64 = (char*)malloc(max_size);
-                    base64encode(sig_base64, max_size, buf, n);
+                    pubnub_bymebl_t decoded_sig;
+                    decoded_sig.size = n;
+                    decoded_sig.ptr = buf;
+                    //TODO: error handling?
+                    pubnub_bymebl_t encoded_sig = pbbase64_encode_alloc_std(decoded_sig);
                     char base64_str[1000];
-                    sprintf(base64_str, "\"%s\"", sig_base64);
-                    free(sig_base64);
+                    sprintf(base64_str, "\"%s\"", encoded_sig.ptr);
+                    free(encoded_sig.ptr);
                     current_allocation_size = safe_alloc_strcat(json_result, base64_str, current_allocation_size);
                     sig_flag = false;
                 }

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -1,5 +1,4 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
-#include "core/pubnub_memory_block.h"
 #include "pubnub_internal.h"
 
 #include "core/pubnub_ccore.h"

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -321,6 +321,12 @@ char* pubnub_parse_token(pubnub_t* pb, char const* token){
 
     pubnub_bymebl_t decoded;
     decoded = pbbase64_decode_alloc_std_str(rawToken);
+    
+    if (decoded.size == 0 && decoded.ptr == NULL) {
+        PUBNUB_LOG_ERROR("Base64 decoding failed! Token \"%s\" is not a valid base64 value!\n", token);
+        return NULL;
+    }
+
     #if PUBNUB_LOG_LEVEL >= PUBNUB_LOG_LEVEL_DEBUG
     PUBNUB_LOG_DEBUG("\nbytes after decoding base64 string = [");
     for (size_t i = 0; i < decoded.size; i++) {

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -198,7 +198,7 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
                     if (encoded_sig.size == 0 && encoded_sig.ptr == NULL) {
                         PUBNUB_LOG_WARNING("\"sig\" field coudn't be encoded! Leaving it empty!");
 
-                        encoded_sig.ptr = malloc(sizeof(char));
+                        encoded_sig.ptr = (uint8_t*)malloc(sizeof(uint8_t));
                         encoded_sig.ptr[0] = '\0';
                     }
 

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -315,6 +315,8 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
 }
 
 char* pubnub_parse_token(pubnub_t* pb, char const* token){
+    PUBNUB_ASSERT_OPT(token != NULL);
+
     char * rawToken = strdup(token);
     replace_char((char*)rawToken, '_', '/');
     replace_char((char*)rawToken, '-', '+');

--- a/core/pubnub_grant_token_api.h
+++ b/core/pubnub_grant_token_api.h
@@ -4,6 +4,7 @@
 
 
 #include "pubnub_api_types.h"
+#include "pubnub_memory_block.h"
 
 #include <stdbool.h>
 #include "lib/cbor/cbor.h"

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.0.3"
+#define PUBNUB_SDK_VERSION "4.0.4"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/lib/base64/pbbase64.c
+++ b/lib/base64/pbbase64.c
@@ -221,10 +221,12 @@ pubnub_bymebl_t pbbase64_decode_alloc(char const*                    s,
     result.size = pbbase64_decoded_length(n) + 1; /* +1 "just in case" */
     result.ptr  = (uint8_t*)malloc(result.size);
     if (NULL == result.ptr) {
+        result.size = 0;
         return result;
     }
     if (0 != pbbase64_decode(s, n, &result, options)) {
         free(result.ptr);
+        result.size = 0;
         result.ptr = NULL;
     }
     return result;

--- a/lib/base64/pbbase64.c
+++ b/lib/base64/pbbase64.c
@@ -83,11 +83,13 @@ pubnub_bymebl_t pbbase64_encode_alloc(pubnub_bymebl_t                data,
     result.size = pbbase64_char_array_size_for_encoding(data.size);
     result.ptr  = (uint8_t*)malloc(result.size);
     if (NULL == result.ptr) {
+        result.size = 0;
         return result;
     }
     if (0 != pbbase64_encode(data, (char*)result.ptr, &result.size, options)) {
         free(result.ptr);
         result.ptr = NULL;
+        result.size = 0;
     }
     return result;
 }


### PR DESCRIPTION
fix: fix crashing parsing token for not valid values

Fixed crashing parsing token for not valid values by logging an error and returning `NULL`.