### PR TITLE
fix Address Sanitiser reports in `pubnub_set_state` function

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,21 @@
 name: c-core
 schema: 1
-version: "5.0.2"
+version: "5.0.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2025-06-17
+    version: v5.0.3
+    changes:
+      - type: bug
+        text: "Fixed wrong string copy if multiple channels(groups) are provided for `pubnub_set_state`. Note that using `memcpy` instead of `strncpy` is used intentionally because of the ESP support."
+      - type: bug
+        text: "Fixed crash when double comma is provided to `pubnub_set_state` as a channels(groups)."
+      - type: bug
+        text: "Fixed wrong check if the reallocation is required in `pubnub_set_state`."
+      - type: bug
+        text: "Removed additional allocation of memory for temporary data."
+      - type: bug
+        text: "Changed the amount of bytes allocated based on the provided parameters instead of hardcoded values."
   - date: 2025-06-02
     version: v5.0.2
     changes:
@@ -950,7 +963,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"
@@ -1016,7 +1029,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"
@@ -1082,7 +1095,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"
@@ -1144,7 +1157,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"
@@ -1205,7 +1218,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"
@@ -1261,7 +1274,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"
@@ -1314,7 +1327,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.0.3
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v5.0.3
+June 17 2025
+
+#### Fixed
+- Fixed wrong string copy if multiple channels(groups) are provided for `pubnub_set_state`. Note that using `memcpy` instead of `strncpy` is used intentionally because of the ESP support.
+- Fixed crash when double comma is provided to `pubnub_set_state` as a channels(groups).
+- Fixed wrong check if the reallocation is required in `pubnub_set_state`.
+- Removed additional allocation of memory for temporary data.
+- Changed the amount of bytes allocated based on the provided parameters instead of hardcoded values.
+
 ## v5.0.2
 June 02 2025
 

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -67,8 +67,6 @@ void pbcc_adjust_state(struct pbcc_context* core,
                 if (ch_temp == NULL) { end = true; ch_len = strlen(str_ch); }
                 else { ch_len = ch_temp - str_ch; }
 
-                if (ch_len == 0) { continue; }
-
                 char* curr_ch = (char*)malloc(ch_len + 1);
                 memcpy(curr_ch, str_ch, ch_len);
                 curr_ch[ch_len] = '\0';

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -66,16 +66,19 @@ void pbcc_adjust_state(struct pbcc_context* core,
                 }
                 if (ch_temp == NULL) { end = true; ch_len = strlen(str_ch); }
                 else { ch_len = ch_temp - str_ch; }
+                
+                if (ch_len != 0) { 
+                    char* curr_ch = (char*)malloc(ch_len + 1);
+                    memcpy(curr_ch, str_ch, ch_len);
+                    curr_ch[ch_len] = '\0';
 
-                char* curr_ch = (char*)malloc(ch_len + 1);
-                memcpy(curr_ch, str_ch, ch_len);
-                curr_ch[ch_len] = '\0';
+                    mem_len = json_kvp_builder(json_state, mem_len, curr_ch, (char*)state);
 
-                mem_len = json_kvp_builder(json_state, mem_len, curr_ch, (char*)state);
+                    free(curr_ch);
+                }
 
                 ch_cnt++;
                 str_ch = ch_temp + 1;
-                free(curr_ch);
             } while (false == end);
         }
 
@@ -93,17 +96,18 @@ void pbcc_adjust_state(struct pbcc_context* core,
                 if (cg_temp == NULL) { end = true; cg_len = strlen(str_cg); }
                 else { cg_len = cg_temp - str_cg; }
 
-                if (cg_len == 0) { continue; }
+                if (cg_len != 0) { 
+                    char* curr_cg = (char*)malloc(cg_len + 1);
+                    memcpy(curr_cg, str_cg, cg_len);
+                    curr_cg[cg_len] = '\0';
 
-                char* curr_cg = (char*)malloc(cg_len + 1);
-                memcpy(curr_cg, str_cg, cg_len);
-                curr_cg[cg_len] = '\0';
+                    mem_len = json_kvp_builder(json_state, mem_len, curr_cg, (char*)state);
 
-                mem_len = json_kvp_builder(json_state, mem_len, curr_cg, (char*)state);
+                    free(curr_cg);
+                }
 
                 cg_cnt++;
                 str_cg = cg_temp + 1;
-                free(curr_cg);
             } while (false == end);
         }
 

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -70,7 +70,8 @@ void pbcc_adjust_state(struct pbcc_context* core,
                 if (ch_len == 0) { continue; }
 
                 char* curr_ch = (char*)malloc(ch_len + 1);
-                strcpy(curr_ch, str_ch);
+                memcpy(curr_ch, str_ch, ch_len);
+                curr_ch[ch_len] = '\0';
 
                 mem_len = json_kvp_builder(json_state, mem_len, curr_ch, (char*)state);
 
@@ -97,7 +98,8 @@ void pbcc_adjust_state(struct pbcc_context* core,
                 if (cg_len == 0) { continue; }
 
                 char* curr_cg = (char*)malloc(cg_len + 1);
-                strcpy(curr_cg, str_cg);
+                memcpy(curr_cg, str_cg, cg_len);
+                curr_cg[cg_len] = '\0';
 
                 mem_len = json_kvp_builder(json_state, mem_len, curr_cg, (char*)state);
 

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -42,7 +42,7 @@ void pbcc_adjust_state(struct pbcc_context* core,
 
     int buff_size = ((tot_ch + tot_cg) * strlen(state)) + (channel ? strlen(channel) : 1) + (channel_group ? strlen(channel_group) : 1) + 20;
     char * json_state = (char*)malloc(buff_size);
-    if (core->state != NULL && buff_size != sizeof(core->state)){
+    if (core->state != NULL && buff_size > strlen(core->state)){
         core->state = (char*)realloc((char*)core->state, buff_size);
     }
     else if (core->state == NULL){

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -40,8 +40,34 @@ void pbcc_adjust_state(struct pbcc_context* core,
         for (int i=0; i < (int)strlen(channel_group); i++) { tot_cg = (channel_group[i] == ',') ? tot_cg + 1 : tot_cg; }
     }
 
-    int buff_size = ((tot_ch + tot_cg) * strlen(state)) + (channel ? strlen(channel) : 1) + (channel_group ? strlen(channel_group) : 1) + 20;
-    char * json_state = (char*)malloc(buff_size);
+    int dq_len       = strlen("\"");
+    int co_len       = strlen(":");
+    int cm_len       = strlen(",");
+    int ch_keys_len  = 0;
+    int chg_keys_len = 0;
+
+    if (tot_ch >= 1 && 0 != strcmp(channel, ",")) {
+        // commas length included in strlen(channel)
+        // tot_ch * (dq_len * 2) - double-quotes around channel name
+        // (tot_ch - 1) * (co_len + cm_len) - how many commas and semicolons 
+        // we need for channels key-value pairs
+        ch_keys_len = strlen(channel) + tot_ch * (dq_len * 2)
+                      + (tot_ch - 1) * (co_len + cm_len);
+    }
+
+    if (tot_cg >= 1) {
+        // commas length included in strlen(channel_group)
+        // tot_cg * (dq_len * 2) - double-quotes around channel group name
+        // (tot_cg - 1) * (co_len + cm_len) - how many commas and semicolons
+        // we need for channel groups key-value pairs
+        chg_keys_len = strlen(channel_group) + tot_cg * (dq_len * 2)
+                       + (tot_cg - 1) * (co_len + cm_len);
+    }
+
+    // 2 is our {}
+    int buff_size =
+        (tot_ch + tot_cg) * strlen(state) + ch_keys_len + chg_keys_len + 2;
+    char* json_state = (char*)malloc(buff_size);
     if (core->state != NULL && buff_size > strlen(core->state)){
         core->state = (char*)realloc((char*)core->state, buff_size);
     }

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -60,7 +60,7 @@ void pbcc_adjust_state(struct pbcc_context* core,
             bool end = false;
             do{
                 ch_temp = strchr(str_ch,',');
-                if (ch_cnt > 0) { 
+                if (ch_cnt > 0 && json_state[mem_len - 1] != ',') { 
                     memcpy(json_state + mem_len, ",", cm_len);
                     mem_len += cm_len;
                 }
@@ -89,7 +89,7 @@ void pbcc_adjust_state(struct pbcc_context* core,
             bool end = false;
             do{
                 cg_temp = strchr(str_cg,',');
-                if (ch_cnt > 0 || cg_cnt > 0) { 
+                if ((ch_cnt > 0 || cg_cnt > 0) && json_state[mem_len - 1] != ',') { 
                     memcpy(json_state + mem_len, ",", cm_len);
                     mem_len += cm_len;
                 }
@@ -112,8 +112,9 @@ void pbcc_adjust_state(struct pbcc_context* core,
         }
 
         int cb_len = strlen("}");
-        memcpy(json_state + mem_len, "}", cb_len);
-        mem_len += cb_len;
+        int trim_comma = json_state[mem_len - 1] == ',' ? 1 : 0;
+        memcpy(json_state + mem_len - trim_comma, "}", cb_len);
+        mem_len += cb_len - trim_comma;
         json_state[mem_len] = '\0';
         PUBNUB_LOG_DEBUG("formatted state is %s\n", json_state);
 

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -6,8 +6,8 @@
 
 static int json_kvp_builder(char* jsonbuilder, int pos, char* key, char* val)
 {
-    int dq_len = strlen("\"");
-    int co_len = strlen(":");
+    int dq_len  = strlen("\"");
+    int co_len  = strlen(":");
     int key_len = strlen(key);
     int val_len = strlen(val);
 
@@ -26,18 +26,22 @@ static int json_kvp_builder(char* jsonbuilder, int pos, char* key, char* val)
 
 
 void pbcc_adjust_state(struct pbcc_context* core,
-        char const* channel,
-        char const* channel_group,
-        char const* state)
+                       char const*          channel,
+                       char const*          channel_group,
+                       char const*          state)
 {
     int ch_cnt = 0, cg_cnt = 0, tot_ch = 0, tot_cg = 0;
-    if (channel){
+    if (channel) {
         tot_ch = 1;
-        for (int i=0; i < (int)strlen(channel); i++) { tot_ch = (channel[i] == ',') ? tot_ch + 1 : tot_ch; }
+        for (int i = 0; i < (int)strlen(channel); i++) {
+            tot_ch = (channel[i] == ',') ? tot_ch + 1 : tot_ch;
+        }
     }
-    if (channel_group){
+    if (channel_group) {
         tot_cg = 1;
-        for (int i=0; i < (int)strlen(channel_group); i++) { tot_cg = (channel_group[i] == ',') ? tot_cg + 1 : tot_cg; }
+        for (int i = 0; i < (int)strlen(channel_group); i++) {
+            tot_cg = (channel_group[i] == ',') ? tot_cg + 1 : tot_cg;
+        }
     }
 
     int dq_len       = strlen("\"");
@@ -46,59 +50,65 @@ void pbcc_adjust_state(struct pbcc_context* core,
     int ch_keys_len  = 0;
     int chg_keys_len = 0;
 
-    if (tot_ch >= 1 && 0 != strcmp(channel, ",")) {
+    if (tot_ch >= 1) {
         // commas length included in strlen(channel)
         // tot_ch * (dq_len * 2) - double-quotes around channel name
-        // (tot_ch - 1) * (co_len + cm_len) - how many commas and semicolons 
+        // (tot_ch - 1) * (co_len + cm_len) - how many commas and colons
         // we need for channels key-value pairs
-        ch_keys_len = strlen(channel) + tot_ch * (dq_len * 2)
-                      + (tot_ch - 1) * (co_len + cm_len);
+        ch_keys_len = strlen(channel) + tot_ch * (dq_len * 2 + co_len)
+                      + ((tot_ch - 1) * cm_len);
     }
 
     if (tot_cg >= 1) {
         // commas length included in strlen(channel_group)
         // tot_cg * (dq_len * 2) - double-quotes around channel group name
-        // (tot_cg - 1) * (co_len + cm_len) - how many commas and semicolons
+        // (tot_cg - 1) * (co_len + cm_len) - how many commas and colons
         // we need for channel groups key-value pairs
-        chg_keys_len = strlen(channel_group) + tot_cg * (dq_len * 2)
-                       + (tot_cg - 1) * (co_len + cm_len);
+        chg_keys_len = strlen(channel_group) + tot_cg * (dq_len * 2 + co_len)
+                       + ((tot_cg - 1) * cm_len);
     }
 
-    // 2 is our {}
+    // 2 is our {} and 1 is our \0
     int buff_size =
-        (tot_ch + tot_cg) * strlen(state) + ch_keys_len + chg_keys_len + 2;
-    char* json_state = (char*)malloc(buff_size);
-    if (core->state != NULL && buff_size > strlen(core->state)){
+        (tot_ch + tot_cg) * strlen(state) + ch_keys_len + chg_keys_len + 2 + 1;
+    if (core->state != NULL && buff_size > strlen(core->state)) {
         core->state = (char*)realloc((char*)core->state, buff_size);
     }
-    else if (core->state == NULL){
+    else if (core->state == NULL) {
         core->state = (char*)malloc(buff_size);
     }
-    int mem_len = 0;
-    if (json_state != NULL && core->state != NULL){
+    char* json_state = (char*)core->state;
+    int   mem_len    = 0;
+    if (json_state != NULL && core->state != NULL) {
         mem_len = strlen("{");
         memcpy(json_state, "{", mem_len);
         int cm_len = strlen(",");
         if (channel && strncmp(channel, (char*)",", 1) != 0) {
-            char* str_ch = (char*)channel;
-            char* ch_temp;
+            char*  str_ch = (char*)channel;
+            char*  ch_temp;
             size_t ch_len;
-            bool end = false;
-            do{
-                ch_temp = strchr(str_ch,',');
-                if (ch_cnt > 0 && json_state[mem_len - 1] != ',') { 
+            bool   end = false;
+            do {
+                ch_temp = strchr(str_ch, ',');
+                if (ch_cnt > 0 && json_state[mem_len - 1] != ',') {
                     memcpy(json_state + mem_len, ",", cm_len);
                     mem_len += cm_len;
                 }
-                if (ch_temp == NULL) { end = true; ch_len = strlen(str_ch); }
-                else { ch_len = ch_temp - str_ch; }
-                
-                if (ch_len != 0) { 
+                if (ch_temp == NULL) {
+                    end    = true;
+                    ch_len = strlen(str_ch);
+                }
+                else {
+                    ch_len = ch_temp - str_ch;
+                }
+
+                if (ch_len != 0) {
                     char* curr_ch = (char*)malloc(ch_len + 1);
                     memcpy(curr_ch, str_ch, ch_len);
                     curr_ch[ch_len] = '\0';
 
-                    mem_len = json_kvp_builder(json_state, mem_len, curr_ch, (char*)state);
+                    mem_len = json_kvp_builder(
+                        json_state, mem_len, curr_ch, (char*)state);
 
                     free(curr_ch);
                 }
@@ -111,23 +121,29 @@ void pbcc_adjust_state(struct pbcc_context* core,
         if (channel_group) {
             char* str_cg = (char*)channel_group;
             char* cg_temp;
-            int cg_len;
-            bool end = false;
-            do{
-                cg_temp = strchr(str_cg,',');
-                if ((ch_cnt > 0 || cg_cnt > 0) && json_state[mem_len - 1] != ',') { 
+            int   cg_len;
+            bool  end = false;
+            do {
+                cg_temp = strchr(str_cg, ',');
+                if ((ch_cnt > 0 || cg_cnt > 0) && json_state[mem_len - 1] != ',') {
                     memcpy(json_state + mem_len, ",", cm_len);
                     mem_len += cm_len;
                 }
-                if (cg_temp == NULL) { end = true; cg_len = strlen(str_cg); }
-                else { cg_len = cg_temp - str_cg; }
+                if (cg_temp == NULL) {
+                    end    = true;
+                    cg_len = strlen(str_cg);
+                }
+                else {
+                    cg_len = cg_temp - str_cg;
+                }
 
-                if (cg_len != 0) { 
+                if (cg_len != 0) {
                     char* curr_cg = (char*)malloc(cg_len + 1);
                     memcpy(curr_cg, str_cg, cg_len);
                     curr_cg[cg_len] = '\0';
 
-                    mem_len = json_kvp_builder(json_state, mem_len, curr_cg, (char*)state);
+                    mem_len = json_kvp_builder(
+                        json_state, mem_len, curr_cg, (char*)state);
 
                     free(curr_cg);
                 }
@@ -137,18 +153,11 @@ void pbcc_adjust_state(struct pbcc_context* core,
             } while (false == end);
         }
 
-        int cb_len = strlen("}");
+        int cb_len     = strlen("}");
         int trim_comma = json_state[mem_len - 1] == ',' ? 1 : 0;
         memcpy(json_state + mem_len - trim_comma, "}", cb_len);
         mem_len += cb_len - trim_comma;
         json_state[mem_len] = '\0';
         PUBNUB_LOG_DEBUG("formatted state is %s\n", json_state);
-
-        strcpy((char*)core->state, (const char*)json_state);
-        free(json_state);
-        json_state = NULL;
     }
-
 }
-
-

--- a/core/pbcc_set_state.c
+++ b/core/pbcc_set_state.c
@@ -154,7 +154,7 @@ void pbcc_adjust_state(struct pbcc_context* core,
         }
 
         int cb_len     = strlen("}");
-        int trim_comma = json_state[mem_len - 1] == ',' ? 1 : 0;
+        int trim_comma = json_state[mem_len - 1] == ',' ? strlen(",") : 0;
         memcpy(json_state + mem_len - trim_comma, "}", cb_len);
         mem_len += cb_len - trim_comma;
         json_state[mem_len] = '\0';

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "5.0.2"
+#define PUBNUB_SDK_VERSION "5.0.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix: Fixed wrong string copy if multiple channels(groups) are provided for `pubnub_set_state`

Fixed wrong string copy if multiple channels(groups) are provided for `pubnub_set_state`. Note that using `memcpy` instead of `strncpy` is used intentionally because of the ESP support. 

fix: Fixed crash when double comma is provided to `pubnub_set_state` as a channels(groups).
 
Fixed crash when double comma is provided to `pubnub_set_state` as a channels(groups). 

fix: Fixed wrong check if the reallocation is required in `pubnub_set_state`.

Fixed wrong check if the reallocation is required in `pubnub_set_state`.

fix: Removed additional allocation of memory for temporary data.

Removed additional allocation of memory for temporary data.

fix: Changed the amount of bytes allocated based on the provided parameters instead of hardcoded values.

Changed the amount of bytes allocated based on the provided parameters instead of hardcoded values.