### PR TITLE
fix free on not initialised PubNub

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.6.1"
+version: "4.6.2"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2023-11-14
+    version: v4.6.2
+    changes:
+      - type: bug
+        text: "Fix `pubnub_free()` function on not initialised PubNub that can cause exceptions/undefined behaviours."
   - date: 2023-11-08
     version: v4.6.1
     changes:
@@ -753,7 +758,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"
@@ -819,7 +824,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"
@@ -885,7 +890,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"
@@ -947,7 +952,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"
@@ -1008,7 +1013,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"
@@ -1064,7 +1069,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"
@@ -1117,7 +1122,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.6.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.6.2
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.6.2
+November 14 2023
+
+#### Fixed
+- Fix `pubnub_free()` function on not initialised PubNub that can cause exceptions/undefined behaviours.
+
 ## v4.6.1
 November 08 2023
 

--- a/core/pubnub_alloc_std.c
+++ b/core/pubnub_alloc_std.c
@@ -135,11 +135,17 @@ void pballoc_free_at_last(pubnub_t* pb)
 
 int pubnub_free(pubnub_t* pb)
 {
-    int result = -1;
-
     PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
 
     PUBNUB_LOG_TRACE("pubnub_free(%p)\n", pb);
+
+    if (pb->state == PBS_NULL) {
+        PUBNUB_LOG_TRACE("pubnub_free(%p) not initialized - freeing...\n", pb);
+        remove_allocated(pb);
+        free(pb);
+
+        return 0;
+    }
 
     pubnub_mutex_lock(pb->monitor);
     pbnc_stop(pb, PNR_CANCELLED);
@@ -156,12 +162,11 @@ int pubnub_free(pubnub_t* pb)
         pballoc_free_at_last(pb);
 #endif
 
-        result = 0;
-    }
-    else {
-        PUBNUB_LOG_TRACE("pubnub_free(%p) pb->state=%d\n", pb, pb->state);
-        pubnub_mutex_unlock(pb->monitor);
+        return 0;
     }
 
-    return result;
+    PUBNUB_LOG_TRACE("pubnub_free(%p) pb->state=%d\n", pb, pb->state);
+    pubnub_mutex_unlock(pb->monitor);
+
+    return -1;
 }

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -4547,6 +4547,10 @@ Ensure(single_context_pubnub, gzip_bad_compression_format)
            equals(PNR_BAD_COMPRESSION_FORMAT));
 }
 
+Ensure(single_context_pubnub, wont_fail_on_freed) {
+    // Do nothing, just let alloc and free happen
+}
+
 /* Verify ASSERT gets fired */
 Ensure(single_context_pubnub, illegal_context_fires_assert)
 {
@@ -4634,6 +4638,7 @@ Ensure(single_context_pubnub, illegal_context_fires_assert)
     expect_assert_in(pubnub_get_message_counts(pbp, "ch", NULL), "pubnub_advanced_history.c");
 #endif /* -- ADVANCED HISTORY message_counts -- */
 }
+
 
 #if 0
 int main(int argc, char *argv[])

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -4639,7 +4639,6 @@ Ensure(single_context_pubnub, illegal_context_fires_assert)
 #endif /* -- ADVANCED HISTORY message_counts -- */
 }
 
-
 #if 0
 int main(int argc, char *argv[])
 {

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.6.1"
+#define PUBNUB_SDK_VERSION "4.6.2"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix: fix `pubnub_free()` function on not initialised PubNub
Fix `pubnub_free()` function on not initialised PubNub that can cause exceptions/undefined behaviours