### PR TITLE
Add missing `ttl` parameter

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.12.2"
+version: "4.12.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2024-08-05
+    version: v4.12.3
+    changes:
+      - type: bug
+        text: "Add the missing `ttl` parameter to the `pubnub_publish_options` for extended `publish` configuration."
   - date: 2024-08-05
     version: v4.12.2
     changes:
@@ -838,7 +843,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"
@@ -904,7 +909,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"
@@ -970,7 +975,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"
@@ -1032,7 +1037,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"
@@ -1093,7 +1098,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"
@@ -1149,7 +1154,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"
@@ -1202,7 +1207,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.12.2
+            location: https://github.com/pubnub/c-core/releases/tag/v4.12.3
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.12.3
+August 05 2024
+
+#### Fixed
+- Add the missing `ttl` parameter to the `pubnub_publish_options` for extended `publish` configuration.
+
 ## v4.12.2
 August 05 2024
 

--- a/core/pubnub_ccore_pubsub.c
+++ b/core/pubnub_ccore_pubsub.c
@@ -498,18 +498,18 @@ enum pubnub_res pbcc_append_url_param_encoded(struct pbcc_context* pb,
     return pbcc_url_encode(pb, param_val, pt);
 }
 
-
 enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
                                   const char*          channel,
                                   const char*          message,
                                   bool                 store_in_history,
                                   bool                 norep,
                                   char const*          meta,
+                                  const size_t         ttl,
                                   enum pubnub_method   method)
 {
-    char const* const uname = pubnub_uname();
-    char const*       user_id  = pbcc_user_id_get(pb);
-    enum pubnub_res   rslt  = PNR_OK;
+    char const* const uname   = pubnub_uname();
+    char const*       user_id = pbcc_user_id_get(pb);
+    enum pubnub_res   rslt    = PNR_OK;
 
     PUBNUB_ASSERT_OPT(user_id != NULL);
     PUBNUB_ASSERT_OPT(message != NULL);
@@ -526,10 +526,11 @@ enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
 #if PUBNUB_CRYPTO_API
     if (NULL != pb->crypto_module) {
         pubnub_bymebl_t message_block;
-        message_block.ptr = (uint8_t*)message;
+        message_block.ptr  = (uint8_t*)message;
         message_block.size = strlen(message);
 
-        pubnub_bymebl_t encrypted = pb->crypto_module->encrypt(pb->crypto_module, message_block);
+        pubnub_bymebl_t encrypted =
+            pb->crypto_module->encrypt(pb->crypto_module, message_block);
 
         if (NULL == encrypted.ptr) {
             PUBNUB_LOG_ERROR("pbcc_publish_prep(pbcc=%p) - encryption failed\n", pb);
@@ -541,15 +542,19 @@ enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
         message = pbcc_base64_encode(encrypted);
 
         free(encrypted.ptr);
- 
+
         if (NULL == message) {
-            PUBNUB_LOG_ERROR("pbcc_publish_prep(pbcc=%p) - base64 encoding failed\n", pb);
+            PUBNUB_LOG_ERROR(
+                "pbcc_publish_prep(pbcc=%p) - base64 encoding failed\n", pb);
             return PNR_INTERNAL_ERROR;
         }
 
-        char* quoted_message = (char*)malloc(strlen(message) + 3); // quotes + null-terminator
+        char* quoted_message =
+            (char*)malloc(strlen(message) + 3); // quotes + null-terminator
         if (NULL == quoted_message) {
-            PUBNUB_LOG_ERROR("pbcc_publish_prep(pbcc=%p) - failed to allocate memory for quoted message\n", pb);
+            PUBNUB_LOG_ERROR("pbcc_publish_prep(pbcc=%p) - failed to allocate "
+                             "memory for quoted message\n",
+                             pb);
             free((void*)message);
             return PNR_OUT_OF_MEMORY;
         }
@@ -566,7 +571,8 @@ enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
     }
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
-    if (user_id) { ADD_URL_PARAM(qparam, uuid, user_id); }
+    ADD_URL_PARAM(qparam, uuid, user_id);
+    if (ttl != SIZE_MAX) { ADD_URL_PARAM_SIZET(qparam, ttl, ttl); }
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key == NULL) { ADD_URL_AUTH_PARAM(pb, qparam, auth); }
     ADD_TS_TO_URL_PARAM();
@@ -578,14 +584,15 @@ enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
     if (meta) { ADD_URL_PARAM(qparam, meta, meta); }
 
 #if PUBNUB_CRYPTO_API
-  SORT_URL_PARAMETERS(qparam);
+    SORT_URL_PARAMETERS(qparam);
 #endif
     ENCODE_URL_PARAMETERS(pb, qparam);
 #if PUBNUB_CRYPTO_API
     if (pb->secret_key != NULL) {
         rslt = pbcc_sign_url(pb, message, method, false);
         if (rslt != PNR_OK) {
-            PUBNUB_LOG_ERROR("pbcc_sign_url failed. pb=%p, message=%s, method=%d", pb, message, method);
+            PUBNUB_LOG_ERROR(
+                "pbcc_sign_url failed. pb=%p, message=%s, method=%d", pb, message, method);
         }
     }
 #endif
@@ -595,10 +602,7 @@ enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
     }
     PUBNUB_LOG_DEBUG("pbcc_publish_prep. REQUEST =%s\n", pb->http_buf);
 #if PUBNUB_CRYPTO_API
-    if (NULL != pb->crypto_module)
-    {
-        free((void*) message);
-    }
+    if (NULL != pb->crypto_module) { free((void*)message); }
 #endif
 
     return (rslt != PNR_OK) ? rslt : PNR_STARTED;

--- a/core/pubnub_ccore_pubsub.h
+++ b/core/pubnub_ccore_pubsub.h
@@ -309,12 +309,12 @@ struct pbcc_context {
         else if (pb->auth != NULL) { ADD_URL_PARAM(name, key, pb->auth); }        
 
 #define ADD_URL_PARAM_SIZET(name, key, value)                               \
-    int val_len = snprintf(NULL, 0, "%lu", (long unsigned int)value);                          \
+    int val_len = snprintf(NULL, 0, "%lu", (long unsigned int)value);       \
     if (val_len >= 21) {                                                    \
         PUBNUB_LOG_ERROR("Error: in ADD_URL_PARAM_SIZET:\n");               \
         return PNR_TX_BUFF_TOO_SMALL;                                       \
     }                                                                       \
-    snprintf(name##_val_str, val_len + 1, "%lu", (long unsigned int)value);                    \
+    snprintf(name##_val_str, val_len + 1, "%lu", (long unsigned int)value); \
     name[(int)(name##_index)].param_key = #key;                             \
     name[(int)(name##_index)].key_size = sizeof(#key)-1;                    \
     name[(int)(name##_index)].param_val = name##_val_str;                   \
@@ -457,6 +457,7 @@ enum pubnub_res pbcc_publish_prep(struct pbcc_context* pb,
                                   bool                 store_in_history,
                                   bool                 norep,
                                   char const*          meta,
+                                  size_t               ttl,
                                   enum pubnub_method   method);
 
 /** Prepares the Signal operation (transaction), mostly by

--- a/core/pubnub_coreapi_ex.h
+++ b/core/pubnub_coreapi_ex.h
@@ -60,7 +60,11 @@ struct pubnub_publish_options {
      */
     char const* meta;
     /** Defines the method by which publish transaction will be performed */
-    enum pubnub_method method; 
+    enum pubnub_method method;
+    /** For how many hours message should be kept and available with history
+        API.
+     */
+    size_t ttl;
 };
 
 /** This returns the default options for publish V1 transactions.

--- a/core/pubnub_objects_api.c
+++ b/core/pubnub_objects_api.c
@@ -211,7 +211,7 @@ enum pubnub_res pubnub_set_uuidmetadata_ex(pubnub_t* pb,
                            offset > 1 ? "," : "",
                            opts.data.profile_url);
     }
-    snprintf(obj_buffer + offset, obj_len - offset, "}\0");
+    snprintf(obj_buffer + offset, obj_len - offset, "}");
 
     result = pubnub_set_uuidmetadata(pb, opts.uuid, opts.include, obj_buffer);
     free(obj_buffer);

--- a/core/pubnub_pubsubapi.c
+++ b/core/pubnub_pubsubapi.c
@@ -107,7 +107,8 @@ enum pubnub_res pubnub_publish(pubnub_t* pb, const char* channel, const char* me
         return PNR_IN_PROGRESS;
     }
 
-    rslt = pbcc_publish_prep(&pb->core, channel, message, true, false, NULL, pubnubSendViaGET);
+    rslt = pbcc_publish_prep(
+        &pb->core, channel, message, true, false, NULL, SIZE_MAX, pubnubSendViaGET);
     if (PNR_STARTED == rslt) {
         pb->trans            = PBTT_PUBLISH;
         pb->core.last_result = PNR_STARTED;

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.12.2"
+#define PUBNUB_SDK_VERSION "4.12.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/core/samples/pubnub_publish_via_post_sample.c
+++ b/core/samples/pubnub_publish_via_post_sample.c
@@ -137,6 +137,33 @@ int main()
     }
 
     puts("=========================================");
+    puts("Publishing(via post with ttl)...");
+    time(&t0);
+    struct pubnub_publish_options options = publish_opts_method(pubnubSendViaPOSTwithGZIP);
+    options.ttl = 16;
+    res = pubnub_publish_ex(pbp,
+                            chan,
+                            "\"Hello world!\"",
+                            options);
+    if (PNR_STARTED == res) {
+        res = pubnub_await(pbp);
+    }
+    printf("Publish 'via post with ttl' lasted %lf seconds.\n", difftime(time(NULL), t0));
+    if (PNR_OK == res) {
+        printf("Published! Response from Pubnub: %s\n",
+               pubnub_last_publish_result(pbp));
+    }
+    else if (PNR_PUBLISH_FAILED == res) {
+        printf("Publishing failed on Pubnub, description: %s\n",
+               pubnub_last_publish_result(pbp));
+    }
+    else {
+        printf("Publishing failed with code: %d('%s')\n",
+               res,
+               pubnub_res_2_string(res));
+    }
+
+    puts("=========================================");
     /* Publishing via post with gzip */
     puts("Publishing(via post with gzip)...");
     time(&t0);


### PR DESCRIPTION
fix(publish): add missing `ttl` parameter

Add the missing `ttl` parameter to the `pubnub_publish_options` for extended `publish` configuration.