### PR TITLE
strings in objects API

### DIFF
--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -7,6 +7,6 @@
     { "pattern": "#define PUBNUB_SDK_VERSION \"(.+)\"$", "cleared": true }
   ],
   "CMakeLists.txt": [
-    { "pattern": "project(c-core VERSION ((.+))$", "cleared": true }
+    { "pattern": "project(c-core VERSION (.+))$", "cleared": true }
   ]
 }

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -9,7 +9,8 @@ changelog:
       - type: feature
         text: "Added possibility to use strings in actions API."
       - type: improvement
-        text: "`pubnub_action_type` enum has been deprecated."  - date: 2024-03-26
+        text: "`pubnub_action_type` enum has been deprecated."
+  - date: 2024-03-26
     version: v4.9.1
     changes:
       - type: bug

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,13 @@ schema: 1
 version: "4.9.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2024-06-14
+    version: v4.10.0
+    changes:
+      - type: feature
+        text: "Added possibility to use strings in actions API."
+      - type: improvement
+        text: "`pubnub_action_type` enum has been deprecated."
   - date: 2024-03-26
     version: v4.9.1
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,6 @@
 name: c-core
 schema: 1
-version: "4.9.0"
+version: "4.10.0"
 scm: github.com/pubnub/c-core
 changelog:
   - date: 2024-06-14
@@ -9,8 +9,7 @@ changelog:
       - type: feature
         text: "Added possibility to use strings in actions API."
       - type: improvement
-        text: "`pubnub_action_type` enum has been deprecated."
-  - date: 2024-03-26
+        text: "`pubnub_action_type` enum has been deprecated."  - date: 2024-03-26
     version: v4.9.1
     changes:
       - type: bug
@@ -794,7 +793,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"
@@ -860,7 +859,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"
@@ -926,7 +925,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"
@@ -988,7 +987,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"
@@ -1049,7 +1048,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"
@@ -1105,7 +1104,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"
@@ -1158,7 +1157,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.9.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.10.0
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ June 14 2024
 #### Modified
 - `pubnub_action_type` enum has been deprecated.
 
+
+
 ## v4.9.1
 March 26 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v4.10.0
+June 14 2024
+
+#### Added
+- Added possibility to use strings in actions API.
+
+#### Modified
+- `pubnub_action_type` enum has been deprecated.
+
 ## v4.9.1
 March 26 2024
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt for the C-core library of Pubnub.
 cmake_minimum_required(VERSION 3.12)
 
-project(c-core VERSION 4.8.0)
+project(c-core VERSION 4.10.0)
 
 message(STATUS Preparing\ ${PROJECT_NAME}\ version\ ${PROJECT_VERSION})
 

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -23,10 +23,37 @@ enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
                                             char* obj_buffer,
                                             size_t buffer_size,
                                             enum pubnub_action_type actype,
-                                            char const** val)
-{
-    char const* user_id = pbcc_user_id_get(pb);
+                                            char const** val) {
     char const* type_literal;
+
+    switch(actype) {
+    case pbactypReaction:
+        type_literal = "reaction";
+        break;
+    case pbactypReceipt:
+        type_literal = "receipt";
+        break;
+    case pbactypCustom:
+        type_literal = "custom";
+        break;
+    default:
+        PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
+                         "unknown action type = %d\n",
+                         pb,
+                         actype);
+        return PNR_INVALID_PARAMETERS;
+    }
+
+    return pbcc_form_the_action_object_str(pb, obj_buffer, buffer_size, type_literal, val);
+}
+
+
+enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
+                                            char* obj_buffer,
+                                            size_t buffer_size,
+                                            char const* action_type,
+                                            char const** val) {
+    char const* user_id = pbcc_user_id_get(pb);
 
     PUBNUB_ASSERT_OPT(user_id != NULL);
 
@@ -42,31 +69,9 @@ enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
                          *val);
         return PNR_INVALID_PARAMETERS;
     }
-    switch(actype) {
-    case pbactypReaction:
-        type_literal = "reaction";
-        break;
-    case pbactypReceipt:
-        type_literal = "receipt";
-        break;
-    case pbactypCustom:
-        type_literal = "custom";
-        break;
-    case pbactypEdited:
-        type_literal = "edited";
-        break;
-    case pbactypDeleted:
-        type_literal = "deleted";
-        break;
-    default:
-        PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
-                         "unknown action type = %d\n",
-                         pb,
-                         actype);
-        return PNR_INVALID_PARAMETERS;
-    }
+
     if (buffer_size < sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
-                             pb_strnlen_s(type_literal, sizeof "reaction") +
+                             pb_strnlen_s(action_type, sizeof "reaction") +
                              pb_strnlen_s(*val, PUBNUB_MAX_OBJECT_LENGTH) +
                              pb->user_id_len) {
         PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
@@ -76,7 +81,7 @@ enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
                          pb,
                          (unsigned long)buffer_size,
                          (unsigned long)(sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
-                                         pb_strnlen_s(type_literal, sizeof "reaction") +
+                                         pb_strnlen_s(action_type, sizeof "reaction") +
                                          pb_strnlen_s(*val, PUBNUB_MAX_OBJECT_LENGTH) +
                                          pb->user_id_len));
         return PNR_TX_BUFF_TOO_SMALL;
