### PR TITLE
fix some crypto issues

### DIFF
--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -7,6 +7,6 @@
     { "pattern": "#define PUBNUB_SDK_VERSION \"(.+)\"$", "cleared": true }
   ],
   "CMakeLists.txt": [
-    { "pattern": "^version(\"(.+)\")$", "cleared": true },
-  ],
+    { "pattern": "^version(\"(.+)\")$", "cleared": true }
+  ]
 }

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,13 @@ schema: 1
 version: "4.9.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2024-03-26
+    version: v4.9.1
+    changes:
+      - type: bug
+        text: "Fix too small amount of memory allocated for aes cbc algorithm in some cases."
+      - type: improvement
+        text: "Add possibility to include address sanitizer in build via CMake."
   - date: 2024-01-08
     version: v4.9.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v4.9.1
+March 26 2024
+
+#### Fixed
+- Fix too small amount of memory allocated for aes cbc algorithm in some cases.
+
+#### Modified
+- Add possibility to include address sanitizer in build via CMake.
+
 ## v4.9.0
 January 08 2024
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ num_option(USE_CALLBACK_API "Use callback API [CALLBACK=ON SYNC=OFF]" ${DEFAULT_
 num_option(USE_IPV6 "Use IPv6 [CALLBACK=ON]" ${DEFAULT_USE_CALLBACK_API})
 num_option(USE_SET_DNS_SERVERS "Use set DNS servers [CALLBACK=ON]" ${DEFAULT_USE_CALLBACK_API})
 num_option(USE_EXTERN_API "Use extern C API [WITH_CPP=ON]" ON)
+num_option(USE_LEGACY_CRYPTO_RANDOM_IV "Use random IV for legacy crypto module [OpenSSL only]" ON)
 log_set(OPENSSL_ROOT_DIR "" "OpenSSL root directory (leave empty for find_package function)[OPENSSL=ON needed]")
 log_set(EXAMPLE "all" "Build example with provided name (use 'all' for all examples) [EXAMPLES=ON needed]")
 log_set(CGREEN_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/cgreen" "CGreen root directory [UNIT_TEST=ON needed]")
@@ -90,7 +91,8 @@ set(FLAGS "\
     -D PUBNUB_USE_AUTO_HEARTBEAT=${USE_AUTO_HEARTBEAT} \
     -D PUBNUB_USE_GRANT_TOKEN_API=${USE_GRANT_TOKEN_API} \
     -D PUBNUB_USE_REVOKE_TOKEN_API=${USE_REVOKE_TOKEN_API} \
-    -D PUBNUB_USE_FETCH_HISTORY=${USE_FETCH_HISTORY}")
+    -D PUBNUB_USE_FETCH_HISTORY=${USE_FETCH_HISTORY} \
+    -D PUBNUB_RAND_INIT_VECTOR=${USE_LEGACY_CRYPTO_RANDOM_IV}")
     
 set(LDLIBS)
 set(OS_SOURCEFILES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endfunction()
 # Function to log a option and its value
 function(log_option name description default)
     option(${name} ${description} ${default})
-    if(${value})
+    if(${name})
         message(STATUS "[*] ${name}")
     else()
         message(STATUS "[ ] ${name}")
@@ -41,6 +41,7 @@ log_option(OPENSSL "Use OpenSSL" OFF)
 log_option(EXAMPLES "Build all examples" OFF)
 log_option(SHARED_LIB "Library type. [SHARED=ON STATIC=OFF]" OFF)
 log_option(WITH_CPP "Build the CPP headers" OFF)
+log_option(ASAN "Use Address sanitizer" OFF)
 
 if (WITH_CPP)
     set(DEFAULT_USE_CALLBACK_API ON)
@@ -90,6 +91,9 @@ set(FLAGS "\
     -D PUBNUB_USE_GRANT_TOKEN_API=${USE_GRANT_TOKEN_API} \
     -D PUBNUB_USE_REVOKE_TOKEN_API=${USE_REVOKE_TOKEN_API} \
     -D PUBNUB_USE_FETCH_HISTORY=${USE_FETCH_HISTORY}")
+    
+set(LDLIBS)
+set(OS_SOURCEFILES)
 
 if (${USE_CALLBACK_API})
     set(FLAGS "\
@@ -97,6 +101,15 @@ if (${USE_CALLBACK_API})
         -D PUBNUB_SET_DNS_SERVERS=${USE_SET_DNS_SERVERS} \
         -D PUBNUB_USE_IPV6=${USE_IPV6} \
         -D PUBNUB_CALLBACK_API")
+endif()
+
+if (${ASAN})
+    set(FLAGS "\
+        ${FLAGS} \
+        -fsanitize=address")
+    set(LDLIBS "\
+        ${LDLIBS} \
+        -fsanitize=address")
 endif()
 
 set(CMAKE_C_FLAGS "\
@@ -145,11 +158,8 @@ set(LIB_SOURCEFILES
     ${CMAKE_CURRENT_LIST_DIR}/lib/sockets/pbpal_adns_sockets.c
     ${CMAKE_CURRENT_LIST_DIR}/lib/pubnub_dns_codec.c)
 
-set(LDLIBS)
-set(OS_SOURCEFILES)
-
 if(UNIX)
-    set(LDLIBS "-lpthread")
+    set(LDLIBS "-lpthread ${LDLIBS}")
     set(OS_SOURCEFILES
         ${CMAKE_CURRENT_LIST_DIR}/posix/posix_socket_blocking_io.c
         ${CMAKE_CURRENT_LIST_DIR}/posix/pubnub_version_posix.c
@@ -529,6 +539,11 @@ if(${EXAMPLES})
                 pubnub_advanced_history_sample
                 pubnub_fetch_history_sample
                 cancel_subscribe_sync_sample)
+            if (OPENSSL)
+                set(EXAMPLE_LIST
+                    pubnub_crypto_module_sample
+                    ${EXAMPLE_LIST})
+            endif()
         endif()
     else()
         message(STATUS "Building example ${EXAMPLE}")

--- a/core/pbcc_crypto_legacy.c
+++ b/core/pbcc_crypto_legacy.c
@@ -55,7 +55,11 @@ static size_t estimated_enc_buffer_size(size_t n) {
 }
 
 static size_t estimated_dec_buffer_size(size_t n) {
-    return n + 1; // for the terminating array
+    // In most cases formula (n + 1) is enough to 
+    // handle the amount of decrypted bytes.
+    // Addition AES_BLOCK_SIZE just to be sure if message
+    // contains very specific padding. 
+    return n + AES_BLOCK_SIZE + 1; 
 }
 
 static int legacy_encrypt(


### PR DESCRIPTION
fix: fix too small amount of memory allocated for aes cbc algorithm in some cases.  

Fix too small amount of memory allocated for aes cbc algorithm in some cases.  

build: add possibility to include address sanitizer in build via CMake. 

Add possibility to include address sanitizer in build via CMake. 