### PR TITLE
move `pubnub_qt` into main thread

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "4.5.0"
+version: "4.6.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2023-10-30
+    version: v4.6.0
+    changes:
+      - type: feature
+        text: "Add the `PUBNUB_QT_MOVE_TO_THREAD` flag as default to give users the opportunity to manage threads by themselves."
+      - type: bug
+        text: "Move `pubnub_qt` into QT main thread by default to be sure that timers will be run in it."
   - date: 2023-10-16
     version: v4.5.0
     changes:
@@ -741,7 +748,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"
@@ -807,7 +814,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"
@@ -873,7 +880,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"
@@ -935,7 +942,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"
@@ -996,7 +1003,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"
@@ -1052,7 +1059,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"
@@ -1105,7 +1112,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.5.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v4.6.0
+October 30 2023
+
+#### Added
+- Add the `PUBNUB_QT_MOVE_TO_THREAD` flag as default to give users the opportunity to manage threads by themselves.
+
+#### Fixed
+- Move `pubnub_qt` into QT main thread by default to be sure that timers will be run in it.
+
 ## v4.5.0
 October 16 2023
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.5.0"
+#define PUBNUB_SDK_VERSION "4.6.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/qt/README.md
+++ b/qt/README.md
@@ -30,3 +30,14 @@ app. For example, do:
 That will create the `Makefile` that will use Qt5 tools.
 
 Of course, you may also use the provided Qt projects in Qt Creator.
+
+## Additional defines
+
+With PubNub QT SDK we provided some additional defines that changes the behaviour of the SDK 
+depending if they're enabled or not:
+
+|Flag|Status|Description|
+|`PUBNUB_QT`|required|Enables and disables some C-core code to fit QT requirements|
+|`PUBNUB_QT_MOVE_TO_THREAD`|optional, enabled by default|Uses [`moveToThread()`](https://doc.qt.io/qt-6/qobject.html#moveToThread) function to organize SDK timers|
+
+

--- a/qt/README.md
+++ b/qt/README.md
@@ -37,6 +37,7 @@ With PubNub QT SDK we provided some additional defines that changes the behaviou
 depending if they're enabled or not:
 
 |Flag|Status|Description|
+|---|---|---|
 |`PUBNUB_QT`|required|Enables and disables some C-core code to fit QT requirements|
 |`PUBNUB_QT_MOVE_TO_THREAD`|optional, enabled by default|Uses [`moveToThread()`](https://doc.qt.io/qt-6/qobject.html#moveToThread) function to organize SDK timers|
 

--- a/qt/README.md
+++ b/qt/README.md
@@ -1,44 +1,32 @@
-# Pubnub C-core for Qt
+# PubNub C-core for Qt
 
-This is a part of C-core for the Qt. It is tested to work only with
-Qt5 and Qt6. It builds on Qt4, too, but there are some run-time issues, i.e.
-publishing some JSON object fails.
+The PubNub Qt SDK is a part of the PubNub C-core SDK. Unlike the C++ wrapper, which wraps a full-featured C-core platform, this is a Qt-native C-core of sorts. It provides its own Qt API, using as many C-core modules as possible.
 
-Unlike the C++ wrapper, which wraps a "full featured" C-core
-platform, this is a "Qt-native C-core" of sorts. It provides
-it's own (Qt) API, while using as much of C-core modules as
-posible.
+## Supported Qt versions
 
-There are sample projects:
+This SDK works with Qt5 and Qt6. It builds on Qt4, too, but there are some runtime issues, e.g.: publishing a JSON object fails.
 
-- `pubnub.pro`, which will build a Qt command line application which
-executes most of the Pubnub transactions/operations - similar to the
-`pubnub_sync_sample` or `pubnub_callback_sample` from C-core.
-- `pubnub_gui.pro`, which will build a Qt GUI application, a
-"minimalistic" Pubnub console
-
-To build the samples, run `qmake pubnub.pro` or `qmake
-pubnub_gui.pro`, and then `make` or, on Windows if using MSVC, `nmake`
-or `jom`.
-
-If you have many Qt versions on your machine, be sure to use
-the Qt5 or Qt6 (whereas QT6 is unix tested only) tools, for which purpose you may utilize the `qtchooser`
-app. For example, do:
-
-	qtchooser -run-tool=qmake -qt=5 pubnub.pro
-
-That will create the `Makefile` that will use Qt5 tools.
+If you have many Qt versions on your machine, use Qt5 or Qt6 (while Qt6 is Unix-tested only). To select the correct version, you can use the `qtchooser` app. For example, run `qtchooser -run-tool=qmake -qt=5 pubnub.pro`. This creates a `Makefile` that uses Qt5 tools.
 
 Of course, you may also use the provided Qt projects in Qt Creator.
 
+## Sample projects
+
+We provide the following sample projects for your convenience:
+
+- `pubnub.pro`, which builds a Qt command line application that executes most of the Pubnub transactions/operations. It's similar to `pubnub_sync_sample` or `pubnub_callback_sample` from the C-core SDK.
+- `pubnub_gui.pro`, which builds a Qt GUI application, a minimalistic Pubnub console.
+
+To build the projects:
+
+1. Run `qmake pubnub.pro` or `qmakepubnub_gui.pro`
+2. Run `make` or, if you use MSVC on Windows, `nmake` or `jom`.
+
 ## Additional defines
 
-With PubNub QT SDK, we provided some additional defines that change the behaviour of the SDK 
-depending if they're enabled or not:
+With PubNub Qt SDK, we provided some additional defines that change the behavior of the SDK:
 
-|Flag|Status|Description|
+|Flag|Required|Description|
 |---|---|---|
-|`PUBNUB_QT`|required|Enables and disables some C-core code to fit QT requirements|
-|`PUBNUB_QT_MOVE_TO_THREAD`|optional, enabled by default|Uses [`moveToThread()`](https://doc.qt.io/qt-6/qobject.html#moveToThread) function to organize SDK timers|
-
-
+|`PUBNUB_QT`|Required|Enables C-core code to fit Qt requirements.|
+|`PUBNUB_QT_MOVE_TO_THREAD`|Pptional, enabled by default|Uses the [`moveToThread()`](https://doc.qt.io/qt-6/qobject.html#moveToThread) function to organize SDK timers.|

--- a/qt/README.md
+++ b/qt/README.md
@@ -33,7 +33,7 @@ Of course, you may also use the provided Qt projects in Qt Creator.
 
 ## Additional defines
 
-With PubNub QT SDK we provided some additional defines that changes the behaviour of the SDK 
+With PubNub QT SDK, we provided some additional defines that change the behaviour of the SDK 
 depending if they're enabled or not:
 
 |Flag|Status|Description|

--- a/qt/pubnub.pro
+++ b/qt/pubnub.pro
@@ -7,7 +7,7 @@ HEADERS += pubnub_qt.h pubnub_qt_sample.h
 SOURCES += pubnub_qt.cpp pubnub_qt_sample.cpp ../core/pubnub_ccore.c ../core/pubnub_ccore_pubsub.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c
 win32:SOURCES += ../core/c99/snprintf.c
 
-DEFINES += PUBNUB_QT
+DEFINES += PUBNUB_QT PUBNUB_QT_MOVE_TO_THREAD
 
 INCLUDEPATH += ..
 win32:INCLUDEPATH += ../core/c99

--- a/qt/pubnub_gui.pro
+++ b/qt/pubnub_gui.pro
@@ -5,7 +5,7 @@ HEADERS += pubnub_qt.h pubnub_qt_gui_sample.h
 SOURCES += pubnub_qt.cpp pubnub_qt_gui_sample.cpp ../core/pubnub_ccore_pubsub.c ../core/pubnub_ccore.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c 
 win32:SOURCES += ../core/c99/snprintf.c
 
-DEFINES += PUBNUB_QT
+DEFINES += PUBNUB_QT PUBNUB_QT_MOVE_TO_THREAD
 
 INCLUDEPATH += .. 
 win32:INCLUDEPATH += ../core/c99

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -72,16 +72,16 @@ pubnub_qt::pubnub_qt(QString pubkey, QString keysub)
     , d_mutex(QMutex::Recursive)
 #endif
 {
+#ifdef PUBNUB_QT_MOVE_TO_THREAD
+    this->moveToThread(QApplication::instance()->thread());
+#endif
+
     pbcc_init(d_context.data(), d_pubkey.data(), d_keysub.data());
     connect(&d_qnam,
             SIGNAL(sslErrors(QNetworkReply*, QList<QSslError>)),
             this,
             SLOT(sslErrors(QNetworkReply*, QList<QSslError>)));
     connect(d_transactionTimer, SIGNAL(timeout()), this, SLOT(transactionTimeout()));
-
-#ifdef PUBNUB_QT_MOVE_TO_THREAD
-    this->moveToThread(QApplication::instance()->thread());
-#endif
 }
 
 

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -22,6 +22,9 @@ extern "C" {
 }
 
 #include <QtNetwork>
+#ifdef PUBNUB_QT_MOVE_TO_THREAD
+#include <QApplication>
+#endif
 
 /* Minimal acceptable message length difference, between unpacked and packed message, in percents */
 #define PUBNUB_MINIMAL_ACCEPTABLE_COMPRESSION_RATIO 10
@@ -75,6 +78,10 @@ pubnub_qt::pubnub_qt(QString pubkey, QString keysub)
             this,
             SLOT(sslErrors(QNetworkReply*, QList<QSslError>)));
     connect(d_transactionTimer, SIGNAL(timeout()), this, SLOT(transactionTimeout()));
+
+#ifdef PUBNUB_QT_MOVE_TO_THREAD
+    this->moveToThread(QApplication::instance()->thread());
+#endif
 }
 
 


### PR DESCRIPTION
fix: move `pubnub_qt` into QT main thread

Move `pubnub_qt` into QT main thread by default to be sure that timers will be run in it

feat: add `PUBNUB_QT_MOVE_TO_THREAD` flag as default

Add the `PUBNUB_QT_MOVE_TO_THREAD` flag as default to give users the opportunity to manage threads by themselves.