### PR TITLE
Fix type mismatch and additional DNS / resolved address logging.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,21 @@
 name: c-core
 schema: 1
-version: "7.0.2"
+version: "7.1.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-03-03
+    version: v7.1.0
+    changes:
+      - type: feature
+        text: "Add new logger API methods to C++ `pubnub::context`, Qt `pubnub_qt`, and Qt `pubnub::context` classes, guarded by `PUBNUB_USE_LOGGER`."
+      - type: improvement
+        text: "Change `PUBNUB_LOG_MAP_SET_BOOL` to `PUBNUB_LOG_MAP_SET_NUMBER` for `opt.limit` and `opt.offset` (both `unsigned`) in `pubnub_here_now_ex` and `pubnub_global_here_now_ex` so the actual numeric values are logged instead of being truncated to `true`/`false`."
+      - type: improvement
+        text: "Use `pbms_start`/`pbms_elapsed` and `pb_sleep_ms` in `pubnub_free_with_timeout` to avoid a CPU-spinning loop and to fix portability issues with `clock()` on some platforms."
+      - type: improvement
+        text: "Add `PUBNUB_LOG_DEBUG` messages for hostname resolution, selected DNS server, resolved addresses, and address family across POSIX/Windows sockets, FreeRTOS, and Microchip Harmony platforms, and promote existing connect-address logs from `TRACE` to `DEBUG`."
+      - type: improvement
+        text: "Adjust log levels for missing DNS record messages to better match the severity of each event."
   - date: 2026-02-27
     version: v7.0.2
     changes:
@@ -1135,7 +1148,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"
@@ -1201,7 +1214,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"
@@ -1267,7 +1280,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"
@@ -1329,7 +1342,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"
@@ -1390,7 +1403,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"
@@ -1446,7 +1459,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"
@@ -1499,7 +1512,7 @@ sdks:
             distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.0.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.0
             requires:
               -
                 name: "miniz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v7.1.0
+March 03 2026
+
+#### Added
+- Add new logger API methods to C++ `pubnub::context`, Qt `pubnub_qt`, and Qt `pubnub::context` classes, guarded by `PUBNUB_USE_LOGGER`.
+
+#### Modified
+- Change `PUBNUB_LOG_MAP_SET_BOOL` to `PUBNUB_LOG_MAP_SET_NUMBER` for `opt.limit` and `opt.offset` (both `unsigned`) in `pubnub_here_now_ex` and `pubnub_global_here_now_ex` so the actual numeric values are logged instead of being truncated to `true`/`false`.
+- Use `pbms_start`/`pbms_elapsed` and `pb_sleep_ms` in `pubnub_free_with_timeout` to avoid a CPU-spinning loop and to fix portability issues with `clock()` on some platforms.
+- Add `PUBNUB_LOG_DEBUG` messages for hostname resolution, selected DNS server, resolved addresses, and address family across POSIX/Windows sockets, FreeRTOS, and Microchip Harmony platforms, and promote existing connect-address logs from `TRACE` to `DEBUG`.
+- Adjust log levels for missing DNS record messages to better match the severity of each event.
+
 ## v7.0.2
 February 27 2026
 

--- a/core/pbcc_subscribe_v2.c
+++ b/core/pbcc_subscribe_v2.c
@@ -102,7 +102,9 @@ enum pubnub_res pbcc_subscribe_v2_prep(
     ADD_URL_AUTH_PARAM(p, qparam, auth);
 #endif
 
-    if (filter_expr) { ADD_URL_PARAM_TRUE_KEY(qparam, "filter-expr", filter_expr); }
+    if (filter_expr) {
+        ADD_URL_PARAM_TRUE_KEY(qparam, "filter-expr", filter_expr);
+    }
     if (heartbeat) {
         ADD_URL_PARAM_SIZET(p, qparam, heartbeat, (size_t)*heartbeat);
     }
@@ -220,8 +222,7 @@ enum pubnub_res pbcc_parse_subscribe_v2_response(struct pbcc_context* p)
         p->msg_end = (unsigned)(found.end - reply - 1);
     }
     else {
-        PBCC_LOG_ERROR(
-            p->logger_manager, "No message array in response.", jpresult);
+        PBCC_LOG_ERROR(p->logger_manager, "No message array in response.");
         return PNR_FORMAT_ERROR;
     }
 

