### PR TITLE
CMake External Project Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,15 @@ if(${USE_REVOKE_TOKEN_API})
         ${CMAKE_CURRENT_LIST_DIR}/core/pubnub_revoke_token_api.c)
 endif()
 
+set(SOURCEFILES 
+    ${CORE_SOURCEFILES} 
+    ${LIB_SOURCEFILES} 
+    ${OS_SOURCEFILES} 
+    ${FEATURE_SOURCEFILES} 
+    ${INTF_SOURCEFILES})
+
+add_library(pubnub ${LIBTYPE} ${SOURCEFILES})
+
 set(OPENSSL_LINK_LIBRARIES)
 if(${OPENSSL})
     message(STATUS "Using OpenSSL")
@@ -253,7 +262,7 @@ if(${OPENSSL})
     set(FEATURE_SOURCEFILES 
         ${OPENSSL_LIBRARIES} 
         ${FEATURE_SOURCEFILES})
-    include_directories(${OPENSSL_INCLUDE_DIR})
+    target_include_directories(pubnub PUBLIC ${OPENSSL_INCLUDE_DIR})
 
     set(LIB_SOURCEFILES 
         ${CMAKE_CURRENT_LIST_DIR}/lib/base64/pbbase64.c 
@@ -279,20 +288,14 @@ if(${OPENSSL})
     set(OPENSSL_LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
 endif()
 
-set(SOURCEFILES 
-    ${CORE_SOURCEFILES} 
-    ${LIB_SOURCEFILES} 
-    ${OS_SOURCEFILES} 
-    ${FEATURE_SOURCEFILES} 
-    ${INTF_SOURCEFILES})
-
-include_directories(
-    ${CMAKE_CURRENT_LIST_DIR} 
+target_include_directories(pubnub PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/cpp
     ${CMAKE_CURRENT_LIST_DIR}/core 
     ${CMAKE_CURRENT_LIST_DIR}/lib)
 
 if(${OPENSSL})
-    include_directories(
+    target_include_directories(pubnub PUBLIC 
         ${CMAKE_CURRENT_LIST_DIR}/openssl/
         ${CMAKE_CURRENT_LIST_DIR}/lib/base64)
 else()
@@ -303,12 +306,12 @@ else()
         set(LIB_SOURCEFILES 
             ${CMAKE_CURRENT_LIST_DIR}/posix/pbpal_posix_blocking_io.c 
             ${LIB_SOURCEFILES})
-        include_directories(${CMAKE_CURRENT_LIST_DIR}/posix)
+        target_include_directories(pubnub PUBLIC ${CMAKE_CURRENT_LIST_DIR}/posix)
     elseif(WIN32 || WIN64 || MSVC)
         set(LIB_SOURCEFILES 
             ${CMAKE_CURRENT_LIST_DIR}/windows/pbpal_windows_blocking_io.c 
             ${LIB_SOURCEFILES})
-        include_directories(
+        target_include_directories(pubnub PUBLIC
             ${CMAKE_CURRENT_LIST_DIR}/windows
             ${CMAKE_CURRENT_LIST_DIR}/core/c99)
     endif()
@@ -321,8 +324,6 @@ else()
     message(STATUS "Building static library")
     set(LIBYTPE STATIC)
 endif()
-
-add_library(pubnub ${LIBTYPE} ${SOURCEFILES})
 
 target_link_libraries(pubnub ${LDLIBS} ${OPENSSL_LINK_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,15 +240,6 @@ if(${USE_REVOKE_TOKEN_API})
         ${CMAKE_CURRENT_LIST_DIR}/core/pubnub_revoke_token_api.c)
 endif()
 
-set(SOURCEFILES 
-    ${CORE_SOURCEFILES} 
-    ${LIB_SOURCEFILES} 
-    ${OS_SOURCEFILES} 
-    ${FEATURE_SOURCEFILES} 
-    ${INTF_SOURCEFILES})
-
-add_library(pubnub ${LIBTYPE} ${SOURCEFILES})
-
 set(OPENSSL_LINK_LIBRARIES)
 if(${OPENSSL})
     message(STATUS "Using OpenSSL")
@@ -262,7 +253,6 @@ if(${OPENSSL})
     set(FEATURE_SOURCEFILES 
         ${OPENSSL_LIBRARIES} 
         ${FEATURE_SOURCEFILES})
-    target_include_directories(pubnub PUBLIC ${OPENSSL_INCLUDE_DIR})
 
     set(LIB_SOURCEFILES 
         ${CMAKE_CURRENT_LIST_DIR}/lib/base64/pbbase64.c 
@@ -286,7 +276,29 @@ if(${OPENSSL})
 
     set(LDLIBS  ${LDLIBS})
     set(OPENSSL_LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
+else()
+    set(LIB_SOURCEFILES 
+        ${CMAKE_CURRENT_LIST_DIR}/lib/sockets/pbpal_sockets.c 
+        ${LIB_SOURCEFILES})
+    if(UNIX)
+        set(LIB_SOURCEFILES 
+            ${CMAKE_CURRENT_LIST_DIR}/posix/pbpal_posix_blocking_io.c 
+            ${LIB_SOURCEFILES})
+    elseif(WIN32 || WIN64 || MSVC)
+        set(LIB_SOURCEFILES 
+            ${CMAKE_CURRENT_LIST_DIR}/windows/pbpal_windows_blocking_io.c 
+            ${LIB_SOURCEFILES})
+    endif()
 endif()
+
+set(SOURCEFILES 
+    ${CORE_SOURCEFILES} 
+    ${LIB_SOURCEFILES} 
+    ${OS_SOURCEFILES} 
+    ${FEATURE_SOURCEFILES} 
+    ${INTF_SOURCEFILES})
+
+add_library(pubnub ${LIBTYPE} ${SOURCEFILES})
 
 target_include_directories(pubnub PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
@@ -298,19 +310,11 @@ if(${OPENSSL})
     target_include_directories(pubnub PUBLIC 
         ${CMAKE_CURRENT_LIST_DIR}/openssl/
         ${CMAKE_CURRENT_LIST_DIR}/lib/base64)
+    target_include_directories(pubnub PUBLIC ${OPENSSL_INCLUDE_DIR})
 else()
-    set(LIB_SOURCEFILES 
-        ${CMAKE_CURRENT_LIST_DIR}/lib/sockets/pbpal_sockets.c 
-        ${LIB_SOURCEFILES})
     if(UNIX)
-        set(LIB_SOURCEFILES 
-            ${CMAKE_CURRENT_LIST_DIR}/posix/pbpal_posix_blocking_io.c 
-            ${LIB_SOURCEFILES})
         target_include_directories(pubnub PUBLIC ${CMAKE_CURRENT_LIST_DIR}/posix)
     elseif(WIN32 || WIN64 || MSVC)
-        set(LIB_SOURCEFILES 
-            ${CMAKE_CURRENT_LIST_DIR}/windows/pbpal_windows_blocking_io.c 
-            ${LIB_SOURCEFILES})
         target_include_directories(pubnub PUBLIC
             ${CMAKE_CURRENT_LIST_DIR}/windows
             ${CMAKE_CURRENT_LIST_DIR}/core/c99)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,14 @@ set(SOURCEFILES
     ${FEATURE_SOURCEFILES} 
     ${INTF_SOURCEFILES})
 
+if(${SHARED_LIB})
+    message(STATUS "Building shared library")
+    set(LIBTYPE SHARED)
+else()
+    message(STATUS "Building static library")
+    set(LIBYTPE STATIC)
+endif()
+
 add_library(pubnub ${LIBTYPE} ${SOURCEFILES})
 
 target_include_directories(pubnub PUBLIC
@@ -319,14 +327,6 @@ else()
             ${CMAKE_CURRENT_LIST_DIR}/windows
             ${CMAKE_CURRENT_LIST_DIR}/core/c99)
     endif()
-endif()
-
-if(${SHARED_LIB})
-    message(STATUS "Building shared library")
-    set(LIBTYPE SHARED)
-else()
-    message(STATUS "Building static library")
-    set(LIBYTPE STATIC)
 endif()
 
 target_link_libraries(pubnub ${LDLIBS} ${OPENSSL_LINK_LIBRARIES})


### PR DESCRIPTION
I tested the new CMake branch. The build works great but I ran into some issues when integrating PubNub into an external CMake project

Demo project is set up as shown

![image](https://github.com/pubnub/c-core/assets/6977035/63be3c57-a34d-49f7-8a3d-ab8a0eb6ca8d)


CMake build fails on missing symbols and missing headers

PR includes fixes for symbols and uses the preferred target based headers `target_include_directories`. To do this i moved the source file list creation above the target `add_library` and moved the header includes below the target creation.