### PR TITLE
Fix truncated `signature` query value

### DIFF
--- a/core/pubnub_ccore_pubsub.c
+++ b/core/pubnub_ccore_pubsub.c
@@ -662,10 +662,10 @@ enum pubnub_res pbcc_sign_url(struct pbcc_context* pc,
 #if PUBNUB_CRYPTO_API
         char* query_str = ques + 1;
         if (v3sign) {
-            rslt_ = pn_gen_pam_v3_sign((pubnub_t *)pc, query_str, url, msg, final_signature);
+            rslt_ = pn_gen_pam_v3_sign((pubnub_t *)pc, query_str, url, msg, final_signature, sizeof(final_signature));
         }
         else {
-            rslt_ = pn_gen_pam_v2_sign((pubnub_t *)pc, query_str, url, final_signature);
+            rslt_ = pn_gen_pam_v2_sign((pubnub_t *)pc, query_str, url, final_signature, sizeof(final_signature));
         }
 #endif
         if (rslt_ == PNR_OK) {

--- a/core/pubnub_crypto.c
+++ b/core/pubnub_crypto.c
@@ -607,7 +607,7 @@ char* pn_pam_hmac_sha256_sign(char const* key, char const* message) {
     return base64_encoded;
 }
 
-enum pubnub_res pn_gen_pam_v2_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char* signature) {
+enum pubnub_res pn_gen_pam_v2_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char* signature, size_t signature_len) {
     enum pubnub_res sign_status = PNR_OK;
     int str_to_sign_len = strlen(p->core.subscribe_key) + strlen(p->core.publish_key) + strlen(partial_url) + strlen(qs_to_sign);
     size_t str_to_sign_size = sizeof(char) * str_to_sign_len + 5;
@@ -625,13 +625,13 @@ enum pubnub_res pn_gen_pam_v2_sign(pubnub_t* p, char const* qs_to_sign, char con
 #endif
     free((char*)str_to_sign);
     if (sign_status == PNR_OK) {
-	    snprintf(signature, sizeof(signature), "%s", part_sign);
+	    snprintf(signature, signature_len, "%s", part_sign);
     }
     free(part_sign);
     return sign_status;
 }
 
-enum pubnub_res pn_gen_pam_v3_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char const* msg, char* signature) {
+enum pubnub_res pn_gen_pam_v3_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char const* msg, char* signature, size_t signature_len) {
     enum pubnub_res sign_status = PNR_OK;
     bool hasBody = false;
     char* method_verb;
@@ -687,7 +687,7 @@ enum pubnub_res pn_gen_pam_v3_sign(pubnub_t* p, char const* qs_to_sign, char con
             part_sign[strlen(part_sign) - 1] = '\0';
             last_sign_char = part_sign[strlen(part_sign) - 1];
         }
-	    snprintf(signature, sizeof(signature), "v2.%s", part_sign);
+	    snprintf(signature, signature_len, "v2.%s", part_sign);
     }
     free(part_sign);
     return sign_status;

--- a/core/pubnub_crypto.h
+++ b/core/pubnub_crypto.h
@@ -164,8 +164,8 @@ PUBNUB_EXTERN int base64encode(char* result, int max_size, const void* b64_encod
 */
 PUBNUB_EXTERN char* pn_pam_hmac_sha256_sign(char const* key, char const* message);
 
-PUBNUB_EXTERN enum pubnub_res pn_gen_pam_v2_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char* signature);
-PUBNUB_EXTERN enum pubnub_res pn_gen_pam_v3_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char const* msg, char* signature);
+PUBNUB_EXTERN enum pubnub_res pn_gen_pam_v2_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char* signature, size_t signature_len);
+PUBNUB_EXTERN enum pubnub_res pn_gen_pam_v3_sign(pubnub_t* p, char const* qs_to_sign, char const* partial_url, char const* msg, char* signature, size_t signature_len);
 
 /** 
    Prepare the aes cbc crypto module for use.


### PR DESCRIPTION
fix(crypto): fix truncated `signature` query value

Fix issue because of which `signature` value in query has been truncated.