### PR TITLE
fix cmake file for not ESP32 builds

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.11.0"
+version: "4.11.1"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2024-06-28
+    version: v4.11.1
+    changes:
+      - type: bug
+        text: "Fixed `cmake` build for not ESP32 builds."
   - date: 2024-06-27
     version: v4.11.0
     changes:
@@ -809,7 +814,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"
@@ -875,7 +880,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"
@@ -941,7 +946,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"
@@ -1003,7 +1008,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"
@@ -1064,7 +1069,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"
@@ -1120,7 +1125,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"
@@ -1173,7 +1178,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.11.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.11.1
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.11.1
+June 28 2024
+
+#### Fixed
+- Fixed `cmake` build for not ESP32 builds.
+
 ## v4.11.0
 June 27 2024
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ log_set(CUSTOM_OPENSSL_LIB_DIR "lib" "OpenSSL lib directory relative to OPENSSL_
 log_set(CUSTOM_OPENSSL_INCLUDE_DIR "include" "OpenSSL include directory relative to OPENSSL_ROOT_DIR [used only if find_package() failed]")
 log_set(EXAMPLE "all" "Build example with provided name (use 'all' for all examples) [EXAMPLES=ON needed]")
 log_set(CGREEN_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/cgreen" "CGreen root directory [UNIT_TEST=ON needed]")
-log_set(LOG_LEVEL "TRACE" "Log level [TRACE/DEBUG/INFO/WARNING/ERROR]")
+log_set(LOG_LEVEL "WARNING" "Log level [TRACE/DEBUG/INFO/WARNING/ERROR]")
 
 if (${OPENSSL} AND ${MBEDTLS})
     message(FATAL_ERROR "You can't use both OpenSSL and mbedTLS at the same time!")
@@ -174,6 +174,7 @@ if(UNIX OR WIN32 OR WIN64 OR MSVC)
         ${CMAKE_CURRENT_LIST_DIR}/core/pubnub_assert_std.c)
 
     set(LIB_SOURCEFILES
+        ${LIB_SOURCEFILES}
         ${CMAKE_CURRENT_LIST_DIR}/lib/sockets/pbpal_adns_sockets.c
         ${CMAKE_CURRENT_LIST_DIR}/lib/sockets/pbpal_resolv_and_connect_sockets.c)
 else()

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.11.0"
+#define PUBNUB_SDK_VERSION "4.11.1"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix: fix `cmake` build for not ESP32 builds

Fixed `cmake` build for not ESP32 builds