### PR TITLE
provide missing `publish()` function overload for qt

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.6.0"
+version: "4.6.1"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2023-11-08
+    version: v4.6.1
+    changes:
+      - type: bug
+        text: "Provide missing `publish()` function overload for QT wrapper that allows set publish related options."
   - date: 2023-10-30
     version: v4.6.0
     changes:
@@ -748,7 +753,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"
@@ -814,7 +819,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"
@@ -880,7 +885,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"
@@ -942,7 +947,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"
@@ -1003,7 +1008,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"
@@ -1059,7 +1064,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"
@@ -1112,7 +1117,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.6.1
+November 08 2023
+
+#### Fixed
+- Provide missing `publish()` function overload for QT wrapper that allows set publish related options.
+
 ## v4.6.0
 October 30 2023
 

--- a/core/pubnub_coreapi_ex.c
+++ b/core/pubnub_coreapi_ex.c
@@ -1,14 +1,18 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#ifndef PUBNUB_QT
 #include "core/pbcc_set_state.h"
-#include "core/pubnub_api_types.h"
 #include "core/pubnub_coreapi.h"
+#endif
+#include "core/pubnub_api_types.h"
 #include "pubnub_internal.h"
 #include "pubnub_log.h"
 
+#ifndef PUBNUB_QT
 #include "pubnub_ccore.h"
 #include "pubnub_netcore.h"
-#include "pubnub_assert.h"
 #include "pubnub_timers.h"
+#endif
+#include "pubnub_assert.h"
 #include "pubnub_crypto.h"
 #include "pubnub_server_limits.h"
 #include "pubnub_coreapi_ex.h"
@@ -30,6 +34,8 @@ struct pubnub_publish_options pubnub_publish_defopts(void)
     result.method     = pubnubSendViaGET;
     return result;
 }
+
+#ifndef PUBNUB_QT
 
 enum pubnub_res pubnub_publish_ex(pubnub_t*                     pb,
                                   const char*                   channel,
@@ -303,4 +309,6 @@ enum pubnub_res pubnub_set_state_ex(pubnub_t *p,
         ? heartbeat_with_state(p, channel, state, opts)
         : pubnub_set_state(p, channel, opts.channel_group, opts.user_id, state);
 }
+
+#endif PUBNUB_QT
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.6.0"
+#define PUBNUB_SDK_VERSION "4.6.1"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/qt/pubnub_gui.pro
+++ b/qt/pubnub_gui.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 QT += widgets network
 CONFIG += C++11
 HEADERS += pubnub_qt.h pubnub_qt_gui_sample.h
-SOURCES += pubnub_qt.cpp pubnub_qt_gui_sample.cpp ../core/pubnub_ccore_pubsub.c ../core/pubnub_ccore.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c 
+SOURCES += pubnub_qt.cpp pubnub_qt_gui_sample.cpp ../core/pubnub_ccore_pubsub.c ../core/pubnub_ccore.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c ../core/pubnub_coreapi_ex.c 
 win32:SOURCES += ../core/c99/snprintf.c
 
 DEFINES += PUBNUB_QT PUBNUB_QT_MOVE_TO_THREAD

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -534,13 +534,15 @@ pubnub_res pubnub_qt::publish(QString const& channel, QString const& message, pu
 {
     QMutexLocker lk(&d_mutex);
     d_method = pubnubSendViaGET;
+    pubnub_publish_options opt_data = opt.data();
+
     return startRequest(pbcc_publish_prep(d_context.data(),
                                           channel.toLatin1().data(),
                                           message.toLatin1().data(),
-                                          opt.data().store,
-                                          !opt.data().replicate,
-                                          opt.data().meta,
-                                          opt.data().method),
+                                          opt_data.store,
+                                          !opt_data.replicate,
+                                          opt_data.meta,
+                                          opt_data.method),
                         PBTT_PUBLISH);
 }
 

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -530,6 +530,21 @@ pubnub_res pubnub_qt::publish(QString const& channel, QString const& message)
 }
 
 
+pubnub_res pubnub_qt::publish(QString const& channel, QString const& message, publish_options& opt)
+{
+    QMutexLocker lk(&d_mutex);
+    d_method = pubnubSendViaGET;
+    return startRequest(pbcc_publish_prep(d_context.data(),
+                                          channel.toLatin1().data(),
+                                          message.toLatin1().data(),
+                                          opt.data().store,
+                                          !opt.data().replicate,
+                                          opt.data().meta,
+                                          opt.data().method),
+                        PBTT_PUBLISH);
+}
+
+
 pubnub_res pubnub_qt::publish_via_post(QString const&    channel,
                                        QByteArray const& message)
 {

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -533,7 +533,6 @@ pubnub_res pubnub_qt::publish(QString const& channel, QString const& message)
 pubnub_res pubnub_qt::publish(QString const& channel, QString const& message, publish_options& opt)
 {
     QMutexLocker lk(&d_mutex);
-    d_method = pubnubSendViaGET;
     pubnub_publish_options opt_data = opt.data();
 
     return startRequest(pbcc_publish_prep(d_context.data(),

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -47,6 +47,65 @@ class QNetworkReply;
 class QSslError;
 QT_END_NAMESPACE
 
+/** A wrapper class for publish options, enabling a nicer
+    usage. Something like:
+
+        pn.publish(chan, msg, publish_options().store(true).ttl(22));
+*/
+class publish_options {
+    pubnub_publish_options d_;
+    QString d_meta;
+
+public:
+
+    publish_options() : d_(pubnub_publish_defopts()) {}
+
+    /** If true, the message is stored in history. If false,
+        the message is _not_ stored in history.
+    */
+    publish_options& store(bool store)
+    {
+        d_.store = store;
+
+        return *this;
+    }    
+
+    /** If `true`, the message is replicated, thus will be received by
+        all subscribers. If `false`, the message is _not_ replicated
+        and will be only delivered to BLOCK event handlers. Setting
+        `false` here and `false` on store is sometimes referred to as
+        a "fire" (instead of a "publish").
+    */
+    publish_options& replicate(bool replicate)
+    {
+        d_.replicate = replicate;
+
+        return *this;
+    }
+
+    /** An optional JSON object, used to send additional ("meta") data
+        about the message, which can be used for stream filtering.
+     */
+    publish_options& meta(QString const& meta)
+    {
+        d_meta = meta;
+        d_.meta = d_meta.isEmpty() ? 0 : d_meta.toLatin1().data();
+
+        return *this;
+    }
+
+    /** Defines the method by which publish transaction will be performed */
+    publish_options& method(pubnub_method method)
+    {
+        d_.method = method;
+
+        return *this;
+    }
+
+    pubnub_publish_options data() { return d_; }
+};
+
+
 /** A wrapper class for set_state options, enabling a nicer
     usage. Something like:
 
@@ -612,6 +671,18 @@ public:
         @return #PNR_STARTED on success, an error otherwise
      */
     pubnub_res publish(QString const &channel, QString const &message);
+
+    /** Publish the @p message (in JSON format) on @p p channel, using the
+        @p p context. This actually means "initiate a publish
+        transaction".
+
+        This function is similar to casual publish, but it allows you to
+        specify additional options for the publish operation.
+
+        See @publish and @p publish_options for more details.
+    */
+    pubnub_res publish(QString const &channel, QString const &message, publish_options& opt);
+
 
     /** Function that initiates 'publish' transaction via POST method
         @param channel The string with the channel


### PR DESCRIPTION
fix: Provide missing `publish()` function overload for QT wrapper

Provide missing `publish()` function overload for QT wrapper that allows set publish related options