### PR TITLE
introduce `void*` parameter for user data in listeners

### DIFF
--- a/core/pbcc_subscribe_event_listener.c
+++ b/core/pbcc_subscribe_event_listener.c
@@ -485,7 +485,7 @@ enum pubnub_res pbcc_event_listener_remove_subscription_object_listener(
     if (NULL == listener || NULL == cb) { return PNR_INVALID_PARAMETERS; }
 
     pubnub_mutex_lock(listener->mutw);
-    if (NULL == listener->global_events) {
+    if (NULL == listener->listeners) {
         pubnub_mutex_unlock(listener->mutw);
         return PNR_OK;
     }

--- a/core/pbcc_subscribe_event_listener.h
+++ b/core/pbcc_subscribe_event_listener.h
@@ -45,14 +45,17 @@ pbcc_event_listener_t* pbcc_event_listener_alloc(const pubnub_t* pb);
 /**
  * @brief Add subscription status change listener.
  *
- * @param listener Pointer to the Event Listener which is used to track and call
- *                 registered subscription status change listeners.
- * @param cb       Subscription status change handling listener function.
+ * @param listener  Pointer to the Event Listener which is used to track and call
+ *                  registered subscription status change listeners.
+ * @param cb        Subscription status change handling listener function.
+ * @param user_data User data pointer which will be passed to the listener
+ *                  function.
  * @return Results of listener addition.
  */
 enum pubnub_res pbcc_event_listener_add_status_listener(
     pbcc_event_listener_t* listener,
-    pubnub_subscribe_status_callback_t cb);
+    pubnub_subscribe_status_callback_t cb,
+    void* user_data);
 
 /**
  * @brief Remove subscription status change listener.
@@ -61,14 +64,17 @@ enum pubnub_res pbcc_event_listener_add_status_listener(
  * list. If multiple observers registered with the same listener function
 * (same address) they all will stop receiving updates.
  *
- * @param listener Pointer to the Event Listener which should unregister
- *                 subscription status change listener.
- * @param cb       Subscription status change handling listener function.
+ * @param listener  Pointer to the Event Listener which should unregister
+ *                  subscription status change listener.
+ * @param cb        Subscription status change handling listener function.
+ * @param user_data User data pointer which would be passed to the listener 
+ *                  function.
  * @return Results of listener removal.
  */
 enum pubnub_res pbcc_event_listener_remove_status_listener(
     pbcc_event_listener_t* listener,
-    pubnub_subscribe_status_callback_t cb);
+    pubnub_subscribe_status_callback_t cb,
+    void* user_data);
 
 /**
  * @brief Add subscription real-time updates listener.
@@ -76,16 +82,19 @@ enum pubnub_res pbcc_event_listener_remove_status_listener(
  * PubNub context will receive real-time updates from all subscription and
  * subscription sets.
  *
- * @param listener Pointer to the Event Listener which is used to track and call
- *                 registered real-time updates listeners.
- * @param type     Type of real-time update for which listener will be called.
- * @param cb       Real-time update handling listener function.
+ * @param listener  Pointer to the Event Listener which is used to track and call
+ *                  registered real-time updates listeners.
+ * @param type      Type of real-time update for which listener will be called.
+ * @param cb        Real-time update handling listener function.
+ * @param user_data User data pointer which will be passed to the listener
+ *                  function.
  * @return Results of listener addition.
  */
 enum pubnub_res pbcc_event_listener_add_message_listener(
     pbcc_event_listener_t* listener,
     pubnub_subscribe_listener_type type,
-    pubnub_subscribe_message_callback_t cb);
+    pubnub_subscribe_message_callback_t cb,
+    void* user_data);
 
 /**
  * @brief Remove subscription real-time updates listener.
@@ -94,17 +103,20 @@ enum pubnub_res pbcc_event_listener_add_message_listener(
  * list. If multiple observers registered with the same listener function
 * (same address) they all will stop receiving updates.
  *
- * @param listener Pointer to the Event Listener which should unregister
-*                  registered real-time updates listeners.
- * @param type     Type of real-time update for which listener won't be called
- *                 anymore.
- * @param cb       Real-time update handling listener function.
+ * @param listener  Pointer to the Event Listener which should unregister
+*                   registered real-time updates listeners.
+ * @param type      Type of real-time update for which listener won't be called
+ *                  anymore.
+ * @param cb        Real-time update handling listener function.
+ * @param user_data User data pointer which would be passed to the listener
+ *                  function.
  * @return Results of listener removal.
  */
 enum pubnub_res pbcc_event_listener_remove_message_listener(
     pbcc_event_listener_t* listener,
     pubnub_subscribe_listener_type type,
-    pubnub_subscribe_message_callback_t cb);
+    pubnub_subscribe_message_callback_t cb,
+    void* user_data);
 
 /**
  * @brief Add subscription real-time updates listener.
@@ -118,6 +130,8 @@ enum pubnub_res pbcc_event_listener_remove_message_listener(
  * @param subscription Pointer to the subscription object for which 'callback'
  *                     for specific real-time updates 'type' will be registered.
  * @param cb           Real-time update handling listener function.
+ * @param user_data    Additional data which should be passed to the `callback`
+ *                     function.
  * @return Result of listener addition.
  */
 enum pubnub_res pbcc_event_listener_add_subscription_object_listener(
@@ -125,7 +139,8 @@ enum pubnub_res pbcc_event_listener_add_subscription_object_listener(
     pubnub_subscribe_listener_type type,
     pbarray_t* names,
     const void* subscription,
-    pubnub_subscribe_message_callback_t cb);
+    pubnub_subscribe_message_callback_t cb,
+    void* user_data);
 
 /**
  * @brief Remove subscription real-time updates listener.
@@ -144,6 +159,10 @@ enum pubnub_res pbcc_event_listener_add_subscription_object_listener(
  * @param subscription Subscription object for which `callback` for specific
  *                     real-time updates 'type' will be removed.
  * @param cb           Real-time update handling listener function.
+ * @param user_data    Additional data which would be passed to the `callback`
+ *                     function.
+ *                     \b Warning: It checks the address of the data pointer, 
+ *                     not the content.
  * @return Results of listener removal.
  */
 enum pubnub_res pbcc_event_listener_remove_subscription_object_listener(
@@ -151,7 +170,8 @@ enum pubnub_res pbcc_event_listener_remove_subscription_object_listener(
     pubnub_subscribe_listener_type type,
     pbarray_t* names,
     const void* subscription,
-    pubnub_subscribe_message_callback_t cb);
+    pubnub_subscribe_message_callback_t cb,
+    void* user_data);
 
 /**
  * @brief Notify subscription status listeners about status change.

--- a/core/pubnub_subscribe_event_listener.c
+++ b/core/pubnub_subscribe_event_listener.c
@@ -241,7 +241,7 @@ enum pubnub_res pubnub_subscribe_manage_listener_(
             event_listener,
             type,
             names,
-            subscribables,
+            subscription,
             callback,
             user_data);
     }

--- a/core/pubnub_subscribe_event_listener.c
+++ b/core/pubnub_subscribe_event_listener.c
@@ -26,6 +26,7 @@
  *                       registered.
  * @param subscribables  Pointer to the subscription object subscribables.
  * @param callback       Real-time update handling listener function.
+ * @param user_data      User data to be passed to the listener function.
  * @return Result of listeners list update operation.
  */
 static enum pubnub_res pubnub_subscribe_manage_listener_(
@@ -34,7 +35,8 @@ static enum pubnub_res pubnub_subscribe_manage_listener_(
     pubnub_subscribe_listener_type      type,
     const void*                         subscription,
     pbhash_set_t*                       subscribables,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);
 
 /**
  * @brief Get list of channel and groups which can be used to map listeners.
@@ -55,52 +57,59 @@ static pbarray_t* pubnub_subscribe_subscribable_names_(
 
 enum pubnub_res pubnub_subscribe_add_status_listener(
     const pubnub_t*                          pb,
-    const pubnub_subscribe_status_callback_t callback)
+    const pubnub_subscribe_status_callback_t callback, 
+    void*                                    user_data)
 {
     pbcc_event_listener_t* event_listener =
         pbcc_subscribe_ee_event_listener(pb->core.subscribe_ee);
-    return pbcc_event_listener_add_status_listener(event_listener, callback);
+    return pbcc_event_listener_add_status_listener(event_listener, callback, user_data);
 }
 
 enum pubnub_res pubnub_subscribe_remove_status_listener(
     const pubnub_t*                          pb,
-    const pubnub_subscribe_status_callback_t callback)
+    const pubnub_subscribe_status_callback_t callback,
+    void*                                    user_data)
 {
     pbcc_event_listener_t* event_listener =
         pbcc_subscribe_ee_event_listener(pb->core.subscribe_ee);
-    return pbcc_event_listener_remove_status_listener(event_listener, callback);
+    return pbcc_event_listener_remove_status_listener(event_listener, callback, user_data);
 }
 
 enum pubnub_res pubnub_subscribe_add_message_listener(
     const pubnub_t*                           pb,
     const pubnub_subscribe_listener_type      type,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data)
 {
     pbcc_event_listener_t* event_listener =
         pbcc_subscribe_ee_event_listener(pb->core.subscribe_ee);
     return pbcc_event_listener_add_message_listener(
         event_listener,
         type,
-        callback);
+        callback,
+        user_data);
 }
 
 enum pubnub_res pubnub_subscribe_remove_message_listener(
     const pubnub_t*                           pb,
     const pubnub_subscribe_listener_type      type,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data)
 {
     pbcc_event_listener_t* event_listener =
         pbcc_subscribe_ee_event_listener(pb->core.subscribe_ee);
     return pbcc_event_listener_remove_message_listener(
         event_listener,
         type,
-        callback);
+        callback,
+        user_data);
 }
 
 enum pubnub_res pubnub_subscribe_add_subscription_listener(
     const pubnub_subscription_t*              subscription,
     const pubnub_subscribe_listener_type      type,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data)
 {
     pbhash_set_t* subs = pubnub_subscription_subscribables_(subscription, NULL);
     if (NULL == subs) { return PNR_OUT_OF_MEMORY; }
@@ -113,7 +122,8 @@ enum pubnub_res pubnub_subscribe_add_subscription_listener(
         type,
         subscription,
         subs,
-        callback);
+        callback,
+        user_data);
     pbhash_set_free_with_destructor(
         &subs,
         (pbhash_set_element_free)pubnub_subscribable_free_);
@@ -124,7 +134,8 @@ enum pubnub_res pubnub_subscribe_add_subscription_listener(
 enum pubnub_res pubnub_subscribe_remove_subscription_listener(
     const pubnub_subscription_t*              subscription,
     const pubnub_subscribe_listener_type      type,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data)
 {
     pbhash_set_t* subs = pubnub_subscription_subscribables_(subscription, NULL);
     if (NULL == subs) { return PNR_OUT_OF_MEMORY; }
@@ -137,7 +148,8 @@ enum pubnub_res pubnub_subscribe_remove_subscription_listener(
         type,
         subscription,
         subs,
-        callback);
+        callback,
+        user_data);
     pbhash_set_free_with_destructor(
         &subs,
         (pbhash_set_element_free)pubnub_subscribable_free_);
@@ -148,7 +160,8 @@ enum pubnub_res pubnub_subscribe_remove_subscription_listener(
 enum pubnub_res pubnub_subscribe_add_subscription_set_listener(
     const pubnub_subscription_set_t*          subscription_set,
     const pubnub_subscribe_listener_type      type,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data)
 {
     pbhash_set_t* subs =
         pubnub_subscription_set_subscribables_(subscription_set);
@@ -162,7 +175,8 @@ enum pubnub_res pubnub_subscribe_add_subscription_set_listener(
         type,
         subscription_set,
         subs,
-        callback);
+        callback,
+        user_data);
     pbhash_set_free_with_destructor(
         &subs,
         (pbhash_set_element_free)pubnub_subscribable_free_);
@@ -173,7 +187,8 @@ enum pubnub_res pubnub_subscribe_add_subscription_set_listener(
 enum pubnub_res pubnub_subscribe_remove_subscription_set_listener(
     const pubnub_subscription_set_t*          subscription_set,
     const pubnub_subscribe_listener_type      type,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data)
 {
     pbhash_set_t* subs =
         pubnub_subscription_set_subscribables_(subscription_set);
@@ -187,7 +202,8 @@ enum pubnub_res pubnub_subscribe_remove_subscription_set_listener(
         type,
         subscription_set,
         subs,
-        callback);
+        callback,
+        user_data);
     pbhash_set_free_with_destructor(
         &subs,
         (pbhash_set_element_free)pubnub_subscribable_free_);
@@ -201,7 +217,8 @@ enum pubnub_res pubnub_subscribe_manage_listener_(
     const pubnub_subscribe_listener_type      type,
     const void*                               subscription,
     pbhash_set_t*                             subscribables,
-    const pubnub_subscribe_message_callback_t callback)
+    const pubnub_subscribe_message_callback_t callback,
+    void*                                     user_data) 
 {
     if (NULL == subscribables) { return PNR_OUT_OF_MEMORY; }
 
@@ -216,7 +233,8 @@ enum pubnub_res pubnub_subscribe_manage_listener_(
             type,
             names,
             subscription,
-            callback);
+            callback,
+            user_data);
     }
     else {
         rslt = pbcc_event_listener_remove_subscription_object_listener(
@@ -224,7 +242,8 @@ enum pubnub_res pubnub_subscribe_manage_listener_(
             type,
             names,
             subscribables,
-            callback);
+            callback,
+            user_data);
     }
 
     /**

--- a/core/pubnub_subscribe_event_listener.h
+++ b/core/pubnub_subscribe_event_listener.h
@@ -30,14 +30,17 @@
  *
  * @note It is possible to add multiple listeners.
  *
- * @param pb       Pointer to the PubNub context from which subscription status
- *                 changes should be reported by provided listener.
- * @param callback Subscription status change handling listener function.
+ * @param pb        Pointer to the PubNub context from which subscription status
+ *                  changes should be reported by provided listener.
+ * @param callback  Subscription status change handling listener function.
+ * @param user_data User data pointer which will be passed to the listener function.
+ *
  * @return Results of listener addition.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_status_listener(
     const pubnub_t*                    pb,
-    pubnub_subscribe_status_callback_t callback);
+    pubnub_subscribe_status_callback_t callback,
+    void*                              user_data);
 
 /**
  * @brief Remove subscription status change listener.
@@ -46,14 +49,18 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_status_listener(
  * list. If multiple observers registered with the same listener function
  * (same address) they all will stop receiving updates.
  *
- * @param pb       Pointer to the PubNub context from which subscription status
- *                 changes shouldn't be reported to the provided listener.
- * @param callback Subscription status change handling listener function.
+ * @param pb        Pointer to the PubNub context from which subscription status
+ *                  changes shouldn't be reported to the provided listener.
+ * @param callback  Subscription status change handling listener function.
+ * @param user_data User data pointer which would be passed to the listener function.
+ *                  \b Warning: It checks only the address of the user data pointer,
+ *                  not the content.
  * @return Results of listener removal.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_status_listener(
     const pubnub_t*                    pb,
-    pubnub_subscribe_status_callback_t callback);
+    pubnub_subscribe_status_callback_t callback,
+    void*                              user_data);
 
 /**
  * @brief Add subscription real-time updates listener.
@@ -63,16 +70,19 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_status_listener(
  *
  * @note It is possible to add multiple listeners.
  *
- * @param pb       Pointer to the PubNub context from which subscription status
- *                 changes should be reported by provided listener.
- * @param type     Type of real-time update for which listener will be called.
- * @param callback Subscription status change handling listener function.
- * @return Results of listener addition.
+ * @param pb        Pointer to the PubNub context from which subscription status
+ *                  changes should be reported by provided listener.
+ * @param type      Type of real-time update for which listener will be called.
+ * @param callback  Subscription status change handling listener function.
+ * @param user_data User data pointer which will be passed to the listener function.
+ *
+ * @return Results  of listener addition.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_message_listener(
     const pubnub_t*                     pb,
     pubnub_subscribe_listener_type      type,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);
 
 /**
  * @brief Remove subscription real-time updates listener..
@@ -81,17 +91,20 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_message_listener(
  * list. If multiple observers registered with the same listener function
  * (same address) they all will stop receiving updates.
  *
- * @param pb       Pointer to the PubNub context from which subscription status
- *                 changes shouldn't be reported to the provided listener.
- * @param type     Type of real-time update for which listener won't be called
- *                 anymore.
- * @param callback Subscription status change handling listener function.
- * @return Results of listener removal.
+ * @param pb        Pointer to the PubNub context from which subscription status
+ *                  changes shouldn't be reported to the provided listener.
+ * @param type      Type of real-time update for which listener won't be called
+ *                  anymore.
+ * @param callback  Subscription status change handling listener function.
+ * @param user_data User data pointer which would be passed to the listener function.
+ *
+ * @return Results  of listener removal.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_message_listener(
     const pubnub_t*                     pb,
     pubnub_subscribe_listener_type      type,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);
 
 /**
  * @brief Add subscription real-time updates listener.
@@ -101,12 +114,16 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_message_listener(
  * @param type         Type of real-time update for which listener will be
  *                     called.
  * @param callback     Real-time update handling listener function.
+ * @param user_data    User data pointer which will be passed to the listener
+ *                     function.
+ *                     \b Note: User data is not managed by the PubNub context.
  * @return Result of listener addition.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_subscription_listener(
     const pubnub_subscription_t*        subscription,
     pubnub_subscribe_listener_type      type,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);    
 
 /**
  * @brief Remove subscription real-time updates listener.
@@ -121,12 +138,17 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_subscription_listener(
  * @param type         Type of real-time update for which listener won't be
  *                     called anymore.
  * @param callback     Real-time update handling listener function.
+ * @param user_data    User data pointer which would be passed to the listener
+ *                     function.
+ *                     \b Warning: It checks only the address of the user data 
+ *                     pointer, not the content.
  * @return Results of listener removal.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_subscription_listener(
     const pubnub_subscription_t*        subscription,
     pubnub_subscribe_listener_type      type,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);
 
 /**
  * @brief Add subscription set real-time updates listener.
@@ -136,12 +158,16 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_subscription_listener(
  * @param type             Type of real-time update for which listener will be
  *                         called.
  * @param callback         Real-time update handling listener function.
+ * @param user_data        User data pointer which will be passed to the listener 
+ *                         function.
+ *                         \b Note: User data is not managed by the PubNub context.
  * @return Result of listener addition.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_subscription_set_listener(
     const pubnub_subscription_set_t*    subscription_set,
     pubnub_subscribe_listener_type      type,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);
 
 /**
  * @brief Remove subscription set real-time updates listener.
@@ -156,12 +182,17 @@ PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_add_subscription_set_listener(
  * @param type             Type of real-time update for which listener won't be
  *                         called anymore.
  * @param callback         Real-time update handling listener function.
+ * @param user_data        User data pointer which would be passed to the listener 
+ *                         function.
+ *                         \b Warning: It checks only the address of the user data 
+ *                         pointer, not the content.
  * @return Results of listener removal.
  */
 PUBNUB_EXTERN enum pubnub_res pubnub_subscribe_remove_subscription_set_listener(
     const pubnub_subscription_set_t*    subscription_set,
     pubnub_subscribe_listener_type      type,
-    pubnub_subscribe_message_callback_t callback);
+    pubnub_subscribe_message_callback_t callback,
+    void*                               user_data);
 #else // #if PUBNUB_USE_SUBSCRIBE_EVENT_ENGINE
 #error To use subscribe event engine API you must define PUBNUB_USE_SUBSCRIBE_EVENT_ENGINE=1
 #endif // #if PUBNUB_USE_SUBSCRIBE_EVENT_ENGINE

