### PR TITLE
Change async DNS resolution path for Windows

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "7.1.2"
+version: "7.1.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-04-16
+    version: v7.1.3
+    changes:
+      - type: improvement
+        text: "Add Windows async DNS resolution via `DnsQueryEx` and improve IPv6 fallback."
   - date: 2026-03-18
     version: v7.1.2
     changes:
@@ -1169,7 +1174,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1228,7 +1233,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1287,7 +1292,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1342,7 +1347,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1396,7 +1401,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1445,7 +1450,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1491,7 +1496,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.1.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.1.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v7.1.3
+April 16 2026
+
+#### Modified
+- Add Windows async DNS resolution via `DnsQueryEx` and improve IPv6 fallback.
+
 ## v7.1.2
 March 18 2026
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if (UNIX)
 elseif (WIN32 OR WIN64 OR MSVC)
     message(STATUS "Using Windows setup")
 
-    set(LDLIBS "ws2_32.lib IPHlpAPI.lib rpcrt4.lib")
+    set(LDLIBS "ws2_32.lib IPHlpAPI.lib rpcrt4.lib dnsapi.lib")
     set(OS_SOURCEFILES
             ${CMAKE_CURRENT_LIST_DIR}/windows/windows_socket_blocking_io.c
             ${CMAKE_CURRENT_LIST_DIR}/windows/pbtimespec_elapsed_ms.c
@@ -342,7 +342,8 @@ if (${USE_CALLBACK_API})
     elseif (WIN32 OR WIN64 OR MSVC)
         set(INTF_SOURCEFILES
                 ${INTF_SOURCEFILES}
-                ${CMAKE_CURRENT_LIST_DIR}/windows/pubnub_dns_system_servers.c)
+                ${CMAKE_CURRENT_LIST_DIR}/windows/pubnub_dns_system_servers.c
+                ${CMAKE_CURRENT_LIST_DIR}/windows/pbpal_dns_query_ex.c)
         if (${OPENSSL})
             set(INTF_SOURCEFILES
                     ${INTF_SOURCEFILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,9 +306,11 @@ endif ()
 set(INTF_SOURCEFILES)
 
 if (${USE_CALLBACK_API})
-    set(CORE_SOURCEFILES
-            ${CORE_SOURCEFILES}
-            ${CMAKE_CURRENT_LIST_DIR}/core/pubnub_dns_servers.c)
+    if (${USE_SET_DNS_SERVERS})
+        set(CORE_SOURCEFILES
+                ${CORE_SOURCEFILES}
+                ${CMAKE_CURRENT_LIST_DIR}/core/pubnub_dns_servers.c)
+    endif ()
 
     set(INTF_SOURCEFILES
             ${CMAKE_CURRENT_LIST_DIR}/core/pubnub_timer_list.c
@@ -324,9 +326,11 @@ if (${USE_CALLBACK_API})
             ${INTF_SOURCEFILES})
 
     if (UNIX)
-        set(INTF_SOURCEFILES
-                ${INTF_SOURCEFILES}
-                ${CMAKE_CURRENT_LIST_DIR}/posix/pubnub_dns_system_servers.c)
+        if (${USE_SET_DNS_SERVERS})
+            set(INTF_SOURCEFILES
+                    ${INTF_SOURCEFILES}
+                    ${CMAKE_CURRENT_LIST_DIR}/posix/pubnub_dns_system_servers.c)
+        endif ()
         if (${OPENSSL})
             set(INTF_SOURCEFILES
                     ${INTF_SOURCEFILES}
@@ -340,9 +344,13 @@ if (${USE_CALLBACK_API})
         endif ()
 
     elseif (WIN32 OR WIN64 OR MSVC)
+        if (${USE_SET_DNS_SERVERS})
+            set(INTF_SOURCEFILES
+                    ${INTF_SOURCEFILES}
+                    ${CMAKE_CURRENT_LIST_DIR}/windows/pubnub_dns_system_servers.c)
+        endif ()
         set(INTF_SOURCEFILES
                 ${INTF_SOURCEFILES}
-                ${CMAKE_CURRENT_LIST_DIR}/windows/pubnub_dns_system_servers.c
                 ${CMAKE_CURRENT_LIST_DIR}/windows/pbpal_dns_query_ex.c)
         if (${OPENSSL})
             set(INTF_SOURCEFILES

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -506,6 +506,25 @@ struct pubnub_ {
 #else  /* PUBNUB_USE_IPV6 */
     struct sockaddr_in dns_addr;
 #endif /* !PUBNUB_USE_IPV6 */
+
+#if defined(_WIN32)
+    /** Windows OS DNS resolution state (DnsQueryEx).
+        Used when no custom DNS servers are configured, allowing
+        the OS resolver to handle DNS (VPN-aware, uses system DNS cache).
+      */
+    struct pbpal_os_dns {
+        bool active;
+        DNS_QUERY_CANCEL cancel_a;
+        DNS_QUERY_CANCEL cancel_aaaa;
+        DNS_QUERY_RESULT query_result_a;
+        DNS_QUERY_RESULT query_result_aaaa;
+        /** Set by thread pool callback via InterlockedExchange. */
+        volatile LONG completed_a;
+        volatile LONG completed_aaaa;
+        volatile LONG status_a;
+        volatile LONG status_aaaa;
+    } os_dns;
+#endif /* defined(_WIN32) */
 #endif /* defined(PUBNUB_CALLBACK_API) */
 
     /** Subscribed channels and channel groups saved.

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.1.2"
+#define PUBNUB_SDK_VERSION "7.1.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/core/test/pubnub_internal.h
+++ b/core/test/pubnub_internal.h
@@ -5,6 +5,9 @@
 #if defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#ifdef PUBNUB_CALLBACK_API
+#include <windns.h>
+#endif
 typedef SOCKET pb_socket_t;
 #else
 #include <unistd.h>

--- a/lib/sockets/pbpal_ntf_callback_poller_poll.c
+++ b/lib/sockets/pbpal_ntf_callback_poller_poll.c
@@ -127,6 +127,14 @@ void pbpal_ntf_callback_update_socket(
                 return;
             }
         }
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+        /* Context not found — this happens when the initial
+           pbpal_ntf_callback_save_socket() was skipped because no socket
+           existed yet (e.g. Windows DnsQueryEx async DNS path).
+           Register now with the real socket. */
+        pbpal_ntf_callback_save_socket(data, pb);
+        return;
+#endif
     }
     PUBNUB_LOG_WARNING(
         pb,

--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -21,6 +21,9 @@
 #include <mstcpip.h>
 #include <winsock2.h>
 typedef ADDRESS_FAMILY sa_family_t;
+#if defined(PUBNUB_CALLBACK_API)
+#include "windows/pbpal_dns_query_ex.h"
+#endif
 #else
 #include "posix/pubnub_get_native_socket.h"
 #include <netinet/tcp.h>
@@ -58,16 +61,32 @@ typedef struct sockaddr_in sockaddr_inX_t;
 #endif /* PUBNUB_CALLBACK_API */
 
 #if PUBNUB_USE_IPV6
-/** Check whether the source address is a Global Unicast address (2000::/3).
+/** Check whether the source address is a Global Unicast address (2000::/3)
+ *  from a real interface — not a tunnel pseudo-interface.
  *
  *  Only addresses in this range are routable on the public IPv6 internet.
  *  Everything else — loopback (::1), link-local (fe80::/10),
  *  ULA (fc00::/7), site-local (fec0::/10, deprecated), multicast (ff00::/8),
  *  unspecified (::) — cannot reach global destinations.
+ *
+ *  Teredo (2001:0000::/32) and 6to4 (2002::/16) are excluded even though
+ *  they fall within 2000::/3: both are deprecated tunnel mechanisms
+ *  (RFC 7526 deprecates 6to4; Teredo is off by default on Windows 10+) that
+ *  Windows may assign a globally-scoped source address for even when there is
+ *  no real IPv6 upstream, causing false-positive detection of IPv6 support.
  */
 static bool is_global_unicast_ipv6(const struct in6_addr* addr)
 {
-    return (addr->s6_addr[0] & 0xe0) == 0x20;
+    if ((addr->s6_addr[0] & 0xe0) != 0x20)
+        return false;
+    /* Teredo: 2001:0000::/32 */
+    if (addr->s6_addr[0] == 0x20 && addr->s6_addr[1] == 0x01 &&
+        addr->s6_addr[2] == 0x00 && addr->s6_addr[3] == 0x00)
+        return false;
+    /* 6to4: 2002::/16 */
+    if (addr->s6_addr[0] == 0x20 && addr->s6_addr[1] == 0x02)
+        return false;
+    return true;
 }
 
 /** Check whether the host has a usable global IPv6 route.
@@ -271,9 +290,15 @@ static void get_dns_ip(
                 (dns_check->dns_server_check & dns_check->dns_mask)) {
                 dns_check->dns_mask <<= 1;
                 if (AF_INET == family) {
-                    // If only IPv4 supported we don't have to fall back to the
-                    // IPv6.
                     get_default_ipv4_dns_ip(pb, (struct pubnub_ipv4_address*)p);
+                    addr->sa_family = AF_INET;
+                }
+                else if (pubnub_dns_read_system_servers_ipv4(
+                             pb, (struct pubnub_ipv4_address*)p, 1) == 1) {
+                    /* AF_INET6 family but system has IPv4 DNS: use it to
+                       avoid the dead Google IPv6 path on broken IPv6 networks.
+                       Do NOT fall back to 8.8.8.8 here — that would prevent
+                       the IPv6 fallback below from running on IPv6-only hosts. */
                     addr->sa_family = AF_INET;
                 }
             }
@@ -326,11 +351,15 @@ static void get_dns_ip(pubnub_t* pb, sa_family_t family, struct sockaddr* addr)
         if ((pubnub_get_dns_primary_server_ipv4(
                  pb, (struct pubnub_ipv4_address*)p) == -1) &&
             (pubnub_get_dns_secondary_server_ipv4(
-                 pb, (struct pubnub_ipv4_address*)p) == -1) &&
-            AF_INET == family) {
-            // If only IPv4 supported we don't have to fall back to the IPv6.
-            get_default_ipv4_dns_ip(pb, (struct pubnub_ipv4_address*)p);
-            addr->sa_family = AF_INET;
+                 pb, (struct pubnub_ipv4_address*)p) == -1)) {
+            if (AF_INET == family) {
+                get_default_ipv4_dns_ip(pb, (struct pubnub_ipv4_address*)p);
+                addr->sa_family = AF_INET;
+            }
+            else if (pubnub_dns_read_system_servers_ipv4(
+                         pb, (struct pubnub_ipv4_address*)p, 1) == 1) {
+                addr->sa_family = AF_INET;
+            }
         }
 #if PUBNUB_USE_IPV6
     }
@@ -620,7 +649,10 @@ static enum pbpal_resolv_n_connect_result try_TCP_connect_spare_address(
     }
 #endif /* PUBNUB_USE_IPV6 */
 
-    if ((AF_INET == family || pbpal_connect_failed == rslt) &&
+    if ((AF_INET == family
+         || pbpal_connect_failed == rslt
+         || (AF_INET6 == family
+             && spare_addresses->ipv6_index >= spare_addresses->n_ipv6)) &&
         spare_addresses->ipv4_index < spare_addresses->n_ipv4) {
 #if PUBNUB_LOG_ENABLED(TRACE)
         if (pubnub_logger_should_log(pb, PUBNUB_LOG_LEVEL_TRACE)) {
@@ -788,6 +820,16 @@ enum pbpal_resolv_n_connect_result pbpal_resolv_and_connect(pubnub_t* pb)
             if (rslt != pbpal_resolv_resource_failure) return rslt;
         }
 #endif /* !defined(_WIN32) */
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+        if (SOCKET_INVALID == pb->pal.socket && pbpal_os_dns_should_use(pb)) {
+            memset(&pb->dns_queries, 0, sizeof(pb->dns_queries));
+            if (0 == pbpal_os_dns_start(pb, origin)) {
+                return pbpal_resolv_sent;
+            }
+            PUBNUB_LOG_WARNING(pb,
+                               "DnsQueryEx failed, falling back to UDP DNS");
+        }
+#endif /* defined(_WIN32) && defined(PUBNUB_CALLBACK_API) */
         if (SOCKET_INVALID == pb->pal.socket) {
             /* Reset DNS server address at the start of new resolution */
             memset(&pb->dns_queries, 0, sizeof(pb->dns_queries));
@@ -1001,6 +1043,20 @@ enum pbpal_resolv_n_connect_result pbpal_check_resolv_and_connect(pubnub_t* pb)
 #if PUBNUB_PROXY_API
         if (pbproxyNONE != pb->proxy_type) { port = pb->proxy_port; }
 #endif
+
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+        if (pb->os_dns.active) {
+            switch (pbpal_os_dns_check(pb)) {
+            case -1: return pbpal_resolv_failed_rcv;
+            case +1: return pbpal_resolv_rcv_wouldblock;
+            case 0:  break;
+            }
+            /* DnsQueryEx path: no UDP socket to close. Jump to address
+               selection which is shared with the legacy UDP path. */
+            goto pbpal_pick_address_and_connect;
+        }
+#endif /* defined(_WIN32) && defined(PUBNUB_CALLBACK_API) */
+
         /* Reuse the DNS server address that was stored when sending the query
          */
         switch (read_dns_response(
@@ -1023,6 +1079,9 @@ enum pbpal_resolv_n_connect_result pbpal_check_resolv_and_connect(pubnub_t* pb)
         }
         socket_close(pb->pal.socket);
 
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+pbpal_pick_address_and_connect:
+#endif
 #if PUBNUB_USE_IPV6
         if (is_ipv6_supported() &&
             !IN6_IS_ADDR_UNSPECIFIED(
@@ -1062,7 +1121,8 @@ enum pbpal_resolv_n_connect_result pbpal_check_resolv_and_connect(pubnub_t* pb)
             else if (AF_INET6 == ((struct sockaddr*)&dest)->sa_family) {
                 pb->flags.retry_after_close =
                     (++pb->spare_addresses.ipv6_index <
-                     pb->spare_addresses.n_ipv6);
+                     pb->spare_addresses.n_ipv6)
+                    || (pb->spare_addresses.n_ipv4 > 0);
             }
 #endif
 #if PUBNUB_USE_SSL
@@ -1144,14 +1204,35 @@ enum pbpal_resolv_n_connect_result pbpal_check_connect(pubnub_t* pb)
             "Time since last DNS query: %ld seconds",
             (long)(time(NULL) -
                    pb->spare_addresses.time_of_the_last_dns_query));
+#if PUBNUB_USE_IPV6
+        {
+            /* Determine the failed connect's address family from the socket
+               so we increment the right spare-address index and allow
+               fallback to IPv4 when all IPv6 addresses are exhausted. */
+            struct sockaddr_storage local = { 0 };
+            socklen_t               len   = sizeof(local);
+            const int               family =
+                (0 == getsockname(pb->pal.socket,
+                                  (struct sockaddr*)&local,
+                                  &len))
+                    ? local.ss_family
+                    : AF_INET;
+            if (AF_INET6 == family) {
+                pb->flags.retry_after_close =
+                    (++pb->spare_addresses.ipv6_index <
+                     pb->spare_addresses.n_ipv6)
+                    || (pb->spare_addresses.n_ipv4 > 0);
+            }
+            else {
+                pb->flags.retry_after_close =
+                    (++pb->spare_addresses.ipv4_index <
+                     pb->spare_addresses.n_ipv4);
+            }
+        }
+#else  /* PUBNUB_USE_IPV6 */
         pb->flags.retry_after_close =
             (++pb->spare_addresses.ipv4_index < pb->spare_addresses.n_ipv4);
-#if PUBNUB_USE_IPV6
-        if (!pb->flags.retry_after_close) {
-            pb->flags.retry_after_close =
-                (++pb->spare_addresses.ipv6_index < pb->spare_addresses.n_ipv6);
-        }
-#endif
+#endif /* PUBNUB_USE_IPV6 */
 #if PUBNUB_USE_SSL
         pb->flags.trySSL = pb->options.useSSL;
 #endif

--- a/lib/sockets/pbpal_sockets.c
+++ b/lib/sockets/pbpal_sockets.c
@@ -5,6 +5,9 @@
 #include "core/pubnub_ntf_sync.h"
 #include "core/pubnub_netcore.h"
 #include "core/pubnub_assert.h"
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+#include "windows/pbpal_dns_query_ex.h"
+#endif
 #if PUBNUB_USE_LOGGER
 #include "core/pubnub_logger.h"
 #endif // PUBNUB_USE_LOGGER
@@ -299,6 +302,12 @@ void pbpal_forget(pubnub_t* pb)
 int pbpal_close(pubnub_t* pb)
 {
     pb->unreadlen = 0;
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+    /* Cancel any pending DnsQueryEx queries. Must happen regardless of
+       socket state because the DnsQueryEx path does not create a UDP
+       socket (pb->pal.socket stays SOCKET_INVALID). */
+    pbpal_os_dns_cancel(pb);
+#endif
     if (pb->pal.socket != SOCKET_INVALID) {
         pbntf_lost_socket(pb);
         socket_close(pb->pal.socket);
@@ -313,6 +322,9 @@ int pbpal_close(pubnub_t* pb)
 
 void pbpal_free(pubnub_t* pb)
 {
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+    pbpal_os_dns_cancel(pb);
+#endif
     if (pb->pal.socket != SOCKET_INVALID) {
         /* While this should not happen, it doesn't hurt to be paranoid.
          */

--- a/lib/sockets/pbpal_sockets.c
+++ b/lib/sockets/pbpal_sockets.c
@@ -75,6 +75,9 @@ void pbpal_init(pubnub_t* pb)
 #if PUBNUB_USE_MULTIPLE_ADDRESSES
     pbpal_multiple_addresses_reset_counters(&pb->spare_addresses);
 #endif
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+    memset(&pb->os_dns, 0, sizeof pb->os_dns);
+#endif
 }
 
 

--- a/make/common/source_files.mk
+++ b/make/common/source_files.mk
@@ -268,6 +268,11 @@ DNS_SERVERS_SOURCE_FILES_POSIX = \
 DNS_SERVERS_SOURCE_FILES_WINDOWS = \
     ../windows/pubnub_dns_system_servers.c
 
+# Windows OS DNS resolver (DnsQueryEx) support for callback API.
+# Falls back to the OS resolver when no custom DNS servers are configured.
+DNS_QUERY_EX_SOURCE_FILES_WINDOWS = \
+    ../windows/pbpal_dns_query_ex.c
+
 # Custom DNS servers IPv4 support feature source files.
 #
 # Important: Can be used only together with `PUBNUB_CALLBACK_API` flag.

--- a/make/windows_compiler_linker_flags.mk
+++ b/make/windows_compiler_linker_flags.mk
@@ -46,9 +46,9 @@ COMPILER_FLAGS = $(NMAKE_FLAGS) $(USER_C_FLAGS)
 ###############################################################################
 
 !if $(WITH_GCC)
-LDLIBS = -lws2_32 -lrpcrt4 -lsecur32
+LDLIBS = -lws2_32 -lrpcrt4 -lsecur32 -ldnsapi
 !else
-LDLIBS = ws2_32.lib IPHlpAPI.lib rpcrt4.lib
+LDLIBS = ws2_32.lib IPHlpAPI.lib rpcrt4.lib dnsapi.lib
 !endif
 
 # TODO: Add support of OpenSSL when built with GCC if possible.

--- a/make/windows_source_files.mk
+++ b/make/windows_source_files.mk
@@ -134,6 +134,11 @@ CALLBACK_SOURCE_FILES_ = \
 !endif
 !endif
 
+# Windows OS DNS resolver (DnsQueryEx) for callback API.
+CALLBACK_SOURCE_FILES_ = \
+    $(CALLBACK_SOURCE_FILES_)              \
+    $(DNS_QUERY_EX_SOURCE_FILES_WINDOWS)
+
 # Single channel history feature source files.
 !if $(USE_FETCH_HISTORY)
 SOURCE_FILES_ = \

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -98,6 +98,9 @@ void pbpal_init(pubnub_t* pb)
 #if PUBNUB_USE_MULTIPLE_ADDRESSES
     pbpal_multiple_addresses_reset_counters(&pb->spare_addresses);
 #endif
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+    memset(&pb->os_dns, 0, sizeof pb->os_dns);
+#endif
 }
 
 

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -7,6 +7,9 @@
 #include "core/pubnub_ntf_sync.h"
 #include "core/pubnub_netcore.h"
 #include "core/pubnub_assert.h"
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+#include "windows/pbpal_dns_query_ex.h"
+#endif
 #if PUBNUB_USE_LOGGER
 #include "core/pbcc_logger_manager.h"
 #endif // PUBNUB_USE_LOGGER
@@ -438,6 +441,9 @@ void pbpal_forget(pubnub_t* pb)
 int pbpal_close(pubnub_t* pb)
 {
     pb->unreadlen = 0;
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+    pbpal_os_dns_cancel(pb);
+#endif
     if (pb->pal.ssl != NULL) {
         SSL_shutdown(pb->pal.ssl);
         SSL_free(pb->pal.ssl);
@@ -457,6 +463,9 @@ int pbpal_close(pubnub_t* pb)
 
 void pbpal_free(pubnub_t* pb)
 {
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+    pbpal_os_dns_cancel(pb);
+#endif
     /* While this should not happen, it doesn't hurt to 'catch' it, if it
      * happens..
      */

--- a/openssl/pubnub_internal.h
+++ b/openssl/pubnub_internal.h
@@ -12,6 +12,10 @@
 */
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#ifdef PUBNUB_CALLBACK_API
+#include <windns.h>
+#pragma comment(lib, "dnsapi.lib")
+#endif
 #else
 #include <unistd.h>
 #include <sys/socket.h>

--- a/openssl/pubnub_ntf_callback_windows.c
+++ b/openssl/pubnub_ntf_callback_windows.c
@@ -13,6 +13,7 @@
 #include "lib/sockets/pbpal_ntf_callback_poller_poll.h"
 #include "core/pbpal_ntf_callback_queue.h"
 #include "core/pbpal_ntf_callback_handle_timer_list.h"
+#include "windows/pbpal_dns_query_ex.h"
 
 #include <process.h>
 
@@ -177,6 +178,8 @@ MAYBE_INLINE int pbntf_got_socket_callback(pubnub_t* pb)
 
 MAYBE_INLINE void pbntf_lost_socket_callback(pubnub_t* pb)
 {
+    pbpal_os_dns_cancel(pb);
+
     EnterCriticalSection(&m_watcher.mutw);
     pbpal_ntf_callback_remove_socket(m_watcher.poll, pb);
     LeaveCriticalSection(&m_watcher.mutw);

--- a/windows/pbpal_dns_query_ex.c
+++ b/windows/pbpal_dns_query_ex.c
@@ -88,7 +88,7 @@ int pbpal_os_dns_start(pubnub_t* pb, const char* hostname)
                  CP_UTF8, 0, hostname, -1,
                  whostname, PBDNS_MAX_HOSTNAME_WCHARS)) {
         PUBNUB_LOG_ERROR(pb,
-                         "DnsQueryEx: MultiByteToWideChar failed for '%s'\n",
+                         "DnsQueryEx: MultiByteToWideChar failed for '%s'",
                          hostname);
         return -1;
     }
@@ -116,7 +116,7 @@ int pbpal_os_dns_start(pubnub_t* pb, const char* hostname)
                         &pb->os_dns.cancel_a);
     if (status != DNS_REQUEST_PENDING && status != ERROR_SUCCESS) {
         PUBNUB_LOG_ERROR(pb,
-                         "DnsQueryEx(A) failed: status=%ld\n",
+                         "DnsQueryEx(A) failed: status=%ld",
                          (long)status);
         pb->os_dns.active = false;
         return -1;
@@ -144,7 +144,7 @@ int pbpal_os_dns_start(pubnub_t* pb, const char* hostname)
     if (status != DNS_REQUEST_PENDING && status != ERROR_SUCCESS) {
         PUBNUB_LOG_WARNING(pb,
                            "DnsQueryEx(AAAA) failed: status=%ld, "
-                           "continuing with A only\n",
+                           "continuing with A only",
                            (long)status);
         /* Mark AAAA as completed so we don't wait for it. */
         InterlockedExchange(&pb->os_dns.status_aaaa,
@@ -161,7 +161,7 @@ int pbpal_os_dns_start(pubnub_t* pb, const char* hostname)
 #endif
 
     PUBNUB_LOG_TRACE(pb,
-                     "DnsQueryEx started for '%s'\n",
+                     "DnsQueryEx started for '%s'",
                      hostname);
     return 0;
 }
@@ -237,7 +237,7 @@ int pbpal_os_dns_check(pubnub_t* pb)
                 got_any = true;
                 PUBNUB_LOG_TRACE(pb,
                                  "DnsQueryEx A resolved: %u.%u.%u.%u "
-                                 "(TTL=%lu)\n",
+                                 "(TTL=%lu)",
                                  ((uint8_t*)&rec->Data.A.IpAddress)[0],
                                  ((uint8_t*)&rec->Data.A.IpAddress)[1],
                                  ((uint8_t*)&rec->Data.A.IpAddress)[2],
@@ -267,7 +267,7 @@ int pbpal_os_dns_check(pubnub_t* pb)
         pb->dns_queries.received_a = true;
         pb->dns_queries.sent_a     = true;
         PUBNUB_LOG_DEBUG(pb,
-                         "DnsQueryEx A: no records (status=%ld)\n",
+                         "DnsQueryEx A: no records (status=%ld)",
                          (long)pb->os_dns.status_a);
     }
 
@@ -293,7 +293,7 @@ int pbpal_os_dns_check(pubnub_t* pb)
                 pb->dns_queries.received_aaaa = true;
                 pb->dns_queries.sent_aaaa     = true;
                 got_any = true;
-                PUBNUB_LOG_TRACE(pb, "DnsQueryEx AAAA resolved (TTL=%lu)\n",
+                PUBNUB_LOG_TRACE(pb, "DnsQueryEx AAAA resolved (TTL=%lu)",
                                  (unsigned long)rec->dwTtl);
             }
 #if PUBNUB_USE_MULTIPLE_ADDRESSES
@@ -316,7 +316,7 @@ int pbpal_os_dns_check(pubnub_t* pb)
         pb->dns_queries.received_aaaa = true;
         pb->dns_queries.sent_aaaa     = true;
         PUBNUB_LOG_DEBUG(pb,
-                         "DnsQueryEx AAAA: no records (status=%ld)\n",
+                         "DnsQueryEx AAAA: no records (status=%ld)",
                          (long)pb->os_dns.status_aaaa);
     }
 #endif /* PUBNUB_USE_IPV6 */
@@ -343,7 +343,7 @@ int pbpal_os_dns_check(pubnub_t* pb)
     if (!got_any) {
         PUBNUB_LOG_ERROR(pb,
                          "DnsQueryEx: no addresses resolved "
-                         "(A status=%ld, AAAA status=%ld)\n",
+                         "(A status=%ld, AAAA status=%ld)",
                          (long)pb->os_dns.status_a,
                          (long)pb->os_dns.status_aaaa);
         return -1;

--- a/windows/pbpal_dns_query_ex.c
+++ b/windows/pbpal_dns_query_ex.c
@@ -1,0 +1,390 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+/**
+ * @file pbpal_dns_query_ex.c
+ * @brief Windows DnsQueryEx-based async DNS resolution for the callback API.
+ *
+ * When no user-provided DNS servers are configured, this module uses the
+ * Windows OS resolver (DnsQueryEx) instead of the SDK's custom UDP DNS.
+ * This ensures DNS queries go through the OS DNS cache and respect VPN
+ * routing (NRPT rules, split-tunnel, etc.).
+ *
+ * Minimum Windows version: Windows 8 (DnsQueryEx) / 8.1 (DnsCancelQuery).
+ */
+
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+
+#include "pbpal_dns_query_ex.h"
+
+#include <pubnub_internal.h>
+#include "core/pubnub_assert.h"
+#include "core/pubnub_dns_servers.h"
+#include "core/pubnub_log.h"
+
+#include <windns.h>
+#include <windows.h>
+#include <string.h>
+#include <time.h>
+
+#pragma comment(lib, "dnsapi.lib")
+
+
+/* Maximum DNS hostname length (RFC 1035: 253 chars + NUL). */
+#define PBDNS_MAX_HOSTNAME_WCHARS 256
+
+
+/* ------------------------------------------------------------------ */
+/*  Forward declarations for completion callbacks                      */
+/* ------------------------------------------------------------------ */
+
+static VOID WINAPI os_dns_completion_a(PVOID   pQueryContext,
+                                       PDNS_QUERY_RESULT pQueryResults);
+#if PUBNUB_USE_IPV6
+static VOID WINAPI os_dns_completion_aaaa(PVOID   pQueryContext,
+                                          PDNS_QUERY_RESULT pQueryResults);
+#endif
+
+
+/* ------------------------------------------------------------------ */
+/*  pbpal_os_dns_should_use                                            */
+/* ------------------------------------------------------------------ */
+
+bool pbpal_os_dns_should_use(pubnub_t* pb)
+{
+    struct pubnub_ipv4_address tmp4;
+
+    if (pubnub_get_dns_primary_server_ipv4(pb, &tmp4) == 0)
+        return false;
+    if (pubnub_get_dns_secondary_server_ipv4(pb, &tmp4) == 0)
+        return false;
+
+#if PUBNUB_USE_IPV6
+    {
+        struct pubnub_ipv6_address tmp6;
+        if (pubnub_get_dns_primary_server_ipv6(pb, &tmp6) == 0)
+            return false;
+        if (pubnub_get_dns_secondary_server_ipv6(pb, &tmp6) == 0)
+            return false;
+    }
+#endif
+
+    return true;
+}
+
+
+/* ------------------------------------------------------------------ */
+/*  pbpal_os_dns_start                                                 */
+/* ------------------------------------------------------------------ */
+
+int pbpal_os_dns_start(pubnub_t* pb, const char* hostname)
+{
+    DNS_QUERY_REQUEST request;
+    DNS_STATUS        status;
+    WCHAR             whostname[PBDNS_MAX_HOSTNAME_WCHARS];
+
+    PUBNUB_ASSERT_OPT(pb != NULL);
+    PUBNUB_ASSERT_OPT(hostname != NULL);
+
+    if (0 == MultiByteToWideChar(
+                 CP_UTF8, 0, hostname, -1,
+                 whostname, PBDNS_MAX_HOSTNAME_WCHARS)) {
+        PUBNUB_LOG_ERROR(pb,
+                         "DnsQueryEx: MultiByteToWideChar failed for '%s'\n",
+                         hostname);
+        return -1;
+    }
+
+    /* Cancel any pending queries from a previous transaction, then
+       reset state. DnsCancelQuery is synchronous -- the completion
+       callback fires before it returns -- so no stale callback can
+       arrive after this point. */
+    pbpal_os_dns_cancel(pb);
+    memset(&pb->os_dns, 0, sizeof pb->os_dns);
+    pb->os_dns.active = true;
+
+    memset(&request, 0, sizeof request);
+    request.Version             = DNS_QUERY_REQUEST_VERSION1;
+    request.QueryName           = whostname;
+    request.QueryType           = DNS_TYPE_A;
+    request.QueryOptions        = DNS_QUERY_STANDARD;
+    request.pQueryContext        = pb;
+    request.pQueryCompletionCallback = os_dns_completion_a;
+
+    pb->os_dns.query_result_a.Version = DNS_QUERY_REQUEST_VERSION1;
+
+    status = DnsQueryEx(&request,
+                        &pb->os_dns.query_result_a,
+                        &pb->os_dns.cancel_a);
+    if (status != DNS_REQUEST_PENDING && status != ERROR_SUCCESS) {
+        PUBNUB_LOG_ERROR(pb,
+                         "DnsQueryEx(A) failed: status=%ld\n",
+                         (long)status);
+        pb->os_dns.active = false;
+        return -1;
+    }
+    if (status == ERROR_SUCCESS) {
+        /* Synchronous completion -- mark as done. */
+        InterlockedExchange(&pb->os_dns.status_a, (LONG)ERROR_SUCCESS);
+        InterlockedExchange(&pb->os_dns.completed_a, 1);
+    }
+
+#if PUBNUB_USE_IPV6
+    memset(&request, 0, sizeof request);
+    request.Version             = DNS_QUERY_REQUEST_VERSION1;
+    request.QueryName           = whostname;
+    request.QueryType           = DNS_TYPE_AAAA;
+    request.QueryOptions        = DNS_QUERY_STANDARD;
+    request.pQueryContext        = pb;
+    request.pQueryCompletionCallback = os_dns_completion_aaaa;
+
+    pb->os_dns.query_result_aaaa.Version = DNS_QUERY_REQUEST_VERSION1;
+
+    status = DnsQueryEx(&request,
+                        &pb->os_dns.query_result_aaaa,
+                        &pb->os_dns.cancel_aaaa);
+    if (status != DNS_REQUEST_PENDING && status != ERROR_SUCCESS) {
+        PUBNUB_LOG_WARNING(pb,
+                           "DnsQueryEx(AAAA) failed: status=%ld, "
+                           "continuing with A only\n",
+                           (long)status);
+        /* Mark AAAA as completed so we don't wait for it. */
+        InterlockedExchange(&pb->os_dns.status_aaaa,
+                            (LONG)DNS_ERROR_RCODE_SERVER_FAILURE);
+        InterlockedExchange(&pb->os_dns.completed_aaaa, 1);
+    }
+    if (status == ERROR_SUCCESS) {
+        InterlockedExchange(&pb->os_dns.status_aaaa, (LONG)ERROR_SUCCESS);
+        InterlockedExchange(&pb->os_dns.completed_aaaa, 1);
+    }
+#else
+    /* IPv6 disabled -- mark AAAA as completed immediately. */
+    InterlockedExchange(&pb->os_dns.completed_aaaa, 1);
+#endif
+
+    PUBNUB_LOG_TRACE(pb,
+                     "DnsQueryEx started for '%s'\n",
+                     hostname);
+    return 0;
+}
+
+
+/* ------------------------------------------------------------------ */
+/*  Completion callbacks  (run on Windows thread pool thread)           */
+/* ------------------------------------------------------------------ */
+
+static VOID WINAPI os_dns_completion_a(PVOID             pQueryContext,
+                                       PDNS_QUERY_RESULT pQueryResults)
+{
+    pubnub_t* pb = (pubnub_t*)pQueryContext;
+
+    InterlockedExchange(&pb->os_dns.status_a,
+                        (LONG)pQueryResults->QueryStatus);
+    InterlockedExchange(&pb->os_dns.completed_a, 1);
+
+    /* Wake the socket-watcher thread so the FSM picks this up. */
+    pbntf_requeue_for_processing(pb);
+}
+
+
+#if PUBNUB_USE_IPV6
+static VOID WINAPI os_dns_completion_aaaa(PVOID             pQueryContext,
+                                          PDNS_QUERY_RESULT pQueryResults)
+{
+    pubnub_t* pb = (pubnub_t*)pQueryContext;
+
+    InterlockedExchange(&pb->os_dns.status_aaaa,
+                        (LONG)pQueryResults->QueryStatus);
+    InterlockedExchange(&pb->os_dns.completed_aaaa, 1);
+
+    pbntf_requeue_for_processing(pb);
+}
+#endif /* PUBNUB_USE_IPV6 */
+
+
+/* ------------------------------------------------------------------ */
+/*  pbpal_os_dns_check                                                 */
+/* ------------------------------------------------------------------ */
+
+int pbpal_os_dns_check(pubnub_t* pb)
+{
+    PDNS_RECORD rec;
+    bool        got_any = false;
+
+    PUBNUB_ASSERT_OPT(pb != NULL);
+
+    if (!InterlockedCompareExchange(&pb->os_dns.completed_a, 0, 0)
+        || !InterlockedCompareExchange(&pb->os_dns.completed_aaaa, 0, 0)) {
+        return +1;
+    }
+
+    if ((DNS_STATUS)pb->os_dns.status_a == ERROR_SUCCESS
+        && pb->os_dns.query_result_a.pQueryRecords != NULL) {
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+        int ipv4_idx = 0;
+#endif
+        for (rec = pb->os_dns.query_result_a.pQueryRecords;
+             rec != NULL;
+             rec = rec->pNext) {
+            if (rec->wType != DNS_TYPE_A)
+                continue;
+
+            if (!pb->dns_queries.received_a) {
+                pb->dns_queries.dns_a_addr.sin_family = AF_INET;
+                memcpy(&pb->dns_queries.dns_a_addr.sin_addr.s_addr,
+                       &rec->Data.A.IpAddress,
+                       4);
+                pb->dns_queries.received_a = true;
+                pb->dns_queries.sent_a     = true;
+                got_any = true;
+                PUBNUB_LOG_TRACE(pb,
+                                 "DnsQueryEx A resolved: %u.%u.%u.%u "
+                                 "(TTL=%lu)\n",
+                                 ((uint8_t*)&rec->Data.A.IpAddress)[0],
+                                 ((uint8_t*)&rec->Data.A.IpAddress)[1],
+                                 ((uint8_t*)&rec->Data.A.IpAddress)[2],
+                                 ((uint8_t*)&rec->Data.A.IpAddress)[3],
+                                 (unsigned long)rec->dwTtl);
+            }
+            /* Store ALL addresses (including primary) in the spare
+               array to match the legacy DNS codec behavior.  The retry
+               logic increments ipv4_index before trying the next one. */
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+            if (ipv4_idx < PUBNUB_MAX_IPV4_ADDRESSES) {
+                memcpy(pb->spare_addresses.ipv4_addresses[ipv4_idx].ipv4,
+                       &rec->Data.A.IpAddress,
+                       4);
+                pb->spare_addresses.ttl_ipv4[ipv4_idx] =
+                    (uint16_t)(rec->dwTtl > 0xFFFF ? 0xFFFF : rec->dwTtl);
+                ipv4_idx++;
+            }
+#endif
+        }
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+        pb->spare_addresses.n_ipv4      = ipv4_idx;
+        pb->spare_addresses.ipv4_index  = 0;
+#endif
+    }
+    else {
+        pb->dns_queries.received_a = true;
+        pb->dns_queries.sent_a     = true;
+        PUBNUB_LOG_DEBUG(pb,
+                         "DnsQueryEx A: no records (status=%ld)\n",
+                         (long)pb->os_dns.status_a);
+    }
+
+#if PUBNUB_USE_IPV6
+    if ((DNS_STATUS)pb->os_dns.status_aaaa == ERROR_SUCCESS
+        && pb->os_dns.query_result_aaaa.pQueryRecords != NULL) {
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+        int ipv6_idx = 0;
+#endif
+        for (rec = pb->os_dns.query_result_aaaa.pQueryRecords;
+             rec != NULL;
+             rec = rec->pNext) {
+            if (rec->wType != DNS_TYPE_AAAA)
+                continue;
+
+            if (!pb->dns_queries.received_aaaa) {
+                struct sockaddr_in6* sin6 =
+                    (struct sockaddr_in6*)&pb->dns_queries.dns_aaaa_addr;
+                sin6->sin6_family = AF_INET6;
+                memcpy(sin6->sin6_addr.s6_addr,
+                       &rec->Data.AAAA.Ip6Address,
+                       16);
+                pb->dns_queries.received_aaaa = true;
+                pb->dns_queries.sent_aaaa     = true;
+                got_any = true;
+                PUBNUB_LOG_TRACE(pb, "DnsQueryEx AAAA resolved (TTL=%lu)\n",
+                                 (unsigned long)rec->dwTtl);
+            }
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+            if (ipv6_idx < PUBNUB_MAX_IPV6_ADDRESSES) {
+                memcpy(pb->spare_addresses.ipv6_addresses[ipv6_idx].ipv6,
+                       &rec->Data.AAAA.Ip6Address,
+                       16);
+                pb->spare_addresses.ttl_ipv6[ipv6_idx] =
+                    (uint16_t)(rec->dwTtl > 0xFFFF ? 0xFFFF : rec->dwTtl);
+                ipv6_idx++;
+            }
+#endif
+        }
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+        pb->spare_addresses.n_ipv6     = ipv6_idx;
+        pb->spare_addresses.ipv6_index = 0;
+#endif
+    }
+    else {
+        pb->dns_queries.received_aaaa = true;
+        pb->dns_queries.sent_aaaa     = true;
+        PUBNUB_LOG_DEBUG(pb,
+                         "DnsQueryEx AAAA: no records (status=%ld)\n",
+                         (long)pb->os_dns.status_aaaa);
+    }
+#endif /* PUBNUB_USE_IPV6 */
+
+#if PUBNUB_USE_MULTIPLE_ADDRESSES
+    time(&pb->spare_addresses.time_of_the_last_dns_query);
+#endif
+
+    if (pb->os_dns.query_result_a.pQueryRecords != NULL) {
+        DnsRecordListFree(pb->os_dns.query_result_a.pQueryRecords,
+                          DnsFreeRecordList);
+        pb->os_dns.query_result_a.pQueryRecords = NULL;
+    }
+#if PUBNUB_USE_IPV6
+    if (pb->os_dns.query_result_aaaa.pQueryRecords != NULL) {
+        DnsRecordListFree(pb->os_dns.query_result_aaaa.pQueryRecords,
+                          DnsFreeRecordList);
+        pb->os_dns.query_result_aaaa.pQueryRecords = NULL;
+    }
+#endif
+
+    pb->os_dns.active = false;
+
+    if (!got_any) {
+        PUBNUB_LOG_ERROR(pb,
+                         "DnsQueryEx: no addresses resolved "
+                         "(A status=%ld, AAAA status=%ld)\n",
+                         (long)pb->os_dns.status_a,
+                         (long)pb->os_dns.status_aaaa);
+        return -1;
+    }
+
+    return 0;
+}
+
+
+/* ------------------------------------------------------------------ */
+/*  pbpal_os_dns_cancel                                                */
+/* ------------------------------------------------------------------ */
+
+void pbpal_os_dns_cancel(pubnub_t* pb)
+{
+    if (pb == NULL || !pb->os_dns.active)
+        return;
+
+    if (!InterlockedCompareExchange(&pb->os_dns.completed_a, 0, 0))
+        DnsCancelQuery(&pb->os_dns.cancel_a);
+
+#if PUBNUB_USE_IPV6
+    if (!InterlockedCompareExchange(&pb->os_dns.completed_aaaa, 0, 0))
+        DnsCancelQuery(&pb->os_dns.cancel_aaaa);
+#endif
+
+    if (pb->os_dns.query_result_a.pQueryRecords != NULL) {
+        DnsRecordListFree(pb->os_dns.query_result_a.pQueryRecords,
+                          DnsFreeRecordList);
+        pb->os_dns.query_result_a.pQueryRecords = NULL;
+    }
+#if PUBNUB_USE_IPV6
+    if (pb->os_dns.query_result_aaaa.pQueryRecords != NULL) {
+        DnsRecordListFree(pb->os_dns.query_result_aaaa.pQueryRecords,
+                          DnsFreeRecordList);
+        pb->os_dns.query_result_aaaa.pQueryRecords = NULL;
+    }
+#endif
+
+    pb->os_dns.active = false;
+}
+
+
+#endif /* defined(_WIN32) && defined(PUBNUB_CALLBACK_API) */

--- a/windows/pbpal_dns_query_ex.c
+++ b/windows/pbpal_dns_query_ex.c
@@ -18,10 +18,10 @@
 #include <pubnub_internal.h>
 #include "core/pubnub_assert.h"
 #include "core/pubnub_dns_servers.h"
-#include "core/pubnub_log.h"
+#if PUBNUB_USE_LOGGER
+#include "core/pubnub_logger_internal.h"
+#endif // PUBNUB_USE_LOGGER
 
-#include <windns.h>
-#include <windows.h>
 #include <string.h>
 #include <time.h>
 

--- a/windows/pbpal_dns_query_ex.h
+++ b/windows/pbpal_dns_query_ex.h
@@ -1,0 +1,56 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#if !defined INC_PBPAL_DNS_QUERY_EX
+#define INC_PBPAL_DNS_QUERY_EX
+
+#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
+
+#include <pubnub_internal.h>
+
+
+/** Check whether the OS DNS resolver (DnsQueryEx) should be used
+    instead of the custom UDP DNS resolver.
+
+    Returns true when no user-provided primary or secondary DNS
+    servers are configured (IPv4 or IPv6).  In that case the OS
+    resolver is preferred because it respects VPN DNS routing,
+    split-tunnel configurations, and the system DNS cache.
+ */
+bool pbpal_os_dns_should_use(pubnub_t* pb);
+
+
+/** Start asynchronous DNS resolution via DnsQueryEx for both A and
+    AAAA record types.
+
+    Populates @p pb->os_dns.  Completion callbacks will fire on a
+    Windows thread-pool thread and enqueue @p pb for FSM processing.
+
+    @param pb       PubNub context (must be under pb->monitor).
+    @param hostname Origin hostname to resolve (narrow string).
+    @return 0 on success (queries submitted), -1 on error.
+ */
+int pbpal_os_dns_start(pubnub_t* pb, const char* hostname);
+
+
+/** Check whether the pending OS DNS resolution has completed and, if
+    so, populate @p pb->dns_queries and @p pb->spare_addresses from
+    the results.
+
+    Called from pbpal_check_resolv_and_connect() on the socket-watcher
+    thread while pb->monitor is held.
+
+    @return 0  all results received and addresses populated.
+    @return +1 still waiting (would-block).
+    @return -1 resolution failed (no addresses obtained).
+ */
+int pbpal_os_dns_check(pubnub_t* pb);
+
+
+/** Cancel any pending DnsQueryEx queries and free result records.
+
+    Safe to call even when no OS DNS resolution is active.
+ */
+void pbpal_os_dns_cancel(pubnub_t* pb);
+
+
+#endif /* defined(_WIN32) && defined(PUBNUB_CALLBACK_API) */
+#endif /* !defined INC_PBPAL_DNS_QUERY_EX */

--- a/windows/pubnub_dns_system_servers.c
+++ b/windows/pubnub_dns_system_servers.c
@@ -88,7 +88,9 @@ static bool is_valid_ipv6(const uint8_t addr[16])
         if (addr[i] != 0) loopback = false;
     }
 
-    if (all_zero || loopback || (addr[0] == 0xfe && (addr[1] & 0xc0) == 0x80))
+    if (all_zero || loopback
+        || (addr[0] == 0xfe && (addr[1] & 0xc0) == 0x80)   /* fe80::/10 link-local */
+        || (addr[0] == 0xfe && (addr[1] & 0xc0) == 0xc0))  /* fec0::/10 site-local (deprecated RFC 3879) */
         return false;
 
     return true;

--- a/windows/pubnub_internal.h
+++ b/windows/pubnub_internal.h
@@ -6,6 +6,11 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#ifdef PUBNUB_CALLBACK_API
+#include <windns.h>
+#pragma comment(lib, "dnsapi.lib")
+#endif
+
 
 typedef SOCKET pb_socket_t;
 

--- a/windows/pubnub_ntf_callback_windows.c
+++ b/windows/pubnub_ntf_callback_windows.c
@@ -13,6 +13,7 @@
 #include "lib/sockets/pbpal_ntf_callback_poller_poll.h"
 #include "core/pbpal_ntf_callback_queue.h"
 #include "core/pbpal_ntf_callback_handle_timer_list.h"
+#include "windows/pbpal_dns_query_ex.h"
 
 #include <process.h>
 
@@ -177,6 +178,8 @@ MAYBE_INLINE int pbntf_got_socket_callback(pubnub_t* pb)
 
 MAYBE_INLINE void pbntf_lost_socket_callback(pubnub_t* pb)
 {
+    pbpal_os_dns_cancel(pb);
+
     EnterCriticalSection(&m_watcher.mutw);
     pbpal_ntf_callback_remove_socket(m_watcher.poll, pb);
     LeaveCriticalSection(&m_watcher.mutw);


### PR DESCRIPTION
refactor(dns): change async DNS resolution path for Windows

Add Windows async DNS resolution via `DnsQueryEx` and improve IPv6 fallback.