### PR TITLE
Fix objects api to accept limit 100

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "4.19.0"
+version: "4.19.1"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2025-04-02
+    version: v4.19.1
+    changes:
+      - type: bug
+        text: "Fix the issue that there was an assertion when using App Context functions with `limit` set to 100."
   - date: 2025-03-19
     version: v4.19.0
     changes:
@@ -924,7 +929,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"
@@ -990,7 +995,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"
@@ -1056,7 +1061,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"
@@ -1118,7 +1123,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"
@@ -1179,7 +1184,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"
@@ -1235,7 +1240,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"
@@ -1288,7 +1293,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v4.19.0
+            location: https://github.com/pubnub/c-core/releases/tag/v4.19.1
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.19.1
+April 02 2025
+
+#### Fixed
+- Fix the issue that there was an assertion when using App Context functions with `limit` set to 100.
+
 ## v4.19.0
 March 19 2025
 

--- a/core/pbcc_objects_api.c
+++ b/core/pbcc_objects_api.c
@@ -86,7 +86,7 @@ enum pubnub_res pbcc_getall_uuidmetadata_prep(
     enum pubnub_res   rslt = PNR_OK;
 
     PUBNUB_ASSERT_OPT(user_id != NULL);
-    PUBNUB_ASSERT_OPT(limit < MAX_OBJECTS_LIMIT);
+    PUBNUB_ASSERT_OPT(limit <= MAX_OBJECTS_LIMIT);
 
     pb->http_content_len = 0;
     pb->msg_ofs = pb->msg_end = 0;
@@ -306,7 +306,7 @@ enum pubnub_res pbcc_getall_channelmetadata_prep(struct pbcc_context* pb,
     enum pubnub_res   rslt = PNR_OK;
 
     PUBNUB_ASSERT_OPT(user_id != NULL);
-    PUBNUB_ASSERT_OPT(limit < MAX_OBJECTS_LIMIT);
+    PUBNUB_ASSERT_OPT(limit <= MAX_OBJECTS_LIMIT);
 
     pb->http_content_len = 0;
     pb->msg_ofs = pb->msg_end = 0;
@@ -535,7 +535,7 @@ enum pubnub_res pbcc_get_memberships_prep(struct pbcc_context* pb,
     enum pubnub_res   rslt = PNR_OK;
 
     PUBNUB_ASSERT_OPT(user_id != NULL);
-    PUBNUB_ASSERT_OPT(limit < MAX_OBJECTS_LIMIT);
+    PUBNUB_ASSERT_OPT(limit <= MAX_OBJECTS_LIMIT);
 
     if (NULL == uuid_metadataid) {
         uuid_metadataid = user_id;
@@ -676,7 +676,7 @@ enum pubnub_res pbcc_get_members_prep(struct pbcc_context* pb,
     enum pubnub_res   rslt = PNR_OK;
 
     PUBNUB_ASSERT_OPT(user_id != NULL);
-    PUBNUB_ASSERT_OPT(limit < MAX_OBJECTS_LIMIT);
+    PUBNUB_ASSERT_OPT(limit <= MAX_OBJECTS_LIMIT);
     if (NULL == channel_metadataid) {
         PUBNUB_LOG_ERROR("pbcc_get_members_prep(pbcc=%p) - Invalid param: "
             "channel_metadataid=NULL\n", pb);

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "4.19.0"
+#define PUBNUB_SDK_VERSION "4.19.1"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix(objects): fix objects api to accept `limit` with value 100

Fix the issue that there was an assertion when using App Context functions with `limit` set to 100