--- a/core/pubnub_coreapi_ex.c
+++ b/core/pubnub_coreapi_ex.c
@@ -277,8 +277,8 @@ enum pubnub_res pubnub_here_now_ex(
         PUBNUB_LOG_MAP_SET_STRING(&data, opt.channel_group, channel_group)
         PUBNUB_LOG_MAP_SET_BOOL(&data, opt.disable_uuids, disable_uuids)
         PUBNUB_LOG_MAP_SET_BOOL(&data, opt.state, include_state)
-        PUBNUB_LOG_MAP_SET_BOOL(&data, opt.limit, limit)
-        PUBNUB_LOG_MAP_SET_BOOL(&data, opt.offset, offset)
+        PUBNUB_LOG_MAP_SET_NUMBER(&data, opt.limit, limit)
+        PUBNUB_LOG_MAP_SET_NUMBER(&data, opt.offset, offset)
         pubnub_log_object(
             pb,
             PUBNUB_LOG_LEVEL_DEBUG,
@@ -332,8 +332,8 @@ enum pubnub_res pubnub_global_here_now_ex(
         pubnub_log_value_t data = pubnub_log_value_map_init();
         PUBNUB_LOG_MAP_SET_BOOL(&data, opt.disable_uuids, disable_uuids)
         PUBNUB_LOG_MAP_SET_BOOL(&data, opt.state, include_state)
-        PUBNUB_LOG_MAP_SET_BOOL(&data, opt.limit, limit)
-        PUBNUB_LOG_MAP_SET_BOOL(&data, opt.offset, offset)
+        PUBNUB_LOG_MAP_SET_NUMBER(&data, opt.limit, limit)
+        PUBNUB_LOG_MAP_SET_NUMBER(&data, opt.offset, offset)
         pubnub_log_object(
             pb,
             PUBNUB_LOG_LEVEL_DEBUG,

--- a/core/pubnub_dns_servers.c
+++ b/core/pubnub_dns_servers.c
@@ -43,20 +43,20 @@ int pubnub_dns_set_primary_server_ipv4(
     pubnub_t*                  pb,
     struct pubnub_ipv4_address ipv4_address)
 {
-    uint8_t* ipv4 = ipv4_address.ipv4;
-
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_DEBUG(
-        pb,
-        "Set primary IPv4 DNS server: %u.%u.%u.%u",
-        ipv4[0],
-        ipv4[1],
-        ipv4[2],
-        ipv4[3]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(DEBUG)
+    {
+        const uint8_t* ipv4 = ipv4_address.ipv4;
+        PUBNUB_LOG_DEBUG(
+            pb,
+            "Set primary IPv4 DNS server: %u.%u.%u.%u",
+            ipv4[0],
+            ipv4[1],
+            ipv4[2],
+            ipv4[3]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(DEBUG)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv4);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(DEBUG)
 
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
@@ -94,20 +94,20 @@ int pubnub_dns_set_secondary_server_ipv4(
     pubnub_t*                  pb,
     struct pubnub_ipv4_address ipv4_address)
 {
-    uint8_t* ipv4 = ipv4_address.ipv4;
-
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_DEBUG(
-        pb,
-        "Set secondary IPv4 DNS server: %u.%u.%u.%u",
-        ipv4[0],
-        ipv4[1],
-        ipv4[2],
-        ipv4[3]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(DEBUG)
+    {
+        const uint8_t* ipv4 = ipv4_address.ipv4;
+        PUBNUB_LOG_DEBUG(
+            pb,
+            "Set secondary IPv4 DNS server: %u.%u.%u.%u",
+            ipv4[0],
+            ipv4[1],
+            ipv4[2],
+            ipv4[3]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(DEBUG)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv4);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(DEBUG)
 
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
@@ -146,25 +146,25 @@ int pubnub_get_dns_primary_server_ipv4(
     struct pubnub_ipv4_address* o_ipv4)
 {
     int            ret;
-    const uint8_t* ipv4 = m_primary_dns_server_ipv4.ipv4;
-
     PUBNUB_ASSERT_OPT(o_ipv4 != NULL);
 
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
 
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_TRACE(
-        pb,
-        "Get primary IPv4 DNS server: %u.%u.%u.%u",
-        ipv4[0],
-        ipv4[1],
-        ipv4[2],
-        ipv4[3]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(TRACE)
+    {
+        const uint8_t* ipv4 = m_primary_dns_server_ipv4.ipv4;
+        PUBNUB_LOG_TRACE(
+            pb,
+            "Get primary IPv4 DNS server: %u.%u.%u.%u",
+            ipv4[0],
+            ipv4[1],
+            ipv4[2],
+            ipv4[3]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(TRACE)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv4);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(TRACE)
 
     if (0 == m_primary_dns_server_ipv4.ipv4[0]) { ret = -1; }
     else {
@@ -184,25 +184,25 @@ int pubnub_get_dns_secondary_server_ipv4(
     struct pubnub_ipv4_address* o_ipv4)
 {
     int            ret;
-    const uint8_t* ipv4 = m_secondary_dns_server_ipv4.ipv4;
-
     PUBNUB_ASSERT_OPT(o_ipv4 != NULL);
 
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
 
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_TRACE(
-        pb,
-        "Get secondary IPv4 DNS server: %u.%u.%u.%u",
-        ipv4[0],
-        ipv4[1],
-        ipv4[2],
-        ipv4[3]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(TRACE)
+    {
+        const uint8_t* ipv4 = m_secondary_dns_server_ipv4.ipv4;
+        PUBNUB_LOG_TRACE(
+            pb,
+            "Get secondary IPv4 DNS server: %u.%u.%u.%u",
+            ipv4[0],
+            ipv4[1],
+            ipv4[2],
+            ipv4[3]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(TRACE)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv4);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(TRACE)
 
     if (0 == m_secondary_dns_server_ipv4.ipv4[0]) { ret = -1; }
     else {
@@ -221,24 +221,24 @@ int pubnub_dns_set_primary_server_ipv6(
     pubnub_t*                  pb,
     struct pubnub_ipv6_address ipv6_address)
 {
-    uint8_t* ipv6 = ipv6_address.ipv6;
-
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_DEBUG(
-        pb,
-        "Set primary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
-        ipv6[0] * 256 + ipv6[1],
-        ipv6[2] * 256 + ipv6[3],
-        ipv6[4] * 256 + ipv6[5],
-        ipv6[6] * 256 + ipv6[7],
-        ipv6[8] * 256 + ipv6[9],
-        ipv6[10] * 256 + ipv6[11],
-        ipv6[12] * 256 + ipv6[13],
-        ipv6[14] * 256 + ipv6[15]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(DEBUG)
+    {
+        const uint8_t* ipv6 = ipv6_address.ipv6;
+        PUBNUB_LOG_DEBUG(
+            pb,
+            "Set primary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
+            ipv6[0] * 256 + ipv6[1],
+            ipv6[2] * 256 + ipv6[3],
+            ipv6[4] * 256 + ipv6[5],
+            ipv6[6] * 256 + ipv6[7],
+            ipv6[8] * 256 + ipv6[9],
+            ipv6[10] * 256 + ipv6[11],
+            ipv6[12] * 256 + ipv6[13],
+            ipv6[14] * 256 + ipv6[15]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(DEBUG)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv6);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(DEBUG)
 
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
@@ -276,24 +276,24 @@ int pubnub_dns_set_secondary_server_ipv6(
     pubnub_t*                  pb,
     struct pubnub_ipv6_address ipv6_address)
 {
-    uint8_t* ipv6 = ipv6_address.ipv6;
-
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_DEBUG(
-        pb,
-        "Set secondary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
-        ipv6[0] * 256 + ipv6[1],
-        ipv6[2] * 256 + ipv6[3],
-        ipv6[4] * 256 + ipv6[5],
-        ipv6[6] * 256 + ipv6[7],
-        ipv6[8] * 256 + ipv6[9],
-        ipv6[10] * 256 + ipv6[11],
-        ipv6[12] * 256 + ipv6[13],
-        ipv6[14] * 256 + ipv6[15]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(DEBUG)
+    {
+        const uint8_t* ipv6 = ipv6_address.ipv6;
+        PUBNUB_LOG_DEBUG(
+            pb,
+            "Set secondary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
+            ipv6[0] * 256 + ipv6[1],
+            ipv6[2] * 256 + ipv6[3],
+            ipv6[4] * 256 + ipv6[5],
+            ipv6[6] * 256 + ipv6[7],
+            ipv6[8] * 256 + ipv6[9],
+            ipv6[10] * 256 + ipv6[11],
+            ipv6[12] * 256 + ipv6[13],
+            ipv6[14] * 256 + ipv6[15]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(DEBUG)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv6);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(DEBUG)
 
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
@@ -332,7 +332,6 @@ int pubnub_get_dns_primary_server_ipv6(
     struct pubnub_ipv6_address* o_ipv6)
 {
     int            ret;
-    const uint8_t* ipv6 = m_primary_dns_server_ipv6.ipv6;
     uint8_t        zero[sizeof m_primary_dns_server_ipv6.ipv6] = { 0 };
 
     PUBNUB_ASSERT_OPT(o_ipv6 != NULL);
@@ -340,22 +339,24 @@ int pubnub_get_dns_primary_server_ipv6(
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
 
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_TRACE(
-        pb,
-        "Get primary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
-        ipv6[0] * 256 + ipv6[1],
-        ipv6[2] * 256 + ipv6[3],
-        ipv6[4] * 256 + ipv6[5],
-        ipv6[6] * 256 + ipv6[7],
-        ipv6[8] * 256 + ipv6[9],
-        ipv6[10] * 256 + ipv6[11],
-        ipv6[12] * 256 + ipv6[13],
-        ipv6[14] * 256 + ipv6[15]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(TRACE)
+    {
+        const uint8_t* ipv6 = m_primary_dns_server_ipv6.ipv6;
+        PUBNUB_LOG_TRACE(
+            pb,
+            "Get primary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
+            ipv6[0] * 256 + ipv6[1],
+            ipv6[2] * 256 + ipv6[3],
+            ipv6[4] * 256 + ipv6[5],
+            ipv6[6] * 256 + ipv6[7],
+            ipv6[8] * 256 + ipv6[9],
+            ipv6[10] * 256 + ipv6[11],
+            ipv6[12] * 256 + ipv6[13],
+            ipv6[14] * 256 + ipv6[15]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(TRACE)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv6);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(TRACE)
 
     if (memcmp(
             m_primary_dns_server_ipv6.ipv6,
@@ -380,7 +381,6 @@ int pubnub_get_dns_secondary_server_ipv6(
     struct pubnub_ipv6_address* o_ipv6)
 {
     int            ret;
-    const uint8_t* ipv6 = m_secondary_dns_server_ipv6.ipv6;
     uint8_t        zero[sizeof m_secondary_dns_server_ipv6.ipv6] = { 0 };
 
     PUBNUB_ASSERT_OPT(o_ipv6 != NULL);
@@ -388,22 +388,24 @@ int pubnub_get_dns_secondary_server_ipv6(
     pubnub_mutex_init_static(m_lock);
     pubnub_mutex_lock(m_lock);
 
-#if PUBNUB_USE_LOGGER
-    PUBNUB_LOG_TRACE(
-        pb,
-        "Get secondary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
-        ipv6[0] * 256 + ipv6[1],
-        ipv6[2] * 256 + ipv6[3],
-        ipv6[4] * 256 + ipv6[5],
-        ipv6[6] * 256 + ipv6[7],
-        ipv6[8] * 256 + ipv6[9],
-        ipv6[10] * 256 + ipv6[11],
-        ipv6[12] * 256 + ipv6[13],
-        ipv6[14] * 256 + ipv6[15]);
-#else  // !PUBNUB_USE_LOGGER
+#if PUBNUB_LOG_ENABLED(TRACE)
+    {
+        const uint8_t* ipv6 = m_secondary_dns_server_ipv6.ipv6;
+        PUBNUB_LOG_TRACE(
+            pb,
+            "Get secondary IPv6 DNS server: %u:%u:%u:%u:%u:%u:%u:%u",
+            ipv6[0] * 256 + ipv6[1],
+            ipv6[2] * 256 + ipv6[3],
+            ipv6[4] * 256 + ipv6[5],
+            ipv6[6] * 256 + ipv6[7],
+            ipv6[8] * 256 + ipv6[9],
+            ipv6[10] * 256 + ipv6[11],
+            ipv6[12] * 256 + ipv6[13],
+            ipv6[14] * 256 + ipv6[15]);
+    }
+#else  // !PUBNUB_LOG_ENABLED(TRACE)
     PUBNUB_UNUSED(pb);
-    PUBNUB_UNUSED(ipv6);
-#endif // PUBNUB_USE_LOGGER
+#endif // PUBNUB_LOG_ENABLED(TRACE)
 
     if (memcmp(
             m_secondary_dns_server_ipv6.ipv6,

--- a/core/pubnub_free_with_timeout_std.c
+++ b/core/pubnub_free_with_timeout_std.c
@@ -4,27 +4,29 @@
 #include "pubnub_free_with_timeout.h"
 #include "pubnub_alloc.h"
 #include "pubnub_assert.h"
+#include "lib/msstopwatch/msstopwatch.h"
+#include "core/pb_sleep_ms.h"
 #if PUBNUB_USE_LOGGER
 #include "pbcc_logger_manager.h"
 #endif // PUBNUB_USE_LOGGER
 
-#include "time.h"
+#define PUBNUB_FREE_POLL_INTERVAL_MS 1
 
 
 int pubnub_free_with_timeout(pubnub_t* pbp, unsigned millisec)
 {
-    const clock_t t0                  = clock();
-    const clock_t clocks_till_timeout = (millisec * CLOCKS_PER_SEC) / 1000;
+    const pbmsref_t t0 = pbms_start();
 
     PUBNUB_ASSERT_OPT(pbp != NULL);
 
     while (pubnub_free(pbp) != 0) {
-        const clock_t elapsed = clock() - t0;
-        if (elapsed > clocks_till_timeout) {
+        const pbms_t elapsed = pbms_elapsed(t0);
+        if (elapsed > (pbms_t)millisec) {
             PUBNUB_LOG_ERROR(
                 pbp, "Failed to free the context in %u milliseconds", millisec);
             return -1;
         }
+        pb_sleep_ms(PUBNUB_FREE_POLL_INTERVAL_MS);
     }
     PUBNUB_LOG_TRACE(
         pbp,

--- a/core/pubnub_free_with_timeout_std.c
+++ b/core/pubnub_free_with_timeout_std.c
@@ -30,8 +30,8 @@ int pubnub_free_with_timeout(pubnub_t* pbp, unsigned millisec)
     }
     PUBNUB_LOG_TRACE(
         pbp,
-        "Freed the context in %lf seconds",
-        ((float)clock() - t0) / CLOCKS_PER_SEC);
+        "Freed the context in %.3f seconds",
+        (double)pbms_elapsed(t0) / 1000.0);
 
     return 0;
 }

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -195,8 +195,7 @@ static void log_http_request(
             (int)pb->core.http_buf_len,
             pb->core.http_buf);
     }
-    else if (canceled) level = PUBNUB_LOG_LEVEL_WARNING;
-    else level = PUBNUB_LOG_LEVEL_ERROR;
+    else if (failed) level = PUBNUB_LOG_LEVEL_ERROR;
 
     char const* body = NULL;
     if (HTTP_request_has_body(pb) && pb->core.message_to_send)
@@ -328,13 +327,14 @@ static int send_fin_head(struct pubnub_* pb)
     /* Use context-specific identification when runtime suffix is set;
        otherwise preserve default (pubnub_uagent). */
     char const* uagent = (pb->core.sdk_version_suffix != NULL)
-        ? pbcc_uname(&pb->core)
-        : pubnub_uagent();
-    snprintf(s,
-             sizeof s,
-             "\r\nUser-Agent: %s%s",
-             uagent,
-             "\r\n" ACCEPT_ENCODING "\r\n");
+                             ? pbcc_uname(&pb->core)
+                             : pubnub_uagent();
+    snprintf(
+        s,
+        sizeof s,
+        "\r\nUser-Agent: %s%s",
+        uagent,
+        "\r\n" ACCEPT_ENCODING "\r\n");
     return pbpal_send_str(pb, s);
 }
 

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -176,10 +176,9 @@ static void log_http_request(
     const bool      failed,
     char const*     details)
 {
-    enum pubnub_log_level level;
+    enum pubnub_log_level level = PUBNUB_LOG_LEVEL_DEBUG;
 
     if (!canceled && !failed) {
-        level              = PUBNUB_LOG_LEVEL_DEBUG;
         char const* scheme = "http://";
 #if PUBNUB_USE_SSL
         if (pb->options.useSSL) scheme = "https://";

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.0.2"
+#define PUBNUB_SDK_VERSION "7.1.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/cpp/pubnub_common.hpp
+++ b/cpp/pubnub_common.hpp
@@ -53,6 +53,9 @@ extern "C" {
 #if PUBNUB_USE_REVOKE_TOKEN_API
 #include "core/pubnub_revoke_token_api.h"
 #endif
+#if PUBNUB_USE_LOGGER
+#include "core/pubnub_logger.h"
+#endif
 #include "core/pubnub_auto_heartbeat.h"
 #include "core/pubnub_crypto.h"
 #include "core/pubnub_memory_block.h"
@@ -2009,6 +2012,220 @@ public:
         pubnub_set_ipv6_connectivity(d_pb);
     }
 #endif /* PUBNUB_USE_IPV6 */
+
+#if PUBNUB_USE_LOGGER
+    /** Add a custom logger to the context logging subsystem.
+     *
+     * Registers a custom logger that will receive log messages from
+     * this context. Multiple loggers can be registered.
+     *
+     * @param logger Pointer to the custom logger (created with
+     *               `pubnub_logger_alloc`).
+     * @retval 0 on success.
+     * @retval -1 on failure (NULL pointer or already added).
+     *
+     * @code
+     * static void my_info(const pubnub_logger_t*      logger,
+     *                     const pubnub_log_message_t* message) {
+     *     if (message->message_type == PUBNUB_LOG_MESSAGE_TYPE_TEXT) {
+     *         const pubnub_log_message_text_t* text =
+     *             (const pubnub_log_message_text_t*)message;
+     *         printf("[INFO] %s\n", text->message);
+     *     }
+     * }
+     *
+     * static const struct pubnub_logger_interface my_vtable = {
+     *     .trace = NULL, .debug = NULL, .info = my_info,
+     *     .warn = NULL, .error = NULL, .destroy = NULL,
+     * };
+     *
+     * pubnub_logger_t* logger = pubnub_logger_alloc(&my_vtable, NULL);
+     * ctx.logger_add(logger);
+     * // ... use PubNub context ...
+     * ctx.logger_remove(logger);
+     * pubnub_logger_free(&logger);
+     * @endcode
+     *
+     * @see pubnub_logger_add
+     * @see pubnub_logger_alloc
+     */
+    int logger_add(pubnub_logger_t* logger)
+    {
+        return pubnub_logger_add(d_pb, logger);
+    }
+
+    /** Remove a custom logger from the context logging subsystem.
+     *
+     * @note It is the caller's responsibility to call
+     *       `pubnub_logger_free` after removing.
+     *
+     * @param logger Pointer to the custom logger to remove.
+     * @retval 0 on success.
+     * @retval -1 on failure (logger not found or NULL pointer).
+     *
+     * @code
+     * ctx.logger_remove(logger);
+     * pubnub_logger_free(&logger);
+     * @endcode
+     *
+     * @see pubnub_logger_remove
+     */
+    int logger_remove(pubnub_logger_t* logger)
+    {
+        return pubnub_logger_remove(d_pb, logger);
+    }
+
+    /** Remove all custom loggers from the context logging subsystem.
+     *
+     * @note It is the caller's responsibility to call
+     *       `pubnub_logger_free` for each logger after this call.
+     *
+     * @code
+     * ctx.logger_remove_all();
+     * pubnub_logger_free(&logger1);
+     * pubnub_logger_free(&logger2);
+     * @endcode
+     *
+     * @see pubnub_logger_remove_all
+     */
+    void logger_remove_all()
+    {
+        pubnub_logger_remove_all(d_pb);
+    }
+
+    /** Set the minimum log level for the context logging subsystem.
+     *
+     * Only messages with level >= @p level will be dispatched to
+     * registered loggers.
+     *
+     * @param level The minimum log level.
+     *
+     * @code
+     * // Only receive warning and error messages.
+     * ctx.set_log_level(PUBNUB_LOG_LEVEL_WARNING);
+     * @endcode
+     *
+     * @see pubnub_logger_set_log_level
+     */
+    void set_log_level(pubnub_log_level level)
+    {
+        pubnub_logger_set_log_level(d_pb, level);
+    }
+
+    /** Get the current minimum log level for the context logging
+     * subsystem.
+     *
+     * @b Default: `PUBNUB_LOG_LEVEL_DEBUG`.
+     *
+     * @return The current minimum log level.
+     *
+     * @code
+     * pubnub_log_level level = ctx.log_level();
+     * @endcode
+     *
+     * @see pubnub_logger_log_level
+     */
+    pubnub_log_level log_level() const
+    {
+        return pubnub_logger_log_level(d_pb);
+    }
+
+    /** Log a text message.
+     *
+     * @param level    Log entry log level.
+     * @param location Call site location string.
+     * @param message  Text message to log.
+     *
+     * @code
+     * ctx.log_text(PUBNUB_LOG_LEVEL_INFO,
+     *              "my_app.cpp:42",
+     *              "Subscription connected");
+     * @endcode
+     *
+     * @see pubnub_log_text
+     */
+    void log_text(pubnub_log_level level,
+                  char const* location,
+                  char const* message)
+    {
+        pubnub_log_text(d_pb, level, location, message);
+    }
+
+    /** Log a text message from a std::string.
+     *
+     * @param level    Log entry log level.
+     * @param location Call site location string.
+     * @param message  Text message to log.
+     *
+     * @code
+     * std::string msg = "Publishing to channel: " + channel;
+     * ctx.log_text(PUBNUB_LOG_LEVEL_DEBUG, "my_app.cpp:55", msg);
+     * @endcode
+     *
+     * @see pubnub_log_text
+     */
+    void log_text(pubnub_log_level level,
+                  char const* location,
+                  std::string const& message)
+    {
+        pubnub_log_text(d_pb, level, location, message.c_str());
+    }
+
+    /** Log a structured object/data.
+     *
+     * @note The value is not freed by this function — caller retains
+     *       ownership.
+     *
+     * @param level    Log entry log level.
+     * @param location Call site location string.
+     * @param message  Structured value to log (map, array, or
+     *                 primitive).
+     * @param details  Optional description (can be NULL).
+     *
+     * @code
+     * pubnub_log_value_t params = pubnub_log_value_map_init();
+     * pubnub_log_value_t ch_val = pubnub_log_value_string("my-channel");
+     * pubnub_log_value_map_set(&params, "channel", &ch_val);
+     * ctx.log_object(PUBNUB_LOG_LEVEL_DEBUG,
+     *                "my_app.cpp:70",
+     *                &params,
+     *                "publish parameters");
+     * @endcode
+     *
+     * @see pubnub_log_object
+     */
+    void log_object(pubnub_log_level level,
+                    char const* location,
+                    pubnub_log_value_t const* message,
+                    char const* details = NULL)
+    {
+        pubnub_log_object(d_pb, level, location, message, details);
+    }
+
+    /** Log an error with an error code and message.
+     *
+     * @note The log level is always `PUBNUB_LOG_LEVEL_ERROR`.
+     *
+     * @param location      Call site location string.
+     * @param error_code    Error code.
+     * @param error_message Error description.
+     * @param details       Additional error details (can be NULL).
+     *
+     * @code
+     * ctx.log_error("my_app.cpp:85", -1,
+     *               "Connection failed", "Timeout after 30s");
+     * @endcode
+     *
+     * @see pubnub_log_error
+     */
+    void log_error(char const* location,
+                   int error_code,
+                   char const* error_message,
+                   char const* details = NULL)
+    {
+        pubnub_log_error(d_pb, location, error_code, error_message, details);
+    }
+#endif /* PUBNUB_USE_LOGGER */
 
     /// Frees the context and any other thing that needs to be
     /// freed/released.

--- a/freertos/pbpal_resolv_and_connect_freertos_tcp.c
+++ b/freertos/pbpal_resolv_and_connect_freertos_tcp.c
@@ -44,6 +44,7 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
         PUBNUB_LOG_ERROR(pb, "Unable to resolve hostname. No address found.");
         return pbpal_resolv_failed_processing;
     }
+    PUBNUB_LOG_DEBUG(pb, "Resolved to: %s", inet_ntoa(addr.sin_addr));
 
     pb->pal.socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (pb->pal.socket == SOCKET_INVALID) {
@@ -59,9 +60,16 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
 #else
     struct sockaddr addr;
     addr.sin_port = htons(HTTP_PORT);
+    PUBNUB_LOG_DEBUG(
+        pb,
+        "Resolving hostname: %s",
+        PUBNUB_ORIGIN_SETTABLE ? pb->origin : PUBNUB_ORIGIN);
     addr.sin_addr =
         gethostbyname(PUBNUB_ORIGIN_SETTABLE ? pb->origin : PUBNUB_ORIGIN);
-    if (addr.sin_addr == 0) { return pbpal_resolv_failed_processing; }
+    if (addr.sin_addr == 0) {
+        PUBNUB_LOG_ERROR(pb, "Hostname resolution failed.");
+        return pbpal_resolv_failed_processing;
+    }
 
     pb->pal.socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (pb->pal.socket == SOCKET_INVALID) {

--- a/lib/sockets/pbpal_adns_sockets.c
+++ b/lib/sockets/pbpal_adns_sockets.c
@@ -240,12 +240,12 @@ int read_dns_response(
             responses_received++;
             if (dnsA == question_type) {
                 tracking->received_a = true;
-                PUBNUB_LOG_WARNING(pb, "No 'A' records for requested domain.");
+                PUBNUB_LOG_ERROR(pb, "No 'A' records for requested domain.");
             }
 #if PUBNUB_USE_IPV6
             else if (dnsAAAA == question_type) {
                 tracking->received_aaaa = true;
-                PUBNUB_LOG_WARNING(
+                PUBNUB_LOG_DEBUG(
                     pb, "No 'AAAA' records for requested domain.");
             }
 #endif /* PUBNUB_USE_IPV6 */

--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -72,6 +72,7 @@ static bool is_global_unicast_ipv6(const struct in6_addr* addr)
 
 /** Check whether the host has a usable global IPv6 route.
  *
+ *
  *  Creates a UDP socket, connects it to a well-known global IPv6 address and
  *  inspects the source address the kernel selects via getsockname().
  *
@@ -391,7 +392,7 @@ static enum pbpal_resolv_n_connect_result connect_TCP_socket(
     case AF_INET:
         sockaddr_size                         = sizeof(struct sockaddr_in);
         ((struct sockaddr_in*)dest)->sin_port = htons(port);
-        PUBNUB_LOG_TRACE(
+        PUBNUB_LOG_DEBUG(
             pb,
             "Connect to IPv4: %s",
             inet_ntoa(((struct sockaddr_in*)dest)->sin_addr));
@@ -400,10 +401,10 @@ static enum pbpal_resolv_n_connect_result connect_TCP_socket(
     case AF_INET6: {
         sockaddr_size                           = sizeof(struct sockaddr_in6);
         ((struct sockaddr_in6*)dest)->sin6_port = htons(port);
-#if PUBNUB_LOG_ENABLED(TRACE)
+#if PUBNUB_LOG_ENABLED(DEBUG)
         {
             char str[INET6_ADDRSTRLEN];
-            PUBNUB_LOG_TRACE(
+            PUBNUB_LOG_DEBUG(
                 pb,
                 "Connect to IPv6: %s",
                 inet_ntop(
@@ -529,7 +530,6 @@ static enum pbpal_resolv_n_connect_result try_TCP_connect_spare_address(
     const uint16_t port)
 {
     struct pubnub_multi_addresses*     spare_addresses = &pb->spare_addresses;
-    struct pubnub_options*             options         = &pb->options;
     struct pubnub_flags*               flags           = &pb->flags;
     pb_socket_t*                       skt             = &pb->pal.socket;
     enum pbpal_resolv_n_connect_result rslt = pbpal_resolv_resource_failure;
@@ -613,7 +613,7 @@ static enum pbpal_resolv_n_connect_result try_TCP_connect_spare_address(
                     (++spare_addresses->ipv6_index < spare_addresses->n_ipv6);
                 if_no_retry_close_socket(skt, flags);
 #if PUBNUB_USE_SSL
-                flags->trySSL = options->useSSL;
+                flags->trySSL = pb->options.useSSL;
 #endif
             }
         }
@@ -695,7 +695,7 @@ static enum pbpal_resolv_n_connect_result try_TCP_connect_spare_address(
                 (++spare_addresses->ipv4_index < spare_addresses->n_ipv4);
             if_no_retry_close_socket(skt, flags);
 #if PUBNUB_USE_SSL
-            flags->trySSL = options->useSSL;
+            flags->trySSL = pb->options.useSSL;
 #endif
         }
     }
@@ -722,6 +722,8 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
 #else  /* PUBNUB_USE_IPV6 */
     sa_family_t family = AF_INET;
 #endif /* !PUBNUB_USE_IPV6 */
+    PUBNUB_LOG_DEBUG(pb, "Address family: %s",
+                     AF_INET6 == family ? "IPv6" : "IPv4");
 
 #ifdef PUBNUB_NTF_RUNTIME_SELECTION
     if (PNA_CALLBACK == pb->api_policy) { // if policy
@@ -800,6 +802,26 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
              * pbpal_check_resolv_and_connect */
             memcpy(&pb->dns_addr, &dest, sizeof(dest));
 
+#if PUBNUB_LOG_ENABLED(DEBUG)
+            if (AF_INET6 == ((struct sockaddr*)&dest)->sa_family) {
+                char dns_str[INET6_ADDRSTRLEN];
+                PUBNUB_LOG_DEBUG(
+                    pb,
+                    "Selected DNS server: %s",
+                    inet_ntop(
+                        AF_INET6,
+                        &((struct sockaddr_in6*)&dest)->sin6_addr,
+                        dns_str,
+                        sizeof dns_str));
+            }
+            else {
+                PUBNUB_LOG_DEBUG(
+                    pb,
+                    "Selected DNS server: %s",
+                    inet_ntoa(((struct sockaddr_in*)&dest)->sin_addr));
+            }
+#endif
+
             pb->pal.socket = socket(
                 ((struct sockaddr*)&dest)->sa_family, SOCK_DGRAM, IPPROTO_UDP);
         }
@@ -846,8 +868,12 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
 
         prepare_port_and_hostname(pb, &port, &origin);
         snprintf(port_string, sizeof port_string, "%hu", port);
+        PUBNUB_LOG_DEBUG(pb, "Resolving '%s:%s' via getaddrinfo", origin, port_string);
         error = getaddrinfo(origin, port_string, &hint, &result);
-        if (error != 0) { return pbpal_resolv_failed_processing; }
+        if (error != 0) {
+            PUBNUB_LOG_ERROR(pb, "getaddrinfo('%s') failed with error: %d", origin, error);
+            return pbpal_resolv_failed_processing;
+        }
 #if PUBNUB_USE_IPV6
         for (int pass = 0; pass < 2; ++pass) {
             bool prioritize_ipv6 = pass == 0 && AF_INET6 == family;
@@ -887,6 +913,26 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
 #endif /* !defined(_WIN32) */
 
                 pbpal_set_blocking_io(pb);
+#if PUBNUB_LOG_ENABLED(DEBUG)
+                if (AF_INET6 == it->ai_family) {
+                    char str[INET6_ADDRSTRLEN];
+                    PUBNUB_LOG_DEBUG(
+                        pb,
+                        "Connecting to resolved IPv6 address: %s",
+                        inet_ntop(
+                            AF_INET6,
+                            &((struct sockaddr_in6*)it->ai_addr)->sin6_addr,
+                            str,
+                            sizeof str));
+                }
+                else {
+                    PUBNUB_LOG_DEBUG(
+                        pb,
+                        "Connecting to resolved IPv4 address: %s",
+                        inet_ntoa(
+                            ((struct sockaddr_in*)it->ai_addr)->sin_addr));
+                }
+#endif
                 if (connect(pb->pal.socket, it->ai_addr, it->ai_addrlen) ==
                     SOCKET_ERROR) {
                     if (socket_would_block()) {

--- a/microchip_harmony/pbpal_resolv_and_connect_harmony_tcp.c
+++ b/microchip_harmony/pbpal_resolv_and_connect_harmony_tcp.c
@@ -19,11 +19,12 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t *pb)
 #else
     TCPIP_DNS_RESOLVE_TYPE query_type = TCPIP_DNS_TYPE_A;
 #endif
+    PUBNUB_LOG_DEBUG(pb, "Resolving '%s' via TCPIP_DNS_Resolve", origin);
     TCPIP_DNS_RESULT dns_result = TCPIP_DNS_Resolve(origin, query_type);
     PUBNUB_ASSERT(pb_valid_ctx_ptr(pb));
-    PUBNUB_ASSERT((pb->state == PBS_IDLE) || (pb->state == PBS_WAIT_DNS_SEND) 
+    PUBNUB_ASSERT((pb->state == PBS_IDLE) || (pb->state == PBS_WAIT_DNS_SEND)
             || (pb->state == PBS_WAIT_DNS_RCV));
-    
+
     switch (dns_result) {
         case TCPIP_DNS_RES_OK:
         case TCPIP_DNS_RES_NAME_IS_IPADDRESS:
@@ -56,6 +57,7 @@ enum pbpal_resolv_n_connect_result pbpal_check_resolv_and_connect(pubnub_t *pb)
     IP_MULTI_ADDRESS ip_addr;
     TCPIP_DNS_RESULT dns_result = TCPIP_DNS_IsResolved(origin, &ip_addr, address_type);
 	PUBNUB_ASSERT_OPT(pb != NULL);
+    PUBNUB_LOG_DEBUG(pb, "DNS resolution status for '%s': %d", origin, (int)dns_result);
     switch (dns_result) {
         case TCPIP_DNS_RES_OK:
             if (SOCKET_INVALID == pb->pal.socket) {
@@ -72,6 +74,7 @@ enum pbpal_resolv_n_connect_result pbpal_check_resolv_and_connect(pubnub_t *pb)
 #endif
             }
             if (SOCKET_INVALID == pb->pal.socket) {
+                PUBNUB_LOG_ERROR(pb, "Failed to open TCP socket for '%s'", origin);
                 return pbpal_connect_resource_failure;
             }
             pbpal_set_tcp_keepalive(pb);

--- a/posix/pubnub_dns_system_servers.c
+++ b/posix/pubnub_dns_system_servers.c
@@ -35,7 +35,6 @@ int pubnub_dns_read_system_servers_ipv4(
         return -1;
     }
     while ((i < n) && !feof(fp)) {
-        uint8_t* dns_bytes = NULL;
         /* Reads new line */
         fgets(buffer, sizeof buffer, fp);
         if (strncmp(buffer, "nameserver", 10) == 0) {
@@ -57,17 +56,18 @@ int pubnub_dns_read_system_servers_ipv4(
                     addr_start);
             }
             else {
-                dns_bytes = o_ipv4[i].ipv4;
-                found     = true;
+                found = true;
+#if PUBNUB_LOG_ENABLED(TRACE)
+                {
+                    char str[INET_ADDRSTRLEN];
+                    PUBNUB_LOG_TRACE(
+                        pb,
+                        "Added IPv4 DNS server address to the list: %s",
+                        inet_ntop(
+                            AF_INET, o_ipv4[i].ipv4, str, INET_ADDRSTRLEN));
+                }
+#endif
                 ++i;
-            }
-
-            if (NULL != dns_bytes) {
-                char str[INET_ADDRSTRLEN];
-                PUBNUB_LOG_TRACE(
-                    pb,
-                    "Added IPv4 DNS server address to the list: %s",
-                    inet_ntop(AF_INET, dns_bytes, str, INET_ADDRSTRLEN));
             }
         }
     }
@@ -116,8 +116,6 @@ int pubnub_dns_read_system_servers_ipv6(
         /* Reads new line */
         fgets(buffer, sizeof buffer, fp);
         if (strncmp(buffer, "nameserver", 10) == 0) {
-            bool     is_ipv4_address = false;
-            uint8_t* dns_bytes       = NULL;
             char*    addr_start      = buffer + 10;
             while (*addr_start == ' ' || *addr_start == '\t') {
                 addr_start++;
@@ -132,19 +130,42 @@ int pubnub_dns_read_system_servers_ipv6(
 
             /* Try parsing as IPv6 first */
             if (pubnub_parse_ipv6_addr(pb, addr_start, &o_ipv6[dns_count]) == 0) {
-                dns_bytes = o_ipv6[dns_count].ipv6;
+#if PUBNUB_LOG_ENABLED(TRACE)
+                {
+                    char str[INET6_ADDRSTRLEN];
+                    PUBNUB_LOG_TRACE(
+                        pb,
+                        "Added IPv6 DNS (%s).",
+                        inet_ntop(
+                            AF_INET6,
+                            o_ipv6[dns_count].ipv6,
+                            str,
+                            INET6_ADDRSTRLEN));
+                }
+#endif
                 ++dns_count;
             }
             else {
                 struct pubnub_ipv4_address ipv4_addr;
                 if (pubnub_parse_ipv4_addr(addr_start, &ipv4_addr) == 0) {
                     has_ipv4_addresses = true;
-                    is_ipv4_address    = true;
                     memset(o_ipv6[dns_count].ipv6, 0, 10);
                     o_ipv6[dns_count].ipv6[10] = 0xff;
                     o_ipv6[dns_count].ipv6[11] = 0xff;
                     memcpy(&o_ipv6[dns_count].ipv6[12], ipv4_addr.ipv4, 4);
-                    dns_bytes = o_ipv6[dns_count].ipv6;
+#if PUBNUB_LOG_ENABLED(TRACE)
+                    {
+                        char str[INET6_ADDRSTRLEN];
+                        PUBNUB_LOG_TRACE(
+                            pb,
+                            "Added IPv4-mapped IPv6 DNS (%s).",
+                            inet_ntop(
+                                AF_INET6,
+                                o_ipv6[dns_count].ipv6,
+                                str,
+                                INET6_ADDRSTRLEN));
+                    }
+#endif
                     ++dns_count;
                 }
                 else {
@@ -153,15 +174,6 @@ int pubnub_dns_read_system_servers_ipv6(
                         "Unable to parse malformed IPv6 address string: %s",
                         addr_start);
                 }
-            }
-
-            if (NULL != dns_bytes) {
-                char str[INET6_ADDRSTRLEN];
-                PUBNUB_LOG_TRACE(
-                    pb,
-                    "Added %s DNS (%s).",
-                    is_ipv4_address ? "IPv4-mapped IPv6" : "IPv6",
-                    inet_ntop(AF_INET6, dns_bytes, str, INET6_ADDRSTRLEN));
             }
         }
     }
@@ -183,6 +195,7 @@ int pubnub_dns_read_system_servers_ipv6(
         "Discovered %u %s DNS server addresses",
         dns_count,
         has_ipv4_addresses ? "IPv4-mapped IPv6/IPv6" : "IPv6");
+    PUBNUB_UNUSED(has_ipv4_addresses);
 
     return dns_count;
 }

--- a/qt/fn_test.pro
+++ b/qt/fn_test.pro
@@ -4,7 +4,7 @@ mac:CONFIG -= app_bundle
 win32:CONFIG += console
 CONFIG += c++11
 HEADERS += pubnub_qt.h pubnub.hpp
-SOURCES += pubnub_qt.cpp pubnub.cpp fntest/pubnub_fntest_runner.cpp ../cpp/fntest/pubnub_fntest.cpp ../cpp/fntest/pubnub_fntest_basic.cpp ../cpp/fntest/pubnub_fntest_medium.cpp ../core/pubnub_ccore.c ../core/pubnub_ccore_pubsub.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c
+SOURCES += pubnub_qt.cpp pubnub.cpp fntest/pubnub_fntest_runner.cpp ../cpp/fntest/pubnub_fntest.cpp ../cpp/fntest/pubnub_fntest_basic.cpp ../cpp/fntest/pubnub_fntest_medium.cpp ../core/pubnub_ccore.c ../core/pubnub_ccore_pubsub.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pubnub_logger.c ../core/pbcc_logger_manager.c ../core/pubnub_log_value.c ../core/pubnub_stdio_logger.c
 win32:SOURCES += ../core/c99/snprintf.c
 
 DEFINES += PUBNUB_QT

--- a/qt/pubnub.hpp
+++ b/qt/pubnub.hpp
@@ -514,7 +514,201 @@ namespace pubnub {
                 (options & ignoreSecureConnectionRequirement) != 0
                 );
         }
-#endif        
+#endif
+
+#if PUBNUB_USE_LOGGER
+        /** Add a custom logger to the context logging subsystem.
+         *
+         * Registers a custom logger that will receive log messages
+         * from this context. Multiple loggers can be registered.
+         *
+         * @param logger Pointer to the custom logger (created with
+         *               `pubnub_logger_alloc`).
+         * @retval 0 on success.
+         * @retval -1 on failure (NULL pointer or already added).
+         *
+         * @code
+         * static void my_info(const pubnub_logger_t*      logger,
+         *                     const pubnub_log_message_t* message) {
+         *     if (message->message_type == PUBNUB_LOG_MESSAGE_TYPE_TEXT) {
+         *         const pubnub_log_message_text_t* text =
+         *             (const pubnub_log_message_text_t*)message;
+         *         printf("[INFO] %s\n", text->message);
+         *     }
+         * }
+         *
+         * static const struct pubnub_logger_interface my_vtable = {
+         *     .trace = NULL, .debug = NULL, .info = my_info,
+         *     .warn = NULL, .error = NULL, .destroy = NULL,
+         * };
+         *
+         * pubnub_logger_t* logger = pubnub_logger_alloc(&my_vtable, NULL);
+         * ctx.logger_add(logger);
+         * // ... use PubNub context ...
+         * ctx.logger_remove(logger);
+         * pubnub_logger_free(&logger);
+         * @endcode
+         *
+         * @see pubnub_logger_alloc
+         */
+        int logger_add(pubnub_logger_t* logger) {
+            return d_pbqt.logger_add(logger);
+        }
+
+        /** Remove a custom logger from the context logging subsystem.
+         *
+         * @note It is the caller's responsibility to call
+         *       `pubnub_logger_free` after removing.
+         *
+         * @param logger Pointer to the custom logger to remove.
+         * @retval 0 on success.
+         * @retval -1 on failure (logger not found or NULL pointer).
+         *
+         * @code
+         * ctx.logger_remove(logger);
+         * pubnub_logger_free(&logger);
+         * @endcode
+         */
+        int logger_remove(pubnub_logger_t* logger) {
+            return d_pbqt.logger_remove(logger);
+        }
+
+        /** Remove all custom loggers from the context logging
+         * subsystem.
+         *
+         * @note It is the caller's responsibility to call
+         *       `pubnub_logger_free` for each logger after this call.
+         *
+         * @code
+         * ctx.logger_remove_all();
+         * pubnub_logger_free(&logger1);
+         * pubnub_logger_free(&logger2);
+         * @endcode
+         */
+        void logger_remove_all() {
+            d_pbqt.logger_remove_all();
+        }
+
+        /** Set the minimum log level for the context logging
+         * subsystem.
+         *
+         * Only messages with level >= @p level will be dispatched to
+         * registered loggers.
+         *
+         * @param level The minimum log level.
+         *
+         * @code
+         * // Only receive warning and error messages.
+         * ctx.set_log_level(PUBNUB_LOG_LEVEL_WARNING);
+         * @endcode
+         */
+        void set_log_level(pubnub_log_level level) {
+            d_pbqt.set_log_level(level);
+        }
+
+        /** Get the current minimum log level for the context logging
+         * subsystem.
+         *
+         * @b Default: `PUBNUB_LOG_LEVEL_DEBUG`.
+         *
+         * @return The current minimum log level.
+         *
+         * @code
+         * pubnub_log_level level = ctx.log_level();
+         * @endcode
+         */
+        pubnub_log_level log_level() const {
+            return d_pbqt.log_level();
+        }
+
+        /** Log a text message.
+         *
+         * @param level    Log entry log level.
+         * @param location Call site location string.
+         * @param message  Text message to log.
+         *
+         * @code
+         * ctx.log_text(PUBNUB_LOG_LEVEL_INFO,
+         *              "my_app.cpp:42",
+         *              "Subscription connected");
+         * @endcode
+         */
+        void log_text(pubnub_log_level level,
+                      char const* location,
+                      char const* message) {
+            d_pbqt.log_text(level, location, message);
+        }
+
+        /** Log a text message from a std::string.
+         *
+         * @param level    Log entry log level.
+         * @param location Call site location string.
+         * @param message  Text message to log.
+         *
+         * @code
+         * std::string msg = "Publishing to channel: " + channel;
+         * ctx.log_text(PUBNUB_LOG_LEVEL_DEBUG,
+         *              "my_app.cpp:55", msg);
+         * @endcode
+         */
+        void log_text(pubnub_log_level level,
+                      char const* location,
+                      std::string const& message) {
+            d_pbqt.log_text(level, location, message.c_str());
+        }
+
+        /** Log a structured object/data.
+         *
+         * @note The value is not freed by this function — caller
+         *       retains ownership.
+         *
+         * @param level    Log entry log level.
+         * @param location Call site location string.
+         * @param message  Structured value to log (map, array, or
+         *                 primitive).
+         * @param details  Optional description (can be NULL).
+         *
+         * @code
+         * pubnub_log_value_t params = pubnub_log_value_map_init();
+         * pubnub_log_value_t ch_val =
+         *     pubnub_log_value_string("my-channel");
+         * pubnub_log_value_map_set(&params, "channel", &ch_val);
+         * ctx.log_object(PUBNUB_LOG_LEVEL_DEBUG,
+         *                "my_app.cpp:70",
+         *                &params,
+         *                "publish parameters");
+         * @endcode
+         */
+        void log_object(pubnub_log_level level,
+                        char const* location,
+                        pubnub_log_value_t const* message,
+                        char const* details = NULL) {
+            d_pbqt.log_object(level, location, message, details);
+        }
+
+        /** Log an error with an error code and message.
+         *
+         * @note The log level is always `PUBNUB_LOG_LEVEL_ERROR`.
+         *
+         * @param location      Call site location string.
+         * @param error_code    Error code.
+         * @param error_message Error description.
+         * @param details       Additional error details (can be NULL).
+         *
+         * @code
+         * ctx.log_error("my_app.cpp:85", -1,
+         *               "Connection failed",
+         *               "Timeout after 30s");
+         * @endcode
+         */
+        void log_error(char const* location,
+                       int error_code,
+                       char const* error_message,
+                       char const* details = NULL) {
+            d_pbqt.log_error(location, error_code, error_message, details);
+        }
+#endif /* PUBNUB_USE_LOGGER */
+
         /// Frees the context and any other thing that needs to be
         /// freed/released.
         ~context() {}

--- a/qt/pubnub.pro
+++ b/qt/pubnub.pro
@@ -4,7 +4,7 @@ CONFIG += C++11
 mac:CONFIG -= app_bundle
 win32:CONFIG += console
 HEADERS += pubnub_qt.h pubnub_qt_sample.h
-SOURCES += pubnub_qt.cpp pubnub_qt_sample.cpp ../core/pubnub_ccore.c ../core/pubnub_ccore_pubsub.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c
+SOURCES += pubnub_qt.cpp pubnub_qt_sample.cpp ../core/pubnub_ccore.c ../core/pubnub_ccore_pubsub.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c ../core/pubnub_logger.c ../core/pbcc_logger_manager.c ../core/pubnub_log_value.c ../core/pubnub_stdio_logger.c
 win32:SOURCES += ../core/c99/snprintf.c
 
 DEFINES += PUBNUB_QT PUBNUB_QT_MOVE_TO_THREAD

--- a/qt/pubnub_gui.pro
+++ b/qt/pubnub_gui.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 QT += widgets network
 CONFIG += C++11
 HEADERS += pubnub_qt.h pubnub_qt_gui_sample.h
-SOURCES += pubnub_qt.cpp pubnub_qt_gui_sample.cpp ../core/pubnub_ccore_pubsub.c ../core/pubnub_ccore.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c ../core/pubnub_coreapi_ex.c 
+SOURCES += pubnub_qt.cpp pubnub_qt_gui_sample.cpp ../core/pubnub_ccore_pubsub.c ../core/pubnub_ccore.c ../core/pbcc_subscribe_v2.c ../core/pbcc_advanced_history.c ../core/pbcc_objects_api.c ../core/pbcc_actions_api.c ../core/pubnub_url_encode.c ../core/pubnub_assert_std.c ../core/pubnub_json_parse.c ../core/pubnub_helper.c ../lib/pbcrc32.c ../lib/pb_strnlen_s.c ../lib/pb_strncasecmp.c ../core/pubnub_memory_block.c ../core/pbcc_set_state.c ../core/pubnub_coreapi_ex.c ../core/pubnub_logger.c ../core/pbcc_logger_manager.c ../core/pubnub_log_value.c ../core/pubnub_stdio_logger.c
 win32:SOURCES += ../core/c99/snprintf.c
 
 DEFINES += PUBNUB_QT PUBNUB_QT_MOVE_TO_THREAD

--- a/qt/pubnub_qt.h
+++ b/qt/pubnub_qt.h
@@ -34,6 +34,10 @@ extern "C" {
 #include "core/pbcc_grant_token_api.h"
 #endif
 #include "core/pubnub_crypto.h"
+#if PUBNUB_USE_LOGGER
+#include "core/pubnub_logger.h"
+#include "core/pbcc_logger_manager.h"
+#endif
 }
 
 #include "cpp/tribool.hpp"
@@ -2021,6 +2025,193 @@ public:
     }
 #endif /* PUBNUB_CRYPTO_API */
 
+#if PUBNUB_USE_LOGGER
+    /** Add a custom logger to the context logging subsystem.
+     *
+     * Registers a custom logger that will receive log messages from
+     * this context. Multiple loggers can be registered.
+     *
+     * @param logger Pointer to the custom logger (created with
+     *               `pubnub_logger_alloc`).
+     * @retval 0 on success.
+     * @retval -1 on failure (NULL pointer or already added).
+     *
+     * @code
+     * static void my_info(const pubnub_logger_t*      logger,
+     *                     const pubnub_log_message_t* message) {
+     *     if (message->message_type == PUBNUB_LOG_MESSAGE_TYPE_TEXT) {
+     *         const pubnub_log_message_text_t* text =
+     *             (const pubnub_log_message_text_t*)message;
+     *         qDebug() << "[INFO]" << text->message;
+     *     }
+     * }
+     *
+     * static const struct pubnub_logger_interface my_vtable = {
+     *     .trace = NULL, .debug = NULL, .info = my_info,
+     *     .warn = NULL, .error = NULL, .destroy = NULL,
+     * };
+     *
+     * pubnub_logger_t* logger = pubnub_logger_alloc(&my_vtable, NULL);
+     * pn.logger_add(logger);
+     * // ... use PubNub context ...
+     * pn.logger_remove(logger);
+     * pubnub_logger_free(&logger);
+     * @endcode
+     *
+     * @see pubnub_logger_alloc
+     */
+    int logger_add(pubnub_logger_t* logger)
+    {
+        return pbcc_logger_manager_logger_add(
+            d_context->logger_manager, logger);
+    }
+
+    /** Remove a custom logger from the context logging subsystem.
+     *
+     * @note It is the caller's responsibility to call
+     *       `pubnub_logger_free` after removing.
+     *
+     * @param logger Pointer to the custom logger to remove.
+     * @retval 0 on success.
+     * @retval -1 on failure (logger not found or NULL pointer).
+     *
+     * @code
+     * pn.logger_remove(logger);
+     * pubnub_logger_free(&logger);
+     * @endcode
+     */
+    int logger_remove(pubnub_logger_t* logger)
+    {
+        return pbcc_logger_manager_logger_remove(
+            d_context->logger_manager, logger);
+    }
+
+    /** Remove all custom loggers from the context logging subsystem.
+     *
+     * @note It is the caller's responsibility to call
+     *       `pubnub_logger_free` for each logger after this call.
+     *
+     * @code
+     * pn.logger_remove_all();
+     * pubnub_logger_free(&logger1);
+     * pubnub_logger_free(&logger2);
+     * @endcode
+     */
+    void logger_remove_all()
+    {
+        pbcc_logger_manager_logger_remove_all(d_context->logger_manager);
+    }
+
+    /** Set the minimum log level for the context logging subsystem.
+     *
+     * Only messages with level >= @p level will be dispatched to
+     * registered loggers.
+     *
+     * @param level The minimum log level.
+     *
+     * @code
+     * // Only receive warning and error messages.
+     * pn.set_log_level(PUBNUB_LOG_LEVEL_WARNING);
+     * @endcode
+     */
+    void set_log_level(pubnub_log_level level)
+    {
+        pbcc_logger_manager_set_log_level(d_context->logger_manager, level);
+    }
+
+    /** Get the current minimum log level for the context logging
+     * subsystem.
+     *
+     * @b Default: `PUBNUB_LOG_LEVEL_DEBUG`.
+     *
+     * @return The current minimum log level.
+     *
+     * @code
+     * pubnub_log_level level = pn.log_level();
+     * @endcode
+     */
+    pubnub_log_level log_level() const
+    {
+        return pbcc_logger_manager_log_level(d_context->logger_manager);
+    }
+
+    /** Log a text message.
+     *
+     * @param level    Log entry log level.
+     * @param location Call site location string.
+     * @param message  Text message to log.
+     *
+     * @code
+     * pn.log_text(PUBNUB_LOG_LEVEL_INFO,
+     *             "my_app.cpp:42",
+     *             "Subscription connected");
+     * @endcode
+     */
+    void log_text(pubnub_log_level level,
+                  char const* location,
+                  char const* message)
+    {
+        pbcc_logger_manager_log_text(
+            d_context->logger_manager, level, location, message);
+    }
+
+    /** Log a structured object/data.
+     *
+     * @note The value is not freed by this function — caller retains
+     *       ownership.
+     *
+     * @param level    Log entry log level.
+     * @param location Call site location string.
+     * @param message  Structured value to log (map, array, or
+     *                 primitive).
+     * @param details  Optional description (can be NULL).
+     *
+     * @code
+     * pubnub_log_value_t params = pubnub_log_value_map_init();
+     * pubnub_log_value_t ch_val = pubnub_log_value_string("my-channel");
+     * pubnub_log_value_map_set(&params, "channel", &ch_val);
+     * pn.log_object(PUBNUB_LOG_LEVEL_DEBUG,
+     *               "my_app.cpp:70",
+     *               &params,
+     *               "publish parameters");
+     * @endcode
+     */
+    void log_object(pubnub_log_level level,
+                    char const* location,
+                    pubnub_log_value_t const* message,
+                    char const* details = NULL)
+    {
+        pbcc_logger_manager_log_object(
+            d_context->logger_manager, level, location, message, details);
+    }
+
+    /** Log an error with an error code and message.
+     *
+     * @note The log level is always `PUBNUB_LOG_LEVEL_ERROR`.
+     *
+     * @param location      Call site location string.
+     * @param error_code    Error code.
+     * @param error_message Error description.
+     * @param details       Additional error details (can be NULL).
+     *
+     * @code
+     * pn.log_error("my_app.cpp:85", -1,
+     *              "Connection failed", "Timeout after 30s");
+     * @endcode
+     */
+    void log_error(char const* location,
+                   int error_code,
+                   char const* error_message,
+                   char const* details = NULL)
+    {
+        pbcc_logger_manager_log_error(d_context->logger_manager,
+                                      PUBNUB_LOG_LEVEL_ERROR,
+                                      location,
+                                      error_code,
+                                      error_message,
+                                      details);
+    }
+#endif /* PUBNUB_USE_LOGGER */
 
 private slots:
     void httpFinished();


### PR DESCRIPTION
feat(log): add logging methods to C++ and Qt wrappers

Add new logger API methods to C++ `pubnub::context`, Qt `pubnub_qt`, and Qt `pubnub::context` classes, guarded by `PUBNUB_USE_LOGGER`.

refactor(log): fix type mismatch in here_now logging macros

Change `PUBNUB_LOG_MAP_SET_BOOL` to `PUBNUB_LOG_MAP_SET_NUMBER` for `opt.limit` and `opt.offset` (both `unsigned`) in `pubnub_here_now_ex` and `pubnub_global_here_now_ex` so the actual numeric values are logged instead of being truncated to `true`/`false`.

refactor(free): replace clock()-based busy-wait with millisecond stopwatch

Use `pbms_start`/`pbms_elapsed` and `pb_sleep_ms` in `pubnub_free_with_timeout` to avoid a CPU-spinning loop and to fix portability issues with `clock()` on some platforms.

refactor(log): add debug logging for DNS resolution and connection

Add `PUBNUB_LOG_DEBUG` messages for hostname resolution, selected DNS server, resolved addresses, and address family across POSIX/Windows sockets, FreeRTOS, and Microchip Harmony platforms, and promote existing connect-address logs from `TRACE` to `DEBUG`.

refactor(log): adjust DNS response log levels

Adjust log levels for missing DNS record messages to better match the severity of each event.