### PR TITLE
Fix history query parameter values

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.12.0"
+version: "4.12.1"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2024-08-05
+    version: v4.12.1
+    changes:
+      - type: bug
+        text: "Fix query values for boolean flags for history endpoint (`include meta`, `include uuid`, `include message type` and `reverse`)."
   - date: 2024-07-29
     version: v4.12.0
     changes:
@@ -828,7 +833,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"
@@ -894,7 +899,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"
@@ -960,7 +965,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"
@@ -1022,7 +1027,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"
@@ -1083,7 +1088,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"
@@ -1139,7 +1144,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"
@@ -1192,7 +1197,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.1
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.12.1
+August 05 2024
+
+#### Fixed
+- Fix query values for boolean flags for history endpoint (`include meta`, `include uuid`, `include message type` and `reverse`).
+
 ## v4.12.0
 July 29 2024
 

--- a/core/pbcc_fetch_history.c
+++ b/core/pbcc_fetch_history.c
@@ -58,16 +58,16 @@ enum pubnub_res pbcc_fetch_history_prep(struct pbcc_context* pb,
     sprintf(max_per_ch_cnt_buf, "%d", max_per_channel);
     if (max_per_channel) { ADD_URL_PARAM(qparam, max, max_per_ch_cnt_buf); }
 
-    if (include_meta != pbccNotSet) { ADD_URL_PARAM(qparam, include_meta, include_meta == pbccTrue ? "1" : "0"); }
-    if (include_message_type != pbccNotSet) { ADD_URL_PARAM(qparam, include_message_type, include_meta == pbccTrue ? "1" : "0"); }
-    if (include_user_id != pbccNotSet) { ADD_URL_PARAM(qparam, include_uuid, include_user_id == pbccTrue ? "1" : "0"); }
+    if (include_meta != pbccNotSet) { ADD_URL_PARAM(qparam, include_meta, include_meta == pbccTrue ? "true" : "false"); }
+    if (include_message_type != pbccNotSet) { ADD_URL_PARAM(qparam, include_message_type, include_meta == pbccTrue ? "true" : "false"); }
+    if (include_user_id != pbccNotSet) { ADD_URL_PARAM(qparam, include_uuid, include_user_id == pbccTrue ? "true" : "false"); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
     ADD_TS_TO_URL_PARAM();
 #else
     ADD_URL_AUTH_PARAM(pb, qparam, auth);
 #endif
-    if (reverse != pbccNotSet) { ADD_URL_PARAM(qparam, reverse, reverse == pbccTrue ? "1" : "0"); }
+    if (reverse != pbccNotSet) { ADD_URL_PARAM(qparam, reverse, reverse == pbccTrue ? "true" : "false"); }
     if (start) { ADD_URL_PARAM(qparam, start, start); }
     if (end) { ADD_URL_PARAM(qparam, end, end); }
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.12.0"
+#define PUBNUB_SDK_VERSION "4.12.1"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/core/samples/pubnub_fetch_history_sample.c
+++ b/core/samples/pubnub_fetch_history_sample.c
@@ -147,8 +147,21 @@ int main(int argc, char* argv[])
             res = pubnub_await(pbp);
     }
     if (PNR_OK == res) {
+        pubnub_chamebl_t response = pubnub_get_fetch_history(pbp);
             printf("Got response for Fetch History! Response from Pubnub: %s\n",
-                    pubnub_get_fetch_history(pbp).ptr);
+            response.ptr);
+        if (NULL == strstr(response.ptr, "\"message_type\"")) {
+            printf("\"message_type\" is missing in response.");
+            return 1;
+        }
+        if (NULL == strstr(response.ptr, "\"uuid\"")) {
+            printf("\"uuid\" is missing in response.");
+            return 1;
+        }
+        if (NULL == strstr(response.ptr, "\"meta\"")) {
+            printf("\"meta\" is missing in response.");
+            return 1;
+        }
     }
     else{
         printf("pubnub_fetch_history() failed with code: %d('%s')\n",


### PR DESCRIPTION
fix(history): fix query parameter values

Fix query values for boolean flags for history endpoint (`include meta`, `include uuid`, `include message type` and `reverse`).