### PR TITLE
Fix issue because of which the sync operation doesn't cancel

### DIFF
--- a/core/pubnub_alloc_static.c
+++ b/core/pubnub_alloc_static.c
@@ -58,6 +58,7 @@ void pballoc_free_at_last(pubnub_t *pb)
     pbpal_free(pb);
     pubnub_mutex_unlock(pb->monitor);
     pubnub_mutex_destroy(pb->monitor);
+    pubnub_mutex_destroy(pb->cancel_monitor);
 #if PUBNUB_USE_AUTO_HEARTBEAT
     pubnub_mutex_destroy(pb->thumper_monitor);
 #endif

--- a/core/pubnub_alloc_std.c
+++ b/core/pubnub_alloc_std.c
@@ -130,6 +130,7 @@ void pballoc_free_at_last(pubnub_t* pb)
     remove_allocated(pb);
     pubnub_mutex_unlock(pb->monitor);
     pubnub_mutex_destroy(pb->monitor);
+    pubnub_mutex_destroy(pb->cancel_monitor);
 #if PUBNUB_USE_AUTO_HEARTBEAT
     pubnub_mutex_destroy(pb->thumper_monitor);
 #endif

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -414,7 +414,10 @@ struct pubnub_ {
 
 #if PUBNUB_THREADSAFE
     pubnub_mutex_t monitor;
+    pubnub_mutex_t  cancel_monitor;
 #endif
+    /** Whether sync `await` should stop (cancel) or not. */
+    bool should_stop_await;
 
 #if PUBNUB_TIMERS_API
     /** Duration of the transaction timeout, in milliseconds */

--- a/core/pubnub_pubsubapi.c
+++ b/core/pubnub_pubsubapi.c
@@ -19,6 +19,7 @@ pubnub_t* pubnub_init(pubnub_t* p, const char* publish_key, const char* subscrib
     PUBNUB_ASSERT(pb_valid_ctx_ptr(p));
 
     pubnub_mutex_init(p->monitor);
+    pubnub_mutex_init(p->cancel_monitor);
     pubnub_mutex_lock(p->monitor);
     pbcc_init(&p->core, publish_key, subscribe_key);
     if (PUBNUB_TIMERS_API) {
@@ -81,6 +82,7 @@ pubnub_t* pubnub_init(pubnub_t* p, const char* publish_key, const char* subscrib
     p->state                          = PBS_IDLE;
     p->trans                          = PBTT_NONE;
     p->options.use_http_keep_alive    = true;
+    p->should_stop_await              = false;
 #if PUBNUB_USE_IPV6
     /* IPv4 connectivity type by default. */
     p->options.ipv6_connectivity = false;
@@ -247,6 +249,10 @@ enum pubnub_cancel_res pubnub_cancel(pubnub_t* pb)
 {
     enum pubnub_cancel_res res = PN_CANCEL_STARTED;
     PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
+
+    pubnub_mutex_lock(pb->cancel_monitor);
+    pb->should_stop_await = true;
+    pubnub_mutex_unlock(pb->cancel_monitor);
 
     pubnub_mutex_lock(pb->monitor);
     pbnc_stop(pb, PNR_CANCELLED);


### PR DESCRIPTION
fix(cancel): fix issue because of which the sync operation doesn't cancel

Fix issue because of which it was impossible for sync PubNub context version to cancel operation awaited in secondary thread,