### PR TITLE
Fix UTF8 characters not working in some end points.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "5.1.3"
+version: "5.1.4"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2025-07-22
+    version: v5.1.4
+    changes:
+      - type: bug
+        text: "Fix bug that UTF8 characters used in some end points were breaking the request format."
   - date: 2025-07-15
     version: v5.1.3
     changes:
@@ -997,7 +1002,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"
@@ -1063,7 +1068,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"
@@ -1129,7 +1134,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"
@@ -1191,7 +1196,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"
@@ -1252,7 +1257,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"
@@ -1308,7 +1313,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"
@@ -1361,7 +1366,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v5.1.3
+            location: https://github.com/pubnub/c-core/releases/tag/v5.1.4
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v5.1.4
+July 22 2025
+
+#### Fixed
+- Fix bug that UTF8 characters used in some end points were breaking the request format.
+
 ## v5.1.3
 July 15 2025
 

--- a/core/pbcc_objects_api.c
+++ b/core/pbcc_objects_api.c
@@ -157,8 +157,9 @@ enum pubnub_res pbcc_set_uuidmetadata_prep(
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/uuids/%s",
-                                pb->subscribe_key, uuid_metadataid);
+                                "/v2/objects/%s/uuids/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, uuid_metadataid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -210,9 +211,9 @@ enum pubnub_res pbcc_get_uuidmetadata_prep(
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/uuids/%s",
-                                pb->subscribe_key,
-                                uuid_metadataid);
+                                "/v2/objects/%s/uuids/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, uuid_metadataid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -259,9 +260,9 @@ enum pubnub_res pbcc_remove_uuidmetadata_prep(struct pbcc_context* pb, char cons
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/uuids/%s",
-                                pb->subscribe_key,
-                                uuid_metadataid);
+                                "/v2/objects/%s/uuids/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, uuid_metadataid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -377,8 +378,9 @@ enum pubnub_res pbcc_set_channelmetadata_prep(struct pbcc_context* pb,
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/channels/%s",
-                                pb->subscribe_key, channel_metadataid);
+                                "/v2/objects/%s/channels/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_metadataid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -434,9 +436,9 @@ enum pubnub_res pbcc_get_channelmetadata_prep(struct pbcc_context* pb,
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/channels/%s",
-                                pb->subscribe_key,
-                                channel_metadataid);
+                                "/v2/objects/%s/channels/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_metadataid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -487,9 +489,9 @@ enum pubnub_res pbcc_remove_channelmetadata_prep(struct pbcc_context* pb, char c
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/channels/%s",
-                                pb->subscribe_key,
-                                channel_metadataid);
+                                "/v2/objects/%s/channels/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_metadataid);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -545,9 +547,10 @@ enum pubnub_res pbcc_get_memberships_prep(struct pbcc_context* pb,
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/uuids/%s/channels",
-                                pb->subscribe_key,
-                                uuid_metadataid);
+                                "/v2/objects/%s/uuids/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, uuid_metadataid);
+    APPEND_URL_LITERAL_M(pb, "/channels");
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -614,9 +617,10 @@ enum pubnub_res pbcc_set_memberships_prep(struct pbcc_context* pb,
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/uuids/%s/channels",
-                                pb->subscribe_key,
-                                uuid_metadataid);
+                                "/v2/objects/%s/uuids/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, uuid_metadataid);
+    APPEND_URL_LITERAL_M(pb, "/channels");
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -688,9 +692,10 @@ enum pubnub_res pbcc_get_members_prep(struct pbcc_context* pb,
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/channels/%s/uuids",
-                                pb->subscribe_key,
-                                channel_metadataid);
+                                "/v2/objects/%s/channels/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_metadataid);
+    APPEND_URL_LITERAL_M(pb, "/uuids");
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -759,9 +764,11 @@ enum pubnub_res pbcc_set_members_prep(struct pbcc_context* pb,
     pb->msg_ofs = pb->msg_end = 0;
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/objects/%s/channels/%s/uuids",
-                                pb->subscribe_key,
-                                channel_metadataid);
+                                "/v2/objects/%s/channels/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_metadataid);
+    APPEND_URL_LITERAL_M(pb, "/uuids");
+
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (user_id) { ADD_URL_PARAM(qparam, uuid, user_id); }

--- a/core/pubnub_ccore.c
+++ b/core/pubnub_ccore.c
@@ -425,9 +425,9 @@ enum pubnub_res pbcc_where_now_prep(struct pbcc_context* pb,
 
     pb->http_buf_len = snprintf(pb->http_buf,
                                 sizeof pb->http_buf,
-                                "/v2/presence/sub-key/%s/uuid/%s",
-                                pb->subscribe_key,
-                                user_id);
+                                "/v2/presence/sub-key/%s/uuid/",
+                                pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, user_id);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (pb_user_id) { ADD_URL_PARAM(qparam, uuid, pb_user_id); }
@@ -484,8 +484,9 @@ enum pubnub_res pbcc_set_state_prep(struct pbcc_context* pb,
     APPEND_URL_ENCODED_M(pb, channel);
     pb->http_buf_len += snprintf(pb->http_buf + pb->http_buf_len,
                                  sizeof pb->http_buf - pb->http_buf_len,
-                                 "/uuid/%s/data",
-                                 user_id);
+                                 "/uuid/");
+    APPEND_URL_ENCODED_M(pb, user_id);
+    APPEND_URL_LITERAL_M(pb, "/data");
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -543,8 +544,8 @@ enum pubnub_res pbcc_state_get_prep(struct pbcc_context* pb,
     APPEND_URL_ENCODED_M(pb, channel);
     pb->http_buf_len += snprintf(pb->http_buf + pb->http_buf_len,
                                  sizeof pb->http_buf - pb->http_buf_len,
-                                 "/uuid/%s",
-                                 user_id);
+                                 "/uuid/");
+    APPEND_URL_ENCODED_M(pb, user_id);
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
     if (channel_group) { ADD_URL_PARAM(qparam, channel-group, channel_group); }
@@ -584,9 +585,10 @@ enum pubnub_res pbcc_remove_channel_group_prep(struct pbcc_context* pb,
     pb->http_buf_len = snprintf(
         pb->http_buf,
         sizeof pb->http_buf,
-        "/v1/channel-registration/sub-key/%s/channel-group/%s/remove",
-        pb->subscribe_key,
-        channel_group);
+        "/v1/channel-registration/sub-key/%s/channel-group/",
+        pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_group);
+    APPEND_URL_LITERAL_M(pb, "/remove");
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }
@@ -628,9 +630,9 @@ enum pubnub_res pbcc_channel_registry_prep(struct pbcc_context* pb,
     pb->http_buf_len = snprintf(
         pb->http_buf,
         sizeof pb->http_buf,
-        "/v1/channel-registration/sub-key/%s/channel-group/%s",
-        pb->subscribe_key,
-        channel_group);
+        "/v1/channel-registration/sub-key/%s/channel-group/",
+        pb->subscribe_key);
+    APPEND_URL_ENCODED_M(pb, channel_group);
 
     URL_PARAMS_INIT(qparam, PUBNUB_MAX_URL_PARAMS);
     if (uname) { ADD_URL_PARAM(qparam, pnsdk, uname); }

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -1516,7 +1516,7 @@ Ensure(single_context_pubnub, set_state)
     pubnub_set_auth(pbp, "three");
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
-    expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/%5Bch1,ch2%5D/"
+    expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/[ch1,ch2]/"
                              "uuid/linda-darnell/"
                              "data?pnsdk=unit-test-0.1&channel-group="
                              "[gr3,gr4]&uuid=universal&auth=three&state=%7BI%7D");
@@ -1719,7 +1719,7 @@ Ensure(single_context_pubnub, state_get_channelgroup)
     pubnub_set_auth(pbp, "cat");
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
-    expect_outgoing_with_url("/v2/presence/sub-key/subY/channel/%5Bch1,ch2%5D/uuid/"
+    expect_outgoing_with_url("/v2/presence/sub-key/subY/channel/[ch1,ch2]/uuid/"
                              "leslie-mann?pnsdk=unit-test-0.1&channel-group=["
                              "gr3,gr4]&uuid=test_id&auth=cat");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -2781,7 +2781,7 @@ Ensure(single_context_pubnub, subscribe_channels_and_channel_groups)
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -2799,7 +2799,7 @@ Ensure(single_context_pubnub, subscribe_channels_and_channel_groups)
 
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "3516149789251234578?pnsdk=unit-test-0.1&channel-"
                              "group=[chgr2,chgr3,chgr4]&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -2998,7 +2998,7 @@ Ensure(single_context_pubnub, subscribe_reestablishing_broken_keep_alive_conecti
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0"
                             "/0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,chgr4]"
                             "&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -3024,7 +3024,7 @@ Ensure(single_context_pubnub, subscribe_reestablishing_broken_keep_alive_conecti
     expect(pbpal_forget, when(pb, equals(pbp)));
     /* Renewing DNS resolution and reestablishing connection */
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "3516149789251234578?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,chgr4]"
                              "&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -3088,7 +3088,7 @@ Ensure(single_context_pubnub, subscribe_not_using_keep_alive_connection)
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming_and_close("HTTP/1.1 200\r\nContent-Length: "
@@ -3113,7 +3113,7 @@ Ensure(single_context_pubnub, subscribe_not_using_and_than_using_keep_alive_conn
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming_and_close("HTTP/1.1 200\r\nContent-Length: "
@@ -3132,7 +3132,7 @@ Ensure(single_context_pubnub, subscribe_not_using_and_than_using_keep_alive_conn
     pubnub_use_http_keep_alive(pbp);
     /* Renewing DNS resolution with new request */
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "3516149789251234578?pnsdk=unit-test-0.1&channel-"
                              "group=[chgr2,chgr3,chgr4]&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -3395,7 +3395,7 @@ Ensure(single_context_pubnub,
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming_and_close("HTTP/1.1 200\r\nContent-Length: "

--- a/core/pubnub_core_unit_test.c
+++ b/core/pubnub_core_unit_test.c
@@ -1516,7 +1516,7 @@ Ensure(single_context_pubnub, set_state)
     pubnub_set_auth(pbp, "three");
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
-    expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/[ch1,ch2]/"
+    expect_outgoing_with_url("/v2/presence/sub-key/subhis/channel/%5Bch1,ch2%5D/"
                              "uuid/linda-darnell/"
                              "data?pnsdk=unit-test-0.1&channel-group="
                              "[gr3,gr4]&uuid=universal&auth=three&state=%7BI%7D");
@@ -1719,7 +1719,7 @@ Ensure(single_context_pubnub, state_get_channelgroup)
     pubnub_set_auth(pbp, "cat");
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
-    expect_outgoing_with_url("/v2/presence/sub-key/subY/channel/[ch1,ch2]/uuid/"
+    expect_outgoing_with_url("/v2/presence/sub-key/subY/channel/%5Bch1,ch2%5D/uuid/"
                              "leslie-mann?pnsdk=unit-test-0.1&channel-group=["
                              "gr3,gr4]&uuid=test_id&auth=cat");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -2193,7 +2193,7 @@ Ensure(single_context_pubnub, where_now)
 
     expect_have_dns_for_pubnub_origin();
     expect_outgoing_with_url(
-        "/v2/presence/sub-key/sub-where/uuid/shane(1953)?pnsdk=unit-test-0.1&uuid=test_id");
+        "/v2/presence/sub-key/sub-where/uuid/shane%281953%29?pnsdk=unit-test-0.1&uuid=test_id");
     incoming("HTTP/1.1 200\r\nContent-Length: "
              "89\r\n\r\n{\"status\":200,\"message\":\"OK\",\"service\":"
              "\"Presence\",\"Payload\":{\"channels\":[tcm,retro,mgm]}}",
@@ -2781,7 +2781,7 @@ Ensure(single_context_pubnub, subscribe_channels_and_channel_groups)
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -2799,7 +2799,7 @@ Ensure(single_context_pubnub, subscribe_channels_and_channel_groups)
 
     expect(pbntf_enqueue_for_processing, when(pb, equals(pbp)), returns(0));
     expect(pbntf_got_socket, when(pb, equals(pbp)), returns(0));
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "3516149789251234578?pnsdk=unit-test-0.1&channel-"
                              "group=[chgr2,chgr3,chgr4]&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -2998,7 +2998,7 @@ Ensure(single_context_pubnub, subscribe_reestablishing_broken_keep_alive_conecti
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0"
                             "/0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,chgr4]"
                             "&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -3024,7 +3024,7 @@ Ensure(single_context_pubnub, subscribe_reestablishing_broken_keep_alive_conecti
     expect(pbpal_forget, when(pb, equals(pbp)));
     /* Renewing DNS resolution and reestablishing connection */
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "3516149789251234578?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,chgr4]"
                              "&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -3088,7 +3088,7 @@ Ensure(single_context_pubnub, subscribe_not_using_keep_alive_connection)
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming_and_close("HTTP/1.1 200\r\nContent-Length: "
@@ -3113,7 +3113,7 @@ Ensure(single_context_pubnub, subscribe_not_using_and_than_using_keep_alive_conn
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming_and_close("HTTP/1.1 200\r\nContent-Length: "
@@ -3132,7 +3132,7 @@ Ensure(single_context_pubnub, subscribe_not_using_and_than_using_keep_alive_conn
     pubnub_use_http_keep_alive(pbp);
     /* Renewing DNS resolution with new request */
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "3516149789251234578?pnsdk=unit-test-0.1&channel-"
                              "group=[chgr2,chgr3,chgr4]&uuid=admin&auth=msgs");
     incoming("HTTP/1.1 200\r\nContent-Length: "
@@ -3395,7 +3395,7 @@ Ensure(single_context_pubnub,
     pubnub_set_user_id(pbp, "admin");
     pubnub_set_auth(pbp, "msgs");
     expect_have_dns_for_pubnub_origin();
-    expect_outgoing_with_url("/subscribe/sub-Key/[ch1,ch2]/0/"
+    expect_outgoing_with_url("/subscribe/sub-Key/%5Bch1,ch2%5D/0/"
                              "0?pnsdk=unit-test-0.1&channel-group=[chgr2,chgr3,"
                              "chgr4]&uuid=admin&auth=msgs");
     incoming_and_close("HTTP/1.1 200\r\nContent-Length: "

--- a/core/pubnub_subscribe_with_state.c
+++ b/core/pubnub_subscribe_with_state.c
@@ -32,7 +32,7 @@ static enum pubnub_res pbcc_subscribe_with_state_prep(struct pbcc_context *p,
                                sizeof p->http_buf,
                                "/subscribe/%s/",
                                p->subscribe_key);
-    APPEND_URL_ENCODED_M(pb, channel);
+    APPEND_URL_ENCODED_M(p, channel);
     p->http_buf_len += snprintf(p->http_buf + p->http_buf_len,
                                 sizeof p->http_buf - p->http_buf_len,
                                 "/0/%s",

--- a/core/pubnub_url_encode.h
+++ b/core/pubnub_url_encode.h
@@ -4,8 +4,8 @@
 
 /* RFC 3986 Unreserved characters plus few
  * safe reserved ones. */
-#define OK_SPAN_CHARACTERS (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~,[]"
-#define OK_SPAN_CHARS_MINUS_COMMA (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~[]"
+#define OK_SPAN_CHARACTERS (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~,"
+#define OK_SPAN_CHARS_MINUS_COMMA (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~"
 
 #include "lib/pb_extern.h"
 

--- a/core/pubnub_url_encode.h
+++ b/core/pubnub_url_encode.h
@@ -4,8 +4,8 @@
 
 /* RFC 3986 Unreserved characters plus few
  * safe reserved ones. */
-#define OK_SPAN_CHARACTERS (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~,"
-#define OK_SPAN_CHARS_MINUS_COMMA (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~"
+#define OK_SPAN_CHARACTERS (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~,[]"
+#define OK_SPAN_CHARS_MINUS_COMMA (char*)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~[]"
 
 #include "lib/pb_extern.h"
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "5.1.3"
+#define PUBNUB_SDK_VERSION "5.1.4"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix(general): Fix UTF8 characters not working in some end points.

Fix bug that UTF8 characters used in some end points were breaking the request format.