### PR TITLE
provide `#if` macros for pn features to not rely only on makefiles

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.7.1"
+version: "4.8.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2023-12-07
+    version: v4.8.0
+    changes:
+      - type: feature
+        text: "Add `#if` switches into files that are related to PubNub features to not rely only on makefiles. [Be careful when update. It's not a breaking change at all but might fail build for custom makefiles!]."
   - date: 2023-11-23
     version: v4.7.1
     changes:
@@ -768,7 +773,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"
@@ -834,7 +839,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"
@@ -900,7 +905,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"
@@ -962,7 +967,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"
@@ -1023,7 +1028,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"
@@ -1079,7 +1084,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"
@@ -1132,7 +1137,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.7.1
+            location: https://github.com/pubnub/c-core/releases/tag/v4.8.0
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.8.0
+December 07 2023
+
+#### Added
+- Add `#if` switches into files that are related to PubNub features to not rely only on makefiles. [Be careful when update. It's not a breaking change at all but might fail build for custom makefiles!].
+
 ## v4.7.1
 November 23 2023
 

--- a/core/pbauto_heartbeat.c
+++ b/core/pbauto_heartbeat.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+
 #include "pubnub_internal.h"
 
 #if !defined _WIN32
@@ -756,3 +759,5 @@ void pbauto_heartbeat_stop(void)
     m_watcher.stop_heartbeat_watcher_thread = true;
     pubnub_mutex_unlock(m_watcher.stoplock);
 }
+
+#endif /* PUBNUB_USE_AUTO_HEARTBEAT */

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_ACTIONS_API
+
 #include "pubnub_internal.h"
 #include "pubnub_version.h"
 #include "pubnub_assert.h"
@@ -624,3 +627,5 @@ enum pubnub_res pbcc_parse_history_with_actions_response(struct pbcc_context* pb
 
     return PNR_OK;
 }
+
+#endif /* PUBNUB_USE_ACTIONS_API */

--- a/core/pbcc_actions_api.h
+++ b/core/pbcc_actions_api.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_ACTIONS_API
+
 #if !defined INC_PBCC_ACTIONS_API
 #define INC_PBCC_ACTIONS_API
 
@@ -105,5 +108,5 @@ enum pubnub_res pbcc_parse_history_with_actions_response(struct pbcc_context* pb
 
 #endif /* !defined INC_PBCC_ACTIONS_API */
 
-
+#endif /* PUBNUB_USE_ACTIONS_API */
 

--- a/core/pbcc_objects_api.c
+++ b/core/pbcc_objects_api.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_OBJECTS_API
+
 #include "pubnub_internal.h"
 #include "pubnub_version.h"
 #include "pubnub_assert.h"
@@ -815,3 +818,6 @@ enum pubnub_res pbcc_parse_objects_api_response(struct pbcc_context* pb)
 
     return PNR_OK;
 }
+
+#endif /* PUBNUB_USE_OBJECTS_API */
+

--- a/core/pbcc_objects_api.h
+++ b/core/pbcc_objects_api.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_OBJECTS_API
+
 #if !defined INC_PBCC_OBJECTS_API
 #define INC_PBCC_OBJECTS_API
 
@@ -154,3 +157,6 @@ enum pubnub_res pbcc_parse_objects_api_response(struct pbcc_context* pb);
 
 
 #endif /* !defined INC_PBCC_OBJECTS_API */
+
+#endif /* PUBNUB_USE_OBJECTS_API */
+

--- a/core/pbcc_subscribe_v2.c
+++ b/core/pbcc_subscribe_v2.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_SUBSCRIBE_V2
+
 #include "pubnub_internal.h"
 
 #include "pubnub_version.h"
@@ -326,3 +329,6 @@ struct pubnub_v2_message pbcc_get_msg_v2(struct pbcc_context* p)
 
     return rslt;
 }
+
+#endif /* PUBNUB_USE_SUBSCRIBE_V2 */
+