@@ -84,7 +89,7 @@ enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
     snprintf(obj_buffer,
              buffer_size,
              "{\"type\":\"%s\",\"value\":%s,\"user_id\":\"%s\"}",
-             type_literal,
+             action_type,
              *val,
              user_id);
     *val = obj_buffer;

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -17,6 +17,7 @@
 
 /* Maximum number of actions to return in response */
 #define MAX_ACTIONS_LIMIT 100
+#define MAX_ACTION_VALUE_LENGTH 15
 
 
 enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
@@ -71,7 +72,7 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
     }
 
     if (buffer_size < sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
-                             pb_strnlen_s(action_type, sizeof "reaction") +
+                             pb_strnlen_s(action_type, MAX_ACTION_VALUE_LENGTH) +
                              pb_strnlen_s(*val, PUBNUB_MAX_OBJECT_LENGTH) +
                              pb->user_id_len) {
         PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
@@ -81,7 +82,7 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
                          pb,
                          (unsigned long)buffer_size,
                          (unsigned long)(sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
-                                         pb_strnlen_s(action_type, sizeof "reaction") +
+                                         pb_strnlen_s(action_type, MAX_ACTION_VALUE_LENGTH) +
                                          pb_strnlen_s(*val, PUBNUB_MAX_OBJECT_LENGTH) +
                                          pb->user_id_len));
         return PNR_TX_BUFF_TOO_SMALL;

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -72,7 +72,7 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
     }
 
     if (buffer_size < sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
-                             pb_strnlen_s(action_type, MAX_ACTION_VALUE_LENGTH) +
+                             pb_strnlen_s(action_type, MAX_ACTION_TYPE_LENGTH) +
                              pb_strnlen_s(*val, PUBNUB_MAX_OBJECT_LENGTH) +
                              pb->user_id_len) {
         PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
@@ -82,7 +82,7 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
                          pb,
                          (unsigned long)buffer_size,
                          (unsigned long)(sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
-                                         pb_strnlen_s(action_type, MAX_ACTION_VALUE_LENGTH) +
+                                         pb_strnlen_s(action_type, MAX_ACTION_TYPE_LENGTH) +
                                          pb_strnlen_s(*val, PUBNUB_MAX_OBJECT_LENGTH) +
                                          pb->user_id_len));
         return PNR_TX_BUFF_TOO_SMALL;

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -52,6 +52,12 @@ enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
     case pbactypCustom:
         type_literal = "custom";
         break;
+    case pbactypEdited:
+        type_literal = "edited";
+        break;
+    case pbactypDeleted:
+        type_literal = "deleted";
+        break;
     default:
         PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
                          "unknown action type = %d\n",

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -29,13 +29,13 @@ enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
 
     switch(actype) {
     case pbactypReaction:
-        type_literal = "reaction";
+        type_literal = "\"reaction\"";
         break;
     case pbactypReceipt:
-        type_literal = "receipt";
+        type_literal = "\"receipt\"";
         break;
     case pbactypCustom:
-        type_literal = "custom";
+        type_literal = "\"custom\"";
         break;
     default:
         PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
@@ -89,7 +89,7 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
     }
     snprintf(obj_buffer,
              buffer_size,
-             "{\"type\":\"%s\",\"value\":%s,\"user_id\":\"%s\"}",
+             "{\"type\":%s,\"value\":%s,\"user_id\":\"%s\"}",
              action_type,
              *val,
              user_id);

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -70,6 +70,14 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
                          *val);
         return PNR_INVALID_PARAMETERS;
     }
+    if (('\"' != *action_type) || ('\"' != *(action_type + pb_strnlen_s(action_type, PUBNUB_MAX_OBJECT_LENGTH) - 1))) {
+        PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
+                         "quotation marks on value ends are missing: "
+                         "action_type = %s\n",
+                         pb,
+                         action_type);
+        return PNR_INVALID_PARAMETERS;
+    }
 
     if (buffer_size < sizeof("{\"type\":\"\",\"value\":,\"user_id\":\"\"}") +
                              pb_strnlen_s(action_type, MAX_ACTION_TYPE_LENGTH) +

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -70,9 +70,9 @@ enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
                          *val);
         return PNR_INVALID_PARAMETERS;
     }
