### PR TITLE
Add timetoken parameter for `pubnub_subscribe_v2`

### DIFF
--- a/core/pbcc_subscribe_v2.c
+++ b/core/pbcc_subscribe_v2.c
@@ -45,7 +45,7 @@ enum pubnub_res pbcc_subscribe_v2_prep(struct pbcc_context* p,
         return PNR_RX_BUFF_NOT_EMPTY;
     }
 
-    if (NULL != timetoken) {
+    if (NULL != timetoken && '\0' != timetoken[0]) {
         size_t token_len = strlen(timetoken);
         memcpy(p->timetoken, timetoken, token_len);
         p->timetoken[token_len] = '\0';

--- a/core/pbcc_subscribe_v2.c
+++ b/core/pbcc_subscribe_v2.c
@@ -28,7 +28,8 @@ enum pubnub_res pbcc_subscribe_v2_prep(struct pbcc_context* p,
                                        char const*          channel,
                                        char const*          channel_group,
                                        const unsigned*      heartbeat,
-                                       char const*          filter_expr)
+                                       char const*          filter_expr,
+                                       char const*          timetoken)
 {
     char        region_str[20];
     char const* tr;
@@ -42,6 +43,12 @@ enum pubnub_res pbcc_subscribe_v2_prep(struct pbcc_context* p,
     }
     if (p->msg_ofs < p->msg_end) {
         return PNR_RX_BUFF_NOT_EMPTY;
+    }
+
+    if (NULL != timetoken) {
+        size_t token_len = strlen(timetoken);
+        memcpy(p->timetoken, timetoken, token_len);
+        p->timetoken[token_len] = '\0';
     }
 
     if ('\0' == p->timetoken[0]) {

--- a/core/pbcc_subscribe_v2.h
+++ b/core/pbcc_subscribe_v2.h
@@ -16,7 +16,8 @@ enum pubnub_res pbcc_subscribe_v2_prep(struct pbcc_context* p,
                                        char const*          channel,
                                        char const*          channel_group,
                                        const unsigned*      heartbeat,
-                                       char const*          filter_expr);
+                                       char const*          filter_expr,
+                                       char const*          timetoken);
 
 
 /** Parses the string received as a response for a subscribe_v2 operation

--- a/core/pubnub_subscribe_event_engine.c
+++ b/core/pubnub_subscribe_event_engine.c
@@ -176,6 +176,7 @@ bool pubnub_subscription_free(pubnub_subscription_t** sub)
     if (pubnub_subscription_free_(*sub)) {
         pubnub_mutex_unlock((*sub)->mutw);
         pubnub_mutex_destroy((*sub)->mutw);
+        free(*sub);
         *sub = NULL;
         return true;
     }
@@ -190,7 +191,6 @@ bool pubnub_subscription_free_(pubnub_subscription_t* sub)
 
     if (0 == pbref_counter_free(sub->counter)) {
         pubnub_entity_free((void**)&sub->entity);
-        free(sub);
         return true;
     }
 

--- a/core/pubnub_subscribe_v2.c
+++ b/core/pubnub_subscribe_v2.c
@@ -19,13 +19,14 @@ struct pubnub_subscribe_v2_options pubnub_subscribe_v2_defopts(void)
     result.channel_group = NULL;
     result.heartbeat     = PUBNUB_MINIMAL_HEARTBEAT_INTERVAL;
     result.filter_expr   = NULL;
+    result.timetoken[0] = '\0';
     return result;
 }
 
 
 enum pubnub_res pubnub_subscribe_v2(pubnub_t*                          p,
                                     const char*                        channel,
-                                    struct pubnub_subscribe_v2_options opt)
+                                    struct pubnub_subscribe_v2_options opts)
 {
     enum pubnub_res rslt;
 
@@ -36,13 +37,18 @@ enum pubnub_res pubnub_subscribe_v2(pubnub_t*                          p,
         pubnub_mutex_unlock(p->monitor);
         return PNR_IN_PROGRESS;
     }
-    rslt = pbauto_heartbeat_prepare_channels_and_ch_groups(p, &channel, &opt.channel_group);
+    rslt = pbauto_heartbeat_prepare_channels_and_ch_groups(p, &channel, &opts.channel_group);
     if (rslt != PNR_OK) {
         return rslt;
     }
 
     rslt = pbcc_subscribe_v2_prep(
-        &p->core, channel, opt.channel_group, &opt.heartbeat, opt.filter_expr);
+        &p->core,
+        channel,
+        opts.channel_group,
+        &opts.heartbeat,
+        opts.filter_expr,
+        opts.timetoken);
     if (PNR_STARTED == rslt) {
         p->trans            = PBTT_SUBSCRIBE_V2;
         p->core.last_result = PNR_STARTED;

--- a/core/pubnub_subscribe_v2.h
+++ b/core/pubnub_subscribe_v2.h
@@ -53,6 +53,16 @@ struct pubnub_subscribe_v2_options {
         If NULL, will not be used.
      */
     char const* filter_expr;
+
+    /** Catch up subscribe time token.
+
+        Timetoken can be retrieved from local time by multiplying received
+        milliseconds to 10_000_000 or using `pubnub_time()` to get PubNub
+        high-precision timetoken.
+
+        By default, is set to 0.
+     */
+    char timetoken[20];
 };
 
 /** This returns the default options for subscribe V2 transactions.

--- a/qt/pubnub_qt.cpp
+++ b/qt/pubnub_qt.cpp
@@ -659,6 +659,7 @@ pubnub_res pubnub_qt::subscribe_v2(QString const& channel, subscribe_v2_options 
             prep_channel_groups.isEmpty() ? 0 : prep_channel_groups.toLatin1().data(),
             opt.get_heartbeat(),
             opt.get_filter_expr()),
+            opt.get_timetoken(),
         PBTT_SUBSCRIBE_V2);
 }
 

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -267,6 +267,7 @@ class subscribe_v2_options {
     unsigned    d_heartbeat;
     QString d_chgrp;
     QString d_filter_expr;
+    QString d_timetoken;
     
 public:
     subscribe_v2_options() : d_heartbeat(PUBNUB_MINIMAL_HEARTBEAT_INTERVAL) {}
@@ -289,11 +290,18 @@ public:
         d_filter_expr = filter_exp;
         return *this;
     }
+    subscribe_v2_options& timetoken(QString const& token) {
+        d_timetoken = token;
+        return *this;
+    }
     unsigned* get_heartbeat() { return &d_heartbeat; }
     char const* get_chgroup() { return d_chgrp.isEmpty() ? 0 : d_chgrp.toLatin1().data(); }
     char const* get_filter_expr()
     {
         return d_filter_expr.isEmpty() ? 0 : d_filter_expr.toLatin1().data();
+    }
+    char const* get_timetoken() {
+        return d_timetoken.isEmpty() ? nullptr : d_timetoken.toLatin1().data();
     }
 };
 #endif /* PUBNUB_USE_SUBSCRIBE_V2 */


### PR DESCRIPTION
feat(subscribe): add timetoken parameter for `pubnub_subscribe_v2`

Add the ability to set `timetoken` (for message catchup) in `pubnub_subscribe_v2_options` which is used with `pubnub_subscribe_v2`.

fix(subscription): fix memory issues with freed subscriptions

Fix issue which was source of segmentation fault when tried to access memory after it has been freed.