--- a/core/pubnub_subscribe_event_listener_types.h
+++ b/core/pubnub_subscribe_event_listener_types.h
@@ -80,7 +80,8 @@ typedef struct
 typedef void (*pubnub_subscribe_status_callback_t)(
     const pubnub_t* pb,
     pubnub_subscription_status status,
-    pubnub_subscription_status_data_t status_data);
+    pubnub_subscription_status_data_t status_data,
+    void* data);
 
 /**
  * @brief PubNub subscribe real-time updates (messages) function definition.
@@ -97,5 +98,6 @@ typedef void (*pubnub_subscribe_status_callback_t)(
  */
 typedef void (*pubnub_subscribe_message_callback_t)(
     const pubnub_t* pb,
-    struct pubnub_v2_message message);
+    struct pubnub_v2_message message, 
+    void* data);
 #endif // #ifndef PUBNUB_SUBSCRIBE_EVENT_LISTENER_TYPES_H

--- a/core/samples/pubnub_api_enforcement_sample.c
+++ b/core/samples/pubnub_api_enforcement_sample.c
@@ -17,13 +17,22 @@
 #include <time.h>
 
 
+/** Helper functions */
+
+/** Waits for the specified number of seconds */
 static void wait_seconds(double time_in_seconds);
+
+/** Frees the resources of the sync context */
 static void sync_sample_free(pubnub_t* p);
+
+/** Frees the resources of the callback context */
 static void callback_sample_free(pubnub_t* p);
+
+/** Callback for message listener */
 static void subscribe_message_listener(
     const pubnub_t*                pb,
-    const struct pubnub_v2_message message);
-
+    const struct pubnub_v2_message message,
+    void*                          user_data);
 
 int main()
 {
@@ -66,7 +75,8 @@ int main()
     pubnub_entity_free((void**)&channel);
     pubnub_subscribe_add_subscription_listener(subscription,
                                                PBSL_LISTENER_ON_MESSAGE,
-                                               subscribe_message_listener);
+                                               subscribe_message_listener,
+                                               NULL);
     printf("Subscribing with subscription...\n");
     enum pubnub_res rslt = pubnub_subscribe_with_subscription(
         subscription,
@@ -157,7 +167,8 @@ static void callback_sample_free(pubnub_t* p)
 
 static void subscribe_message_listener(
     const pubnub_t*                pb,
-    const struct pubnub_v2_message message) {
+    const struct pubnub_v2_message message,
+    void*                          user_data) {
     printf("CALLBACK | Received message: %.*s\n", (int) message.payload.size, message.payload.ptr);
 }
 

--- a/core/samples/pubnub_api_enforcement_sample.c
+++ b/core/samples/pubnub_api_enforcement_sample.c
@@ -56,7 +56,7 @@ int main()
     pubnub_set_user_id(pbp_callback, user_id);
 
     pubnub_set_blocking_io(pbp_sync);
-    pubnub_set_blocking_io(pbp_callback);
+    pubnub_set_non_blocking_io(pbp_callback);
 
     /** Callback context */
 


### PR DESCRIPTION
feat: introduce `void*` parameter for user data in listeners

Introduce `void*` parameter for user data in listeners to let callbacks keep context on demand.