### PR TITLE
Add `status` and `types` support

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.17.0"
+version: "4.18.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2025-02-06
+    version: v4.18.0
+    changes:
+      - type: feature
+        text: "Add `status` and `type` support for channel and uuid metadata objects state update API."
   - date: 2025-01-16
     version: v4.17.0
     changes:
@@ -907,7 +912,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"
@@ -973,7 +978,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"
@@ -1039,7 +1044,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"
@@ -1101,7 +1106,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"
@@ -1162,7 +1167,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"
@@ -1218,7 +1223,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"
@@ -1271,7 +1276,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.17.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.18.0
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.18.0
+February 06 2025
+
+#### Added
+- Add `status` and `type` support for channel and uuid metadata objects state update API.
+
 ## v4.17.0
 January 16 2025
 

--- a/core/pubnub_objects_api.c
+++ b/core/pubnub_objects_api.c
@@ -40,9 +40,9 @@ do {                                                                            
 
 const struct pubnub_page_object pubnub_null_page = {NULL, NULL};
 
-const struct pubnub_user_data pubnub_null_user_data = {NULL, NULL, NULL, NULL, NULL};
+const struct pubnub_user_data pubnub_null_user_data = {NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
-const struct pubnub_channel_data pubnub_null_channel_data = {NULL, NULL, NULL};
+const struct pubnub_channel_data pubnub_null_channel_data = {NULL, NULL, NULL, NULL, NULL};
 
 
 struct pubnub_getall_metadata_opts pubnub_getall_metadata_defopts(void)
@@ -163,13 +163,19 @@ enum pubnub_res pubnub_set_uuidmetadata_ex(pubnub_t* pb,
     enum pubnub_res result;
     size_t          obj_len = 0;
 
-    obj_len = NULL != opts.data.custom ? strlen(opts.data.custom) : 0;
-    obj_len += NULL != opts.data.email ? strlen(opts.data.email) : 0;
-    obj_len += NULL != opts.data.name ? strlen(opts.data.name) : 0;
-    obj_len += NULL != opts.data.external_id ? strlen(opts.data.external_id) : 0;
-    obj_len += NULL != opts.data.profile_url ? strlen(opts.data.profile_url) : 0;
+    // "Magic numbers" is length for JSON keys.
+    obj_len = NULL != opts.data.custom ? strlen(opts.data.custom) + 9 : 0;
+    obj_len += NULL != opts.data.email ? strlen(opts.data.email) + 10 : 0;
+    obj_len += NULL != opts.data.name ? strlen(opts.data.name) + 9 : 0;
+    obj_len += NULL != opts.data.external_id ? strlen(opts.data.external_id) + 15 : 0;
+    obj_len += NULL != opts.data.profile_url ? strlen(opts.data.profile_url) + 15 : 0;
+    obj_len += NULL != opts.data.status ? strlen(opts.data.status) + 11 : 0;
+    obj_len += NULL != opts.data.type ? strlen(opts.data.type) + 9 : 0;
 
-    obj_buffer = (char*)malloc(obj_len + 64); // 64 is for the JSON object structure with small buffer
+    // Buffer for JSON object end/start and fields separation comma + null byte.
+    if (obj_len > 0) obj_len += 9;
+
+    obj_buffer = (char*)malloc(obj_len);
     int offset = snprintf(obj_buffer, obj_len, "{");
 
     // TODO: maybe it will be a good idea to add serialization at some point to this SDK
@@ -210,6 +216,22 @@ enum pubnub_res pubnub_set_uuidmetadata_ex(pubnub_t* pb,
                            "%s\"profileUrl\":\"%s\"",
                            offset > 1 ? "," : "",
                            opts.data.profile_url);
+    }
+
+    if (NULL != opts.data.status) {
+        offset += snprintf(obj_buffer + offset,
+                           obj_len - offset,
+                           "%s\"status\":\"%s\"",
+                           offset > 1 ? "," : "",
+                           opts.data.status);
+    }
+
+    if (NULL != opts.data.type) {
+        offset += snprintf(obj_buffer + offset,
+                           obj_len - offset,
+                           "%s\"type\":\"%s\"",
+                           offset > 1 ? "," : "",
+                           opts.data.type);
     }
     snprintf(obj_buffer + offset, obj_len - offset, "}");
 
@@ -380,15 +402,21 @@ enum pubnub_res pubnub_set_channelmetadata_ex(pubnub_t*   pb,
     enum pubnub_res result;
     size_t          obj_len = 0;
 
-    obj_len = NULL != opts.data.custom ? strlen(opts.data.custom) : 0;
-    obj_len += NULL != opts.data.description ? strlen(opts.data.description) : 0;
-    obj_len += NULL != opts.data.name ? strlen(opts.data.name) : 0;
+    // "Magic numbers" is length for JSON keys.
+    obj_len = NULL != opts.data.custom ? strlen(opts.data.custom) + 9 : 0;
+    obj_len += NULL != opts.data.description ? strlen(opts.data.description) + 16 : 0;
+    obj_len += NULL != opts.data.name ? strlen(opts.data.name) + 9 : 0;
+    obj_len += NULL != opts.data.status ? strlen(opts.data.status) + 11 : 0;
+    obj_len += NULL != opts.data.type ? strlen(opts.data.type) + 9 : 0;
 
-    obj_buffer = (char*)malloc(obj_len + 64); // 64 is for the JSON object structure with small buffer
+    // Buffer for JSON object end/start and fields separation comma + null byte.
+    if (obj_len > 0) obj_len += 7;
+
+    obj_buffer = (char*)malloc(obj_len);
     int offset = snprintf(obj_buffer, obj_len, "{");
 
     if (NULL != opts.data.custom) {
-        offset += snprintf(obj_buffer, obj_len, "\"custom\":%s", opts.data.custom);
+        offset += snprintf(obj_buffer + offset, obj_len, "\"custom\":%s", opts.data.custom);
     }
 
     if (NULL != opts.data.description) {
@@ -405,6 +433,22 @@ enum pubnub_res pubnub_set_channelmetadata_ex(pubnub_t*   pb,
                            "%s\"name\":\"%s\"",
                            offset > 1 ? "," : "",
                            opts.data.name);
+    }
+
+    if (NULL != opts.data.status) {
+        offset += snprintf(obj_buffer + offset,
+                           obj_len - offset,
+                           "%s\"status\":\"%s\"",
+                           offset > 1 ? "," : "",
+                           opts.data.status);
+    }
+
+    if (NULL != opts.data.type) {
+        offset += snprintf(obj_buffer + offset,
+                           obj_len - offset,
+                           "%s\"type\":\"%s\"",
+                           offset > 1 ? "," : "",
+                           opts.data.type);
     }
 
     offset += snprintf(obj_buffer + offset, obj_len - offset, "}");

--- a/core/pubnub_objects_api.h
+++ b/core/pubnub_objects_api.h
@@ -39,6 +39,12 @@ struct pubnub_user_data {
     /** JSON providing custom data about the user. Values must be scalar only; arrays or objects are not supported.
         Filtering App Context data through the custom property is not recommended in SDKs. */
     char const* custom;
+
+    /** User's object type information. */
+    char const* type;
+
+    /** User's object status. */
+    char const* status;
 };
 
 
@@ -53,6 +59,13 @@ struct pubnub_channel_data {
     /** JSON providing custom data about the channel. Values must be scalar only; arrays or objects are not supported.
         Filtering App Context data through the custom property is not recommended in SDKs. */
     char const* custom;
+
+    /** Channel's object type information. */
+    char const* type;
+
+    /** Channel's object status. */
+    char const* status;
+
 };
 
 
@@ -179,7 +192,7 @@ struct pubnub_set_uuidmetadata_opts {
     /** Uuid of the user. */
     char const* uuid; 
 
-    /** The comma delimited (C) string with additional/complex attributes to include in response.
+    /** The comma-delimited (C) string with additional/complex attributes to include in response.
         Use NULL if you don't want to retrieve additional attributes. */
     char const* include;
 
@@ -240,7 +253,7 @@ PUBNUB_EXTERN enum pubnub_res pubnub_remove_uuidmetadata(pubnub_t* pb, char cons
 /** Returns the spaces associated with the subscriber key of the context @p pbp, optionally
     including each space's custom data object.
     @param pb The pubnub context. Can't be NULL
-    @param include array of (C) strings in comma delimited format with additional/complex attributes to include in response.
+    @param include array of (C) strings in comma-delimited format with additional/complex attributes to include in response.
                    Use NULL if you don't want to retrieve additional attributes.
     @param limit Number of entities to return in response. Regular values 1 - 100. If you set `0`,
                  that means “use the default”. At the time of this writing, default was 100.
@@ -279,7 +292,7 @@ PUBNUB_EXTERN enum pubnub_res pubnub_getall_channelmetadata_ex(pubnub_t* pb, str
     Returns the created space object, optionally including its custom data object.
     @note Channel ID and name are required properties of @p channel_metadata_obj
     @param pb The pubnub context. Can't be NULL
-    @param include array of (C) strings in comma delimited format with additional/complex attributes to include in response.
+    @param include array of (C) strings in comma-delimited format with additional/complex attributes to include in response.
                    Use NULL if you don't want to retrieve additional attributes.
     @param channel_metadata_obj The JSON string with the definition of the channel metadata Object to create.
     @return #PNR_STARTED on success, an error otherwise
@@ -292,7 +305,7 @@ PUBNUB_EXTERN enum pubnub_res pubnub_set_channelmetadata(pubnub_t* pb,
 
 /** Options for the `pubnub_set_channelmetadata_ex` function */
 struct pubnub_set_channelmetadata_opts {
-    /** The comma delimited (C) string with additional/complex attributes to include in response.
+    /** The comma-delimited (C) string with additional/complex attributes to include in response.
         Use NULL if you don't want to retrieve additional attributes. */
     char const* include;
 
@@ -355,7 +368,7 @@ struct pubnub_membership_opts {
     /** The UUID to retrieve the memberships. */
     char const* uuid;
 
-    /** The comma delimited (C) string with additional/complex attributes to include in response.
+    /** The comma-delimited (C) string with additional/complex attributes to include in response.
         Use NULL if you don't want to retrieve additional attributes. */
     char const* include;
 
@@ -401,7 +414,7 @@ PUBNUB_EXTERN struct pubnub_membership_opts pubnub_memberships_defopts();
     @param pb The pubnub context. Can't be NULL
     @param uuid_metadataid The UUID to retrieve the memberships.
                    Cannot be NULL.
-    @param include array of (C) strings in comma delimited format with additional/complex attributes to include in response.
+    @param include array of (C) strings in comma-delimited format with additional/complex attributes to include in response.
                    Use NULL if you don't want to retrieve additional attributes.
     @param limit Number of entities to return in response. Regular values 1 - 100.
                  If you set `0`, that means “use the default”. At the time of this writing,
@@ -459,7 +472,7 @@ PUBNUB_EXTERN enum pubnub_res pubnub_get_memberships_ex(pubnub_t* pb, struct pub
     @param pb The pubnub context. Can't be NULL
     @param uuid_metadataid The UUID to add/update the memberships.
                    Cannot be NULL.
-    @param include array of (C) strings in comma delimited format with additional/complex attributes to include in response.
+    @param include array of (C) strings in comma-delimited format with additional/complex attributes to include in response.
                    Use NULL if you don't want to retrieve additional attributes.
     @param set_obj The JSON object that defines the add/update to perform.
                       Cannot be NULL.
@@ -479,7 +492,9 @@ PUBNUB_EXTERN enum pubnub_res pubnub_set_memberships(pubnub_t* pb,
            "channel":{ "id": "main-channel-id" },
            "custom": {
              "starred": true
-           }
+           },
+           "status": "active",
+           "type": "hall"
          },
          {
            "channel":{ "id": "channel-0" },
@@ -673,7 +688,9 @@ PUBNUB_EXTERN enum pubnub_res pubnub_add_members(pubnub_t* pb,
            "id": "some-user-id",
            "custom": {
              "starred": true
-           }
+           },
+           "status": "moderating",
+           "type": "admin"
          },
          {
            "id": "user-0-id",
@@ -685,7 +702,7 @@ PUBNUB_EXTERN enum pubnub_res pubnub_add_members(pubnub_t* pb,
 
     @param pb The pubnub context. Can't be NULL
     @param channel_metadataid The Channel ID for which to add/update the user metadata.
-    @param include array of (C) strings in comma delimited format with additional/complex attributes to include in response.
+    @param include array of (C) strings in comma-delimited format with additional/complex attributes to include in response.
                    Use NULL if you don't want to retrieve additional attributes.
     @param set_obj The JSON object that defines the add/update to perform. Cannot be NULL.
     @return #PNR_STARTED on success, an error otherwise

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.17.0"
+#define PUBNUB_SDK_VERSION "4.18.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/make/common/targets_app.mk
+++ b/make/common/targets_app.mk
@@ -54,6 +54,11 @@ SYNC_SAMPLE_SOURCES = $(subst /,$(PATH_SEP),$(SYNC_SAMPLE_SOURCES_))
 pubnub_sync_sample$(APP_EXT): $(SYNC_SAMPLE_SOURCES) pubnub_sync$(LIB_EXT)
 	$(COMPILER) $(OUT_FLAG)$@ $(COMPILER_FLAGS) $(CPPFLAGS) $(PREREQUISITES) $(LDLIBS)
 
+SYNC_OBJECTS_SOURCES_ = ../core/samples/pubnub_objects_api_sample.c
+SYNC_OBJECTS_SOURCES = $(subst /,$(PATH_SEP),$(SYNC_OBJECTS_SOURCES_))
+pubnub_objects_api_sample$(APP_EXT): $(SYNC_OBJECTS_SOURCES) pubnub_sync$(LIB_EXT)
+	$(COMPILER) $(OUT_FLAG)$@ $(COMPILER_FLAGS) $(CPPFLAGS) $(PREREQUISITES) $(LDLIBS)
+
 
 # ----------------- Samples based on callback PubNub library -----------------
 


### PR DESCRIPTION
feat(app-context): add `status` and `types` support

Add `status` and `type` support for channel and uuid metadata objects state update API.