### PR TITLE
Fix reconnect and disconnect false error.

### DIFF
--- a/core/pbcc_subscribe_event_engine.c
+++ b/core/pbcc_subscribe_event_engine.c
@@ -519,6 +519,22 @@ enum pubnub_res pbcc_subscribe_ee_disconnect(pbcc_subscribe_ee_t* ee)
     PUBNUB_ASSERT_OPT(NULL != ee);
 
     pubnub_mutex_lock(ee->mutw);
+    pbcc_ee_state_t* current_state_obj = pbcc_ee_current_state(ee->ee);
+    if (NULL != current_state_obj) {
+        pbcc_subscribe_ee_state current_state_type = (pbcc_subscribe_ee_state)pbcc_ee_state_type(current_state_obj);
+        if (current_state_type == SUBSCRIBE_EE_STATE_UNSUBSCRIBED ||
+            current_state_type == SUBSCRIBE_EE_STATE_HANDSHAKE_FAILED ||
+            current_state_type == SUBSCRIBE_EE_STATE_HANDSHAKE_STOPPED ||
+            current_state_type == SUBSCRIBE_EE_STATE_RECEIVE_FAILED ||
+            current_state_type == SUBSCRIBE_EE_STATE_RECEIVE_STOPPED) {
+            pbcc_ee_state_free(&current_state_obj);
+            pubnub_mutex_unlock(ee->mutw);
+            PUBNUB_LOG_WARNING("pbcc_subscribe_ee_disconnect: called while already in a disconnected/terminal state. Skipping disconnect.\n");
+            return PNR_OK;
+        }
+        pbcc_ee_state_free(&current_state_obj);
+    }
+
     pbcc_ee_event_t* event = pbcc_disconnect_event_alloc(ee);
     if (NULL == event) {
         PUBNUB_LOG_ERROR("pbcc_subscribe_ee_disconnect: failed to allocate "
@@ -538,6 +554,19 @@ enum pubnub_res pbcc_subscribe_ee_reconnect(
     PUBNUB_ASSERT_OPT(NULL != ee);
 
     pubnub_mutex_lock(ee->mutw);
+    pbcc_ee_state_t* current_state_obj = pbcc_ee_current_state(ee->ee);
+    if (NULL != current_state_obj) {
+        pbcc_subscribe_ee_state current_state_type = (pbcc_subscribe_ee_state)pbcc_ee_state_type(current_state_obj);
+        if (current_state_type == SUBSCRIBE_EE_STATE_RECEIVING ||
+            current_state_type == SUBSCRIBE_EE_STATE_UNSUBSCRIBED) {
+            pbcc_ee_state_free(&current_state_obj);
+            pubnub_mutex_unlock(ee->mutw);
+            PUBNUB_LOG_WARNING("pbcc_subscribe_ee_reconnect: called while in state. Skipping reconnect.\n");
+            return PNR_OK;
+        }
+        pbcc_ee_state_free(&current_state_obj);
+    }
+
     pbcc_ee_event_t* event = pbcc_reconnect_event_alloc(ee, cursor);
     if (NULL == event) {
         PUBNUB_LOG_ERROR("pbcc_subscribe_ee_reconnect: failed to allocate "


### PR DESCRIPTION
fix(subscription): Fix reconnect and disconnect false error logged when called within incorrect subscription state.

Fix `pubnub_reconnect` and `pubnub_disconnect` not to print an error when called within incorrect subscription state. Warning will be printed instead and function won't execute further.