### PR TITLE
fix MSVC compiler for parse_token

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.0.4"
+version: "4.0.5"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2022-12-02
+    version: v4.0.5
+    changes:
+      - type: bug
+        text: "Fixed compilation error for MSVC in `pubnub_parse_token` function."
   - date: 2022-11-25
     version: v4.0.4
     changes:
@@ -674,7 +679,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"
@@ -740,7 +745,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"
@@ -806,7 +811,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"
@@ -868,7 +873,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"
@@ -929,7 +934,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"
@@ -985,7 +990,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"
@@ -1038,7 +1043,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.0.4
+            location: https://github.com/pubnub/c-core/releases/tag/v4.0.5
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.0.5
+December 02 2022
+
+#### Fixed
+- Fixed compilation error for MSVC in `pubnub_parse_token` function.
+
 ## v4.0.4
 November 25 2022
 

--- a/core/pubnub_grant_token_api.c
+++ b/core/pubnub_grant_token_api.c
@@ -201,7 +201,7 @@ static CborError data_recursion(CborValue* it, int nestingLevel, char** json_res
                         encoded_sig.ptr[0] = '\0';
                     }
 
-                    char base64_str[encoded_sig.size + 2];
+                    char base64_str[67]; // HMAC+SHA256 max size + quotes + tailing null
                     sprintf(base64_str, "\"%s\"", encoded_sig.ptr);
 
                     free(encoded_sig.ptr);

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.0.4"
+#define PUBNUB_SDK_VERSION "4.0.5"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix: MSVC compilation error

Fixed compilation error for MSVC in `pubnub_parse_token` function.  