--- a/core/pbcc_subscribe_v2.h
+++ b/core/pbcc_subscribe_v2.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_SUBSCRIBE_V2
+
 #if !defined INC_PBCC_SUBSCRIBE_V2
 #define INC_PBCC_SUBSCRIBE_V2
 
@@ -35,3 +38,6 @@ struct pubnub_v2_message pbcc_get_msg_v2(struct pbcc_context* p);
 
 
 #endif /* !defined INC_PBCC_SUBSCRIBE_V2 */
+
+#endif /* PUBNUB_USE_SUBSCRIBE_V2 */
+

--- a/core/pbgzip_compress.c
+++ b/core/pbgzip_compress.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #include "pubnub_internal.h"
 
 #include "core/pubnub_assert.h"
@@ -129,3 +132,5 @@ enum pubnub_res pbgzip_compress(pubnub_t* pb, char const* message)
 
     return deflate_total_to_context_buffer(pb, message, size);
 }
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */

--- a/core/pbgzip_compress.h
+++ b/core/pbgzip_compress.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #if !defined INC_PUBNUB_COMPRESSION
 #define INC_PUBNUB_COMPRESSION
 
@@ -12,3 +15,5 @@
 enum pubnub_res pbgzip_compress(pubnub_t *pb, char const* message);
 
 #endif /* INC_PUBNUB_COMPRESSION */
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */

--- a/core/pbgzip_decompress.c
+++ b/core/pbgzip_decompress.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_RECEIVE_GZIP_RESPONSE
+
 #include "pubnub_internal.h"
 
 #include "core/pubnub_assert.h"
@@ -164,3 +167,6 @@ enum pubnub_res pbgzip_decompress(pubnub_t* pb)
     return inflate_total(
         pb, data + GZIP_HEADER_LENGTH_BYTES, size, (size_t)unpacked_size);
 }
+
+#endif /* PUBNUB_RECEIVE_GZIP_RESPONSE */
+

--- a/core/pbgzip_decompress.h
+++ b/core/pbgzip_decompress.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_RECEIVE_GZIP_RESPONSE
+
 #if !defined INC_PUBNUB_DECOMPRESSION
 #define INC_PUBNUB_DECOMPRESSION
 
@@ -19,3 +22,6 @@ enum pubnub_data_compressionType{
 enum pubnub_res pbgzip_decompress(pubnub_t *pb);
 
 #endif /* INC_PUBNUB_DECOMPRESSION */
+
+#endif /* PUBNUB_RECEIVE_GZIP_RESPONSE */
+

--- a/core/pbhttp_digest.c
+++ b/core/pbhttp_digest.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #include "pubnub_internal.h"
 
 #include "core/pubnub_proxy_core.h"
@@ -319,3 +322,5 @@ int pbhttp_digest_prep_header_to_send(struct pbhttp_digest_context* ctx,
 
     return 0;
 }
+
+#endif /* PUBNUB_PROXY_API */

--- a/core/pbhttp_digest.h
+++ b/core/pbhttp_digest.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #if !defined INC_PBHTTP_DIGEST
 #define      INC_PBHTTP_DIGEST
 
@@ -152,3 +155,5 @@ char const* pbhttp_digest_algorithm2str(enum pbhttp_digest_algorithm e);
 
 
 #endif /* !defined INC_PBHTTP_DIGEST */
+#endif /* PUBNUB_PROXY_API */
+

--- a/core/pbntlm_core.c
+++ b/core/pbntlm_core.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #include "core/pbntlm_core.h"
 
 #include "core/pbntlm_packer.h"
@@ -80,4 +83,6 @@ int pbntlm_core_prep_msg_to_send(pubnub_t *pb, pubnub_bymebl_t* data)
         return -1;
     }
 }
+
+#endif /* PUBNUB_PROXY_API */
 

--- a/core/pbntlm_core.h
+++ b/core/pbntlm_core.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #if !defined INC_PBNTLM_CORE
 #define      INC_PBNTLM_CORE
 
@@ -16,3 +19,4 @@ int pbntlm_core_prep_msg_to_send(pubnub_t *pb, pubnub_bymebl_t* data);
 
 
 #endif /* !defined INC_PBNTLM_CORE */
+#endif /* PUBNUB_PROXY_API */

--- a/core/pbntlm_packer.h
+++ b/core/pbntlm_packer.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #if !defined INC_PBNTLM_PACKER
 #define      INC_PBNTLM_PACKER
 
@@ -19,3 +22,5 @@ void pbntlm_packer_deinit(pbntlm_ctx_t *pb);
 
 
 #endif /* !defined INC_PBNTLM_PACKER */
+#endif /* PUBNUB_PROXY_API */
+

--- a/core/pbntlm_packer_sspi.c
+++ b/core/pbntlm_packer_sspi.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #include "pbntlm_packer.h"
 
 #include "pubnub_log.h"
@@ -212,3 +215,6 @@ void pbntlm_packer_deinit(pbntlm_ctx_t *pb)
         SecInvalidateHandle(&pb->hcreds);
     }
 }
+
+#endif /* PUBNUB_PROXY_API */
+

--- a/core/pbntlm_packer_std.c
+++ b/core/pbntlm_packer_std.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #include "pbntlm_packer.h"
 
 #include "pubnub_log.h"
@@ -51,3 +54,5 @@ void pbntlm_packer_deinit(pbntlm_ctx_t *pb)
 {
     PUBNUB_UNUSED(pb);
 }
+
+#endif /* PUBNUB_PROXY_API */

--- a/core/pubnub_actions_api.c
+++ b/core/pubnub_actions_api.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_ACTIONS_API
+
 #include "pubnub_internal.h"
 
 #include "core/pubnub_ccore.h"
@@ -267,3 +270,6 @@ enum pubnub_res pubnub_history_with_message_actions_more(pubnub_t* pb)
 
     return rslt;
 }
+
+#endif /* PUBNUB_USE_ACTIONS_API */
+

--- a/core/pubnub_actions_api.h
+++ b/core/pubnub_actions_api.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_ACTIONS_API
+
 #if !defined INC_PUBNUB_ACTIONS_API
 #define INC_PUBNUB_ACTIONS_API
 
@@ -160,3 +163,6 @@ PUBNUB_EXTERN enum pubnub_res pubnub_history_with_message_actions_more(pubnub_t*
 
 
 #endif /* !defined INC_PUBNUB_ACTIONS_API */
+
+#endif /* PUBNUB_USE_ACTIONS_API */
+

--- a/core/pubnub_advanced_history.h
+++ b/core/pubnub_advanced_history.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_ADVANCED_HISTORY
+
 #if !defined INC_PUBNUB_ADVANCED_HISTORY
 #define INC_PUBNUB_ADVANCED_HISTORY
 
@@ -62,3 +65,6 @@ PUBNUB_EXTERN int pubnub_get_message_counts(pubnub_t* pb, char const*channel, in
 
 
 #endif /* !defined INC_PUBNUB_ADVANCED_HISTORY */
+
+#endif /* PUBNUB_USE_ADVANCED_HISTORY */
+

--- a/core/pubnub_auto_heartbeat.h
+++ b/core/pubnub_auto_heartbeat.h
@@ -1,4 +1,5 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
 #if !defined INC_PUBNUB_AUTO_HEARTBEAT
 #define INC_PUBNUB_AUTO_HEARTBEAT
 

--- a/core/pubnub_fetch_history.h
+++ b/core/pubnub_fetch_history.h
@@ -1,4 +1,6 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#if PUBNUB_USE_FETCH_HISTORY
+
 #if !defined INC_PUBNUB_FETCH_HISTORY
 #define INC_PUBNUB_FETCH_HISTORY
 
@@ -85,3 +87,6 @@ PUBNUB_EXTERN enum pubnub_res pubnub_fetch_history(pubnub_t*                    
 PUBNUB_EXTERN pubnub_chamebl_t pubnub_get_fetch_history(pubnub_t* pb);
 
 #endif /* !defined INC_PUBNUB_FETCH_HISTORY */
+
+#endif /* PUBNUB_USE_FETCH_HISTORY */
+

--- a/core/pubnub_objects_api.c
+++ b/core/pubnub_objects_api.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_OBJECTS_API
+
 #include "pubnub_internal.h"
 
 #include "core/pubnub_ccore.h"
@@ -563,3 +566,6 @@ enum pubnub_res pubnub_remove_members(pubnub_t* pb,
 
     return rslt;
 }
+
+#endif /* PUBNUB_USE_OBJECTS_API */
+

--- a/core/pubnub_objects_api.h
+++ b/core/pubnub_objects_api.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_OBJECTS_API
+
 #if !defined INC_PUBNUB_OBJECTS_API
 #define INC_PUBNUB_OBJECTS_API
 
@@ -334,3 +337,6 @@ PUBNUB_EXTERN enum pubnub_res pubnub_remove_members(pubnub_t* pb,
 
 
 #endif /* !defined INC_PUBNUB_OBJECTS_API */
+
+#endif /* PUBNUB_USE_OBJECTS_API */
+

--- a/core/pubnub_proxy.c
+++ b/core/pubnub_proxy.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #include "pubnub_internal.h"
 
 #include "pubnub_proxy.h"
@@ -144,3 +147,5 @@ int pubnub_set_proxy_authentication_username_password(pubnub_t*   p,
 
     return 0;
 }
+
+#endif /* PUBNUB_PROXY_API */

--- a/core/pubnub_proxy.h
+++ b/core/pubnub_proxy.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #if !defined INC_PUBNUB_PROXY
 #define INC_PUBNUB_PROXY
 
@@ -221,3 +224,5 @@ PUBNUB_EXTERN int pubnub_proxy_get_config(pubnub_t*               pb,
 
 
 #endif /* defined INC_PUBNUB_PROXY */
+
+#endif /* PUBNUB_PROXY_API */

--- a/core/pubnub_proxy_core.c
+++ b/core/pubnub_proxy_core.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #include "core/pubnub_proxy_core.h"
 
 #include "core/pubnub_assert.h"
@@ -378,3 +381,5 @@ enum pbproxyFinInstruction pbproxy_handle_finish(pubnub_t* pb)
 
     return pbproxyFinGoOn;
 }
+
+#endif /* PUBNUB_PROXY_API */

--- a/core/pubnub_proxy_core.c
+++ b/core/pubnub_proxy_core.c
@@ -1,7 +1,5 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
 
-#if PUBNUB_PROXY_API
-
 #include "core/pubnub_proxy_core.h"
 
 #include "core/pubnub_assert.h"
@@ -382,4 +380,3 @@ enum pbproxyFinInstruction pbproxy_handle_finish(pubnub_t* pb)
     return pbproxyFinGoOn;
 }
 
-#endif /* PUBNUB_PROXY_API */

--- a/core/pubnub_proxy_core.h
+++ b/core/pubnub_proxy_core.h
@@ -1,7 +1,5 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
 
-#if PUBNUB_PROXY_API
-
 #if !defined INC_PUBNUB_PROXY_CORE
 #define      INC_PUBNUB_PROXY_CORE
 
@@ -84,5 +82,4 @@ enum pbproxyFinInstruction pbproxy_handle_finish(pubnub_t *pb);
 
 
 #endif /* !defined INC_PUBNUB_PROXY_CORE */
-#endif /* PUBNUB_PROXY_API */
 

--- a/core/pubnub_proxy_core.h
+++ b/core/pubnub_proxy_core.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_PROXY_API
+
 #if !defined INC_PUBNUB_PROXY_CORE
 #define      INC_PUBNUB_PROXY_CORE
 
@@ -81,3 +84,5 @@ enum pbproxyFinInstruction pbproxy_handle_finish(pubnub_t *pb);
 
 
 #endif /* !defined INC_PUBNUB_PROXY_CORE */
+#endif /* PUBNUB_PROXY_API */
+

--- a/core/pubnub_subscribe_v2.c
+++ b/core/pubnub_subscribe_v2.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_SUBSCRIBE_V2
+
 #include "pubnub_internal.h"
 
 #include "pubnub_server_limits.h"
@@ -67,3 +70,6 @@ struct pubnub_v2_message pubnub_get_v2(pubnub_t* pb)
 
     return result;
 }
+
+#endif /* PUBNUB_USE_SUBSCRIBE_V2 */
+

--- a/core/pubnub_subscribe_v2.h
+++ b/core/pubnub_subscribe_v2.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_SUBSCRIBE_V2
+
 #if !defined INC_PUBNUB_SUBSCRIBE_V2
 #define INC_PUBNUB_SUBSCRIBE_V2
 
@@ -102,3 +105,6 @@ PUBNUB_EXTERN struct pubnub_v2_message pubnub_get_v2(pubnub_t* pbp);
 
 
 #endif /* !defined INC_PUBNUB_SUBSCRIBE_V2 */
+
+#endif /* PUBNUB_USE_SUBSCRIBE_V2 */
+

--- a/core/pubnub_subscribe_v2_message.h
+++ b/core/pubnub_subscribe_v2_message.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_SUBSCRIBE_V2
+
 #if !defined INC_PUBNUB_SUBSCRIBE_V2_MESSAGE
 #define      INC_PUBNUB_SUBSCRIBE_V2_MESSAGE
 
@@ -56,3 +59,6 @@ struct pubnub_v2_message {
 
 
 #endif /* INC_PUBNUB_SUBSCRIBE_V2_MESSAGE */
+
+#endif /* PUBNUB_USE_SUBSCRIBE_V2 */
+

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.7.1"
+#define PUBNUB_SDK_VERSION "4.8.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/lib/miniz/miniz.c
+++ b/lib/miniz/miniz.c
@@ -25,6 +25,8 @@
  *
  **************************************************************************/
 
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #include "miniz.h"
 
 typedef unsigned char mz_validate_uint16[sizeof(mz_uint16) == 2 ? 1 : -1];
@@ -601,3 +603,5 @@ const char *mz_error(int err)
 
   For more information, please refer to <http://unlicense.org/>
 */
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */

--- a/lib/miniz/miniz.h
+++ b/lib/miniz/miniz.h
@@ -111,6 +111,9 @@
      uses the 64-bit variants: fopen64(), stat64(), etc. Otherwise you won't be able to process large files
      (i.e. 32-bit stat() fails for me on files > 0x7FFFFFFF bytes).
 */
+
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #pragma once
 
 #include "miniz_common.h"
@@ -468,3 +471,5 @@ typedef void *const voidpc;
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */

--- a/lib/miniz/miniz_tdef.c
+++ b/lib/miniz/miniz_tdef.c
@@ -25,6 +25,8 @@
  *
  **************************************************************************/
 
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #include "miniz_tdef.h"
 #include "miniz.h"
 
@@ -1562,3 +1564,5 @@ void tdefl_compressor_free(tdefl_compressor *pComp)
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* MINIZ_NO_ZLIB_APIS */

--- a/lib/miniz/miniz_tdef.h
+++ b/lib/miniz/miniz_tdef.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #pragma once
 #include "miniz_common.h"
 
@@ -187,3 +190,5 @@ void tdefl_compressor_free(tdefl_compressor *pComp);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */

--- a/lib/miniz/miniz_tinfl.c
+++ b/lib/miniz/miniz_tinfl.c
@@ -24,6 +24,8 @@
  *
  **************************************************************************/
 
+#if PUBNUB_RECEIVE_GZIP_RESPONSE
+
 #include "lib/miniz/miniz_tinfl.h"
 #include "core/pubnub_log.h"
 
@@ -734,3 +736,6 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PUBNUB_RECEIVE_GZIP_RESPONSE */
+

--- a/lib/miniz/miniz_tinfl.h
+++ b/lib/miniz/miniz_tinfl.h
@@ -1,3 +1,5 @@
+#if PUBNUB_RECEIVE_GZIP_RESPONSE
+
 #pragma once
 #include "lib/miniz/miniz_common.h"
 /* ------------------- Low-level Decompression API Definitions */
@@ -142,3 +144,5 @@ struct tinfl_decompressor_tag
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PUBNUB_RECEIVE_GZIP_RESPONSE */

--- a/lib/pbcrc32.c
+++ b/lib/pbcrc32.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #include "lib/pbcrc32.h"
 #include "core/pubnub_assert.h"
 
@@ -32,3 +35,6 @@ uint32_t pbcrc32(const void *data, size_t n_bytes)
     }
     return crc;
 }
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */
+

--- a/lib/pbcrc32.h
+++ b/lib/pbcrc32.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_GZIP_COMPRESSION
+
 #if !defined INC_PB_CRC32
 #define INC_PB_CRC32
 
@@ -12,4 +15,6 @@
 uint32_t pbcrc32(const void *data, size_t n_bytes);
 
 #endif /* INC_PB_CRC32 */
+
+#endif /* PUBNUB_USE_GZIP_COMPRESSION */
 

--- a/lib/pbstr_remove_from_list.c
+++ b/lib/pbstr_remove_from_list.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+
 #include "lib/pb_strnlen_s.h"
 #include "core/pubnub_assert.h"
 
@@ -77,3 +80,6 @@ void pbstr_free_if_empty(char** list)
         *list = NULL;
     }
 }
+
+#endif /* PUBNUB_USE_AUTO_HEARTBEAT */
+

--- a/lib/pbstr_remove_from_list.h
+++ b/lib/pbstr_remove_from_list.h
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+
 #if !defined INC_PBSTR_REMOVE_FROM_LIST
 #define INC_PBSTR_REMOVE_FROM_LIST
 
@@ -12,3 +15,6 @@ void pbstr_remove_from_list(char* list, const char* leave_list);
 void pbstr_free_if_empty(char** list);
 
 #endif /* !defined INC_PBSTR_REMOVE_FROM_LIST */
+
+#endif /* PUBNUB_USE_AUTO_HEARTBEAT */
+

--- a/posix/pbauto_heartbeat_init_posix.c
+++ b/posix/pbauto_heartbeat_init_posix.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+
 #include "pubnub_internal.h"
 #include "core/pubnub_log.h"
 
@@ -121,3 +124,5 @@ int pbauto_heartbeat_init(struct HeartbeatWatcherData* m_watcher)
 
     return 0;
 }
+
+#endif

--- a/windows/pbauto_heartbeat_init_windows.c
+++ b/windows/pbauto_heartbeat_init_windows.c
@@ -1,4 +1,7 @@
 /* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+#if PUBNUB_USE_AUTO_HEARTBEAT
+
 #include "pubnub_internal.h"
 #include "core/pubnub_log.h"
 
@@ -30,3 +33,6 @@ int pbauto_heartbeat_init(struct HeartbeatWatcherData* m_watcher)
 
     return 0;
 }
+
+#endif /* PUBNUB_USE_AUTO_HEARTBEAT */
+


### PR DESCRIPTION
feat: Add `#if` switches into files that are related to PubNub features to not rely only on makefiles.

Add `#if` switches into files that are related to PubNub features to not rely only on makefiles. [Be careful when update. It's not a breaking change at all but might fail build for custom makefiles!]