### PR TITLE
Address issue that returned `poll` immediately

### DIFF
--- a/core/pbpal.h
+++ b/core/pbpal.h
@@ -37,13 +37,15 @@ enum pbpal_resolv_n_connect_result {
 enum pbpal_tls_result {
     pbtlsEstablished,
     pbtlsStarted,
+    pbtlsStartedWaitRead,
+    pbtlsStartedWaitWrite,
     pbtlsInProgress,
     pbtlsResourceFailure,
     pbtlsFailed
 };
 
 /* Handles socket condition on given platform */
-enum pubnub_res pbpal_handle_socket_condition(int result, pubnub_t* pb, char const* file, int line);
+enum pubnub_res pbpal_handle_socket_condition(int result, pubnub_t* pb, char const* file, int line, bool *needRead, bool* needWrite);
 
 /** Handles start of a TCP (HTTP) connection. It first handles DNS
     resolving for the context @p pb.  If DNS is already resolved, it

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -723,7 +723,11 @@ next_state:
             case pbtlsEstablished:
                 break;
             case pbtlsStarted:
+            case pbtlsStartedWaitRead:
+            case pbtlsStartedWaitWrite:
                 pb->state = PBS_WAIT_TLS_CONNECT;
+                if (pbtlsStartedWaitWrite == res) pbntf_watch_out_events(pb);
+                if (pbtlsStartedWaitRead == res) pbntf_watch_in_events(pb);
                 return 0;
             case pbtlsFailed:
                 if (pb->options.fallbackSSL) {
@@ -770,6 +774,8 @@ next_state:
             pb->state = PBS_TX_GET;
             goto next_state;
         case pbtlsStarted:
+        case pbtlsStartedWaitRead:
+        case pbtlsStartedWaitWrite:
             break;
         case pbtlsFailed:
             if (pb->options.fallbackSSL) {

--- a/core/samples/pubnub_sync_sample.c
+++ b/core/samples/pubnub_sync_sample.c
@@ -140,11 +140,6 @@ subscribe_thr(void *pn_sub_addr)
 
 int main()
 {
-#if defined _WIN32
-    uintptr_t sub_thread;
-#else
-    pthread_t sub_thread;
-#endif
     time_t          t0;
     char const*     msg;
     enum pubnub_res res;
@@ -168,19 +163,6 @@ int main()
     generate_user_id(pbp);
 
     pubnub_set_auth(pbp, "danaske");
-
-#if defined _WIN32
-    sub_thread = _beginthread(subscribe_thr, 0, pbp);
-#else
-    pthread_create(&sub_thread, NULL, subscribe_thr, pbp);
-#endif
-    puts("Lets go sleeping...");
-    sleep(4);
-    puts("Done sleeping. Cancelling subscribe long-poll...");
-    pubnub_cancel(pbp);
-    sleep(2);
-    printf("What we have: %s\n", pubnub_res_2_string(pubnub_last_result(pbp)));
-    return 0;
 
     puts("Publishing...");
     time(&t0);

--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -420,10 +420,12 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
 #endif
 #ifdef PUBNUB_CALLBACK_API
     sockaddr_inX_t dest = { 0 };
+#if PUBNUB_PROXY_API
 #if PUBNUB_USE_IPV6
     const bool has_ipv6_proxy = 0 != pb->proxy_ipv6_address.ipv6[0]
         || 0 != pb->proxy_ipv6_address.ipv6[1];
 #endif /* PUBNUB_USE_IPV6 */
+#endif /* PUBNUB_PROXY_API */
 
     prepare_port_and_hostname(pb, &port, &origin);
 #if PUBNUB_PROXY_API


### PR DESCRIPTION
fix(poller): address issue that returned `poll` immediately

Fix the issue because of which `poll` always returned immediately without waiting for the actual event (TLS handshake flow uses proper watcher now).