### PR TITLE
pbpal_mbedtls: Fix socket and memory leaks

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,19 @@
 name: c-core
 schema: 1
-version: "5.1.2"
+version: "5.1.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2025-07-15
+    version: v5.1.3
+    changes:
+      - type: bug
+        text: "Fixed memory leak when calling pubnub_free on an initialized PubNub object."
+      - type: bug
+        text: "Fixed socket leak when calling pubnub_free on a PubNub object with an open connection."
+      - type: bug
+        text: "Fixed socket leak when publishing using a context with use_http_keep_alive = 0."
+      - type: bug
+        text: "Fixed crash due to double-free when calling pubnub_free after pbpal_handle_socket_condition encounters a socket error."
   - date: 2025-07-08
     version: v5.1.2
     changes:
@@ -986,7 +997,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"
@@ -1052,7 +1063,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"
@@ -1118,7 +1129,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"
@@ -1180,7 +1191,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"
@@ -1241,7 +1252,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"
@@ -1297,7 +1308,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"
@@ -1350,7 +1361,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v5.1.3
+July 15 2025
+
+#### Fixed
+- Fixed memory leak when calling pubnub_free on an initialized PubNub object.
+- Fixed socket leak when calling pubnub_free on a PubNub object with an open connection.
+- Fixed socket leak when publishing using a context with use_http_keep_alive = 0.
+- Fixed crash due to double-free when calling pubnub_free after pbpal_handle_socket_condition encounters a socket error. Fixed the following issues reported by [@blake-spangenberg](https://github.com/blake-spangenberg): [#221](https://github.com/pubnub/c-core/issues/221).
+
 ## v5.1.2
 July 08 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ July 15 2025
 - Fixed socket leak when publishing using a context with use_http_keep_alive = 0.
 - Fixed crash due to double-free when calling pubnub_free after pbpal_handle_socket_condition encounters a socket error. Fixed the following issues reported by [@blake-spangenberg](https://github.com/blake-spangenberg): [#221](https://github.com/pubnub/c-core/issues/221).
 
+Thank you @blake-spangenberg for your contribution!
+
 ## v5.1.2
 July 08 2025
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "5.1.2"
+#define PUBNUB_SDK_VERSION "5.1.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix: Fixes memory leak when calling pubnub_free on an initialized PubNub object

Fixed memory leak when calling pubnub_free on an initialized PubNub object

fix: Fixes socket leak when calling pubnub_free on a PubNub object with an open connection

Fixed socket leak when calling pubnub_free on a PubNub object with an open connection

fix: Fixes socket leak when publishing using a context with use_http_keep_alive = 0

Fixed socket leak when publishing using a context with use_http_keep_alive = 0

fix: Fixes crash due to double-free when calling pubnub_free after pbpal_handle_socket_condition encounters a socket error

Fixed crash due to double-free when calling pubnub_free after pbpal_handle_socket_condition encounters a socket error

Thanks to @blake-spangenberg for fixing issues mentioned above!
Closes #221 