-    if (('\"' != *action_type) || ('\"' != *(action_type + pb_strnlen_s(action_type, PUBNUB_MAX_OBJECT_LENGTH) - 1))) {
+    if (('\"' != *action_type) || ('\"' != *(action_type + pb_strnlen_s(action_type, MAX_ACTION_TYPE_LENGTH) - 1))) {
         PUBNUB_LOG_ERROR("pbcc_form_the_action_object(pbcc=%p) - "
-                         "quotation marks on value ends are missing: "
+                         "quotation marks on action type ends are missing: "
                          "action_type = %s\n",
                          pb,
                          action_type);

--- a/core/pbcc_actions_api.c
+++ b/core/pbcc_actions_api.c
@@ -17,7 +17,7 @@
 
 /* Maximum number of actions to return in response */
 #define MAX_ACTIONS_LIMIT 100
-#define MAX_ACTION_VALUE_LENGTH 15
+#define MAX_ACTION_TYPE_LENGTH 15
 
 
 enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,

--- a/core/pbcc_actions_api.h
+++ b/core/pbcc_actions_api.h
@@ -7,7 +7,7 @@
 
 #include "pubnub_api_types.h"
 #include "pubnub_memory_block.h"
-#include "pb_deprecated.h"
+#include "lib/pb_deprecated.h"
 
 struct pbcc_context;
 

--- a/core/pbcc_actions_api.h
+++ b/core/pbcc_actions_api.h
@@ -21,7 +21,9 @@ struct pbcc_context;
 enum pubnub_action_type {
     pbactypReaction,
     pbactypReceipt,
-    pbactypCustom
+    pbactypCustom,
+    pbactypEdited,
+    pbactypDeleted
 };
 
 /** Forms the action object to be sent in 'pubnub_add_action' request body.

--- a/core/pbcc_actions_api.h
+++ b/core/pbcc_actions_api.h
@@ -7,6 +7,7 @@
 
 #include "pubnub_api_types.h"
 #include "pubnub_memory_block.h"
+#include "pb_deprecated.h"
 
 struct pbcc_context;
 
@@ -21,19 +22,33 @@ struct pbcc_context;
 enum pubnub_action_type {
     pbactypReaction,
     pbactypReceipt,
-    pbactypCustom,
-    pbactypEdited,
-    pbactypDeleted
+    pbactypCustom
 };
 
 /** Forms the action object to be sent in 'pubnub_add_action' request body.
+    
+    @deprecated This function is deprecated. Use pbcc_form_the_action_object_str() instead.
+                The present declaration will be changed to the string version in the future.
+    @see pbcc_form_the_action_object_str
+
     @return #PNR_OK on success, an error otherwise
   */
-enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
+PUBNUB_DEPRECATED enum pubnub_res pbcc_form_the_action_object(struct pbcc_context* pb,
                                             char* obj_buffer,
                                             size_t buffer_size,
                                             enum pubnub_action_type actype,
                                             char const** json);
+
+
+/** Forms the action object to be sent in 'pubnub_add_action' request body.
+    @return #PNR_OK on success, an error otherwise
+  */
+enum pubnub_res pbcc_form_the_action_object_str(struct pbcc_context* pb,
+                                            char* obj_buffer,
+                                            size_t buffer_size,
+                                            const char* action_type,
+                                            char const** json);
+
 
 /** Prepares the 'add_action' transaction, mostly by
     formatting the URI of the HTTP request.

--- a/core/pubnub_actions_api.c
+++ b/core/pubnub_actions_api.c
@@ -17,12 +17,40 @@
 #include <string.h>
 
 
-enum pubnub_res pubnub_add_message_action(pubnub_t* pb,
+enum pubnub_res pubnub_add_message_action(pubnub_t *pb,
+                                  const char *channel,
+                                  const char *message_timetoken,
+                                  enum pubnub_action_type actype,
+                                  const char *value) {
+    char const* type_literal;
+
+    switch(actype) {
+    case pbactypReaction:
+        type_literal = "reaction";
+        break;
+    case pbactypReceipt:
+        type_literal = "receipt";
+        break;
+    case pbactypCustom:
+        type_literal = "custom";
+        break;
+    default:
+        PUBNUB_LOG_ERROR("pubnub_add_message_action(pbcc=%p) - "
+                         "unknown action type = %d\n",
+                         pb,
+                         actype);
+        return PNR_INVALID_PARAMETERS;
+    }
+
+    return pubnub_add_message_action_str(pb, channel, message_timetoken, type_literal, value);
+}
+
+
+enum pubnub_res pubnub_add_message_action_str(pubnub_t* pb,
                                   char const* channel,
                                   char const* message_timetoken,
-                                  enum pubnub_action_type actype,
-                                  char const* value)
-{
+                                  char const* actype,
+                                  char const* value) {
     enum pubnub_res rslt;
     char obj_buffer[PUBNUB_BUF_MAXLEN];
 
@@ -34,7 +62,7 @@ enum pubnub_res pubnub_add_message_action(pubnub_t* pb,
         pubnub_mutex_unlock(pb->monitor);
         return PNR_IN_PROGRESS;
     }
-    rslt = pbcc_form_the_action_object(&pb->core,
+    rslt = pbcc_form_the_action_object_str(&pb->core,
                                        obj_buffer,
                                        sizeof obj_buffer,
                                        actype,

--- a/core/pubnub_actions_api.c
+++ b/core/pubnub_actions_api.c
@@ -26,13 +26,13 @@ enum pubnub_res pubnub_add_message_action(pubnub_t *pb,
 
     switch(actype) {
     case pbactypReaction:
-        type_literal = "reaction";
+        type_literal = "\"reaction\"";
         break;
     case pbactypReceipt:
-        type_literal = "receipt";
+        type_literal = "\"receipt\"";
         break;
     case pbactypCustom:
-        type_literal = "custom";
+        type_literal = "\"custom\"";
         break;
     default:
         PUBNUB_LOG_ERROR("pubnub_add_message_action(pbcc=%p) - "

--- a/core/pubnub_actions_api.h
+++ b/core/pubnub_actions_api.h
@@ -7,7 +7,7 @@
 
 #include "lib/pb_extern.h"
 #include "pbcc_actions_api.h"
-#include "pb_deprecated.h"
+#include "lib/pb_deprecated.h"
 
 #include <stdbool.h>
 

--- a/core/pubnub_actions_api.h
+++ b/core/pubnub_actions_api.h
@@ -7,6 +7,7 @@
 
 #include "lib/pb_extern.h"
 #include "pbcc_actions_api.h"
+#include "pb_deprecated.h"
 
 #include <stdbool.h>
 
@@ -18,6 +19,12 @@
     If the transaction is finished successfully response will have 'data' field with
     added action data. If there is no data, nor error description in the response,
     response parsing function returns format error.
+    
+    @deprecated This function is deprecated. Use pubnub_add_message_action_str() instead.
+                The present declaration will be changed to the string version in the future.
+    @see pubnub_add_message_action_str()
+    @see pbcc_action_type_to_str
+
     @param pb The pubnub context. Can't be NULL
     @param channel The channel on which action is referring to.
     @param message_timetoken The timetoken(unquoted) of a published message action is
@@ -26,10 +33,36 @@
     @param value Json string describing the action that is to be added
     @return #PNR_STARTED on success, an error otherwise
   */
-PUBNUB_EXTERN enum pubnub_res pubnub_add_message_action(pubnub_t* pb,
+PUBNUB_EXTERN PUBNUB_DEPRECATED enum pubnub_res pubnub_add_message_action(pubnub_t* pb,
                                           char const* channel,
                                           char const* message_timetoken,
                                           enum pubnub_action_type actype,
+                                          char const* value);
+
+
+/** Adds new type of message called action as a support for user reactions on a published
+    messages.
+    Json string @p value is checked for its quotation marks at its ends. If any of the
+    quotation marks is missing function returns parameter error.
+    If the transaction is finished successfully response will have 'data' field with
+    added action data. If there is no data, nor error description in the response,
+    response parsing function returns format error.
+    
+    @deprecated This function is deprecated. Use pubnub_add_message_action_str() instead.
+    @see pubnub_add_message_action_str()
+
+    @param pb The pubnub context. Can't be NULL
+    @param channel The channel on which action is referring to.
+    @param message_timetoken The timetoken(unquoted) of a published message action is
+                             applying to
+    @param action_type String describing the action type (Max 15 characters without whitespaces)
+    @param value Json string describing the action that is to be added
+    @return #PNR_STARTED on success, an error otherwise
+  */
+PUBNUB_EXTERN enum pubnub_res pubnub_add_message_action_str(pubnub_t* pb,
+                                          char const* channel,
+                                          char const* message_timetoken,
+                                          char const* action_type,
                                           char const* value);
 
 

--- a/core/pubnub_actions_api.h
+++ b/core/pubnub_actions_api.h
@@ -55,7 +55,7 @@ PUBNUB_EXTERN PUBNUB_DEPRECATED enum pubnub_res pubnub_add_message_action(pubnub
     @param channel The channel on which action is referring to.
     @param message_timetoken The timetoken(unquoted) of a published message action is
                              applying to
-    @param action_type String describing the action type (Max 15 characters without whitespaces)
+    @param action_type Jsoned string describing the action type (Max 15 characters without whitespaces)
     @param value Json string describing the action that is to be added
     @return #PNR_STARTED on success, an error otherwise
   */

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.9.0"
+#define PUBNUB_SDK_VERSION "4.10.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
feat: possibility to use string in actions API

Added possibility to use strings in actions API

refactor: `pubnub_action_type` deprecated

`pubnub_action_type` enum has been deprecated
