### PR TITLE
Fix/cancelation

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "7.2.0"
+version: "7.2.1"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-05-06
+    version: v7.2.1
+    changes:
+      - type: bug
+        text: "Initialise logger request/response buffers in pbcc_init to make sure that the loggers doesn't receive junked data when cancelation occurs before request preparation."
+      - type: bug
+        text: "Fixed data race in situation when one logger used via logger_manager is being called from two different contexts."
   - date: 2026-04-22
     version: v7.2.0
     changes:
@@ -1179,7 +1186,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1238,7 +1245,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1297,7 +1304,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1352,7 +1359,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1406,7 +1413,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1455,7 +1462,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1501,7 +1508,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.0
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v7.2.1
+May 06 2026
+
+#### Fixed
+- Initialise logger request/response buffers in pbcc_init to make sure that the loggers doesn't receive junked data when cancelation occurs before request preparation.
+- Fixed data race in situation when one logger used via logger_manager is being called from two different contexts.
+
 ## v7.2.0
 April 22 2026
 

--- a/core/pbcc_logger_manager.c
+++ b/core/pbcc_logger_manager.c
@@ -398,49 +398,37 @@ void pbcc_logger_manager_log_network_response(
         (pbcc_logger_manager_t*)manager, (const pubnub_log_message_t*)&log);
 }
 
-/** Maximum number of loggers that can be dispatched in a single call.
- *  This is used to take a snapshot of the logger list under the lock
- *  so that iteration happens without holding the mutex and without
- *  dereferencing `logger->next` which may be concurrently modified. */
-#define PBCC_LOG_MAX_LOGGERS 8
-
 void pbcc_logger_manager_log_message(
     pbcc_logger_manager_t*      manager,
     const pubnub_log_message_t* message)
 {
-    /* Snapshot the logger list under the lock.  We copy pointers into
-     * a local array so that the subsequent iteration does NOT follow
+    /* Snapshot the logger list under the global lock.  We copy pointers
+     * into a local array so that the subsequent dispatch does NOT follow
      * `logger->next` -- that field may be concurrently modified by
-     * another manager's `logger_add` or `logger_remove_all`. */
-    const pubnub_logger_t* snapshot[PBCC_LOG_MAX_LOGGERS];
+     * another manager's `logger_add` or `logger_remove_all`.
+     *
+     * Dispatching happens outside the lock so that user callbacks cannot
+     * block other managers from logging or modifying their lists. */
+    const pubnub_logger_t* snapshot[PBCC_MAX_LOGGERS_PER_MANAGER];
     int                    count = 0;
 
     pubnub_mutex_init_static(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
+
 #if PUBNUB_USE_DEFAULT_LOGGER
     const pubnub_logger_t* logger = manager->default_logger;
 #else  // #if !PUBNUB_USE_DEFAULT_LOGGER
     const pubnub_logger_t* logger = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
-    while (NULL != logger && count < PBCC_LOG_MAX_LOGGERS) {
+    while (NULL != logger && count < PBCC_MAX_LOGGERS_PER_MANAGER) {
         snapshot[count++] = logger;
         logger            = logger->next;
     }
-    if (NULL != logger) {
-        /* More loggers registered than the snapshot can hold.  The
-         * excess loggers will NOT receive this message. */
-        printf(
-            "[PubNub] Warning: more than %d loggers registered; "
-            "excess loggers will not receive this log message.\n",
-            PBCC_LOG_MAX_LOGGERS);
-    }
+
     pubnub_mutex_unlock(manager->mutw);
     pubnub_mutex_unlock(s_logger_list_lock);
 
-    /* Dispatch to each logger outside the lock.  The snapshot array
-     * contains stable pointers -- the logger objects themselves are
-     * owned by the user and must remain valid while registered. */
     for (int i = 0; i < count; ++i) {
         const pubnub_logger_t* lg = snapshot[i];
         if (NULL == lg->vtable) continue;

--- a/core/pbcc_logger_manager.c
+++ b/core/pbcc_logger_manager.c
@@ -118,15 +118,27 @@ void pbcc_logger_manager_free(pbcc_logger_manager_t* manager)
 {
     if (NULL == manager) return;
 
-    // Remove all additional loggers.
-    pbcc_logger_manager_logger_remove_all(manager);
-
+    /* Hold the global lock across both the list detach and the default
+     * logger free.  This ensures no other thread is mid-dispatch
+     * (iterating loggers under the same lock) when we free the default
+     * logger object. */
+    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
+
+    /* Detach custom loggers (same as remove_all but already under lock). */
+#if PUBNUB_USE_DEFAULT_LOGGER
+    manager->default_logger->next = NULL;
+#endif // #if PUBNUB_USE_DEFAULT_LOGGER
+    manager->loggers = NULL;
+
 #if PUBNUB_USE_DEFAULT_LOGGER
     if (NULL != manager->default_logger)
         pubnub_logger_free(&manager->default_logger);
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
+
     pubnub_mutex_unlock(manager->mutw);
+    pubnub_mutex_unlock(s_logger_list_lock);
     pubnub_mutex_destroy(manager->mutw);
 
     free(manager);
@@ -402,16 +414,12 @@ void pbcc_logger_manager_log_message(
     pbcc_logger_manager_t*      manager,
     const pubnub_log_message_t* message)
 {
-    /* Snapshot the logger list under the global lock.  We copy pointers
-     * into a local array so that the subsequent dispatch does NOT follow
-     * `logger->next` -- that field may be concurrently modified by
-     * another manager's `logger_add` or `logger_remove_all`.
-     *
-     * Dispatching happens outside the lock so that user callbacks cannot
-     * block other managers from logging or modifying their lists. */
-    const pubnub_logger_t* snapshot[PBCC_MAX_LOGGERS_PER_MANAGER];
-    int                    count = 0;
-
+    /* Hold the global lock during the entire iteration and dispatch.
+     * This serializes all log message delivery across all managers,
+     * which is necessary because `logger->next` may be shared between
+     * managers and can only be safely read while no other thread is
+     * modifying it (via `logger_add`, `logger_remove`, `remove_all`,
+     * or `pbcc_logger_manager_free`). */
     pubnub_mutex_init_static(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
@@ -421,39 +429,43 @@ void pbcc_logger_manager_log_message(
 #else  // #if !PUBNUB_USE_DEFAULT_LOGGER
     const pubnub_logger_t* logger = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
-    while (NULL != logger && count < PBCC_MAX_LOGGERS_PER_MANAGER) {
-        snapshot[count++] = logger;
-        logger            = logger->next;
-    }
-
-    pubnub_mutex_unlock(manager->mutw);
-    pubnub_mutex_unlock(s_logger_list_lock);
-
-    for (int i = 0; i < count; ++i) {
-        const pubnub_logger_t* lg = snapshot[i];
-        if (NULL == lg->vtable) continue;
+    while (NULL != logger) {
+        if (NULL == logger->vtable) {
+            logger = logger->next;
+            continue;
+        }
 
         switch (message->level) {
         case PUBNUB_LOG_LEVEL_TRACE:
-            if (NULL != lg->vtable->trace) lg->vtable->trace(lg, message);
+            if (NULL != logger->vtable->trace)
+                logger->vtable->trace(logger, message);
             break;
         case PUBNUB_LOG_LEVEL_DEBUG:
-            if (NULL != lg->vtable->debug) lg->vtable->debug(lg, message);
+            if (NULL != logger->vtable->debug)
+                logger->vtable->debug(logger, message);
             break;
         case PUBNUB_LOG_LEVEL_INFO:
-            if (NULL != lg->vtable->info) lg->vtable->info(lg, message);
+            if (NULL != logger->vtable->info)
+                logger->vtable->info(logger, message);
             break;
         case PUBNUB_LOG_LEVEL_WARNING:
-            if (NULL != lg->vtable->warn) lg->vtable->warn(lg, message);
+            if (NULL != logger->vtable->warn)
+                logger->vtable->warn(logger, message);
             break;
         case PUBNUB_LOG_LEVEL_ERROR:
-            if (NULL != lg->vtable->error) lg->vtable->error(lg, message);
+            if (NULL != logger->vtable->error)
+                logger->vtable->error(logger, message);
             break;
         default:
             /* Nothing to log */
             break;
         }
+
+        logger = logger->next;
     }
+
+    pubnub_mutex_unlock(manager->mutw);
+    pubnub_mutex_unlock(s_logger_list_lock);
 }
 
 pubnub_log_message_t pbcc_logger_manager_message_init(

--- a/core/pbcc_logger_manager.c
+++ b/core/pbcc_logger_manager.c
@@ -19,6 +19,26 @@
 
 
 // ----------------------------------------------
+//         Global logger list lock
+// ----------------------------------------------
+
+/** Global mutex that protects modifications to `pubnub_logger_t::next`.
+ *
+ *  The `next` pointer lives inside the logger object, which may be shared
+ *  across multiple logger managers (contexts).  Per-manager mutexes cannot
+ *  synchronise access when two different managers concurrently read and
+ *  write the same `next` field.  This global mutex is held during:
+ *
+ *  - list iteration  (reading `next`)   in `pbcc_logger_manager_log_message`
+ *  - list insertion  (writing `next`)   in `pbcc_logger_manager_logger_add`
+ *  - list removal    (writing `next`)   in `pbcc_logger_manager_logger_remove`
+ *  - list teardown   (detach head)      in
+ * `pbcc_logger_manager_logger_remove_all`
+ */
+pubnub_mutex_static_decl_and_init(s_logger_list_lock);
+
+
+// ----------------------------------------------
 //              Internal structures
 // ----------------------------------------------
 
@@ -47,8 +67,8 @@ struct pbcc_logger_manager {
 // ----------------------------------------------
 
 static void pbcc_logger_manager_log_message(
-    const pbcc_logger_manager_t* manager,
-    const pubnub_log_message_t*  message);
+    pbcc_logger_manager_t*      manager,
+    const pubnub_log_message_t* message);
 
 static pubnub_log_message_t pbcc_logger_manager_message_init(
     const pbcc_logger_manager_t*       manager,
@@ -66,9 +86,8 @@ pbcc_logger_manager_t* pbcc_logger_manager_alloc(const char* pubnub_id)
     pbcc_logger_manager_t* manager =
         (pbcc_logger_manager_t*)malloc(sizeof(pbcc_logger_manager_t));
     if (NULL == manager) {
-        printf(
-            "[PubNub] Logger manager allocation error. Insufficient memory "
-            "error.\n");
+        printf("[PubNub] Logger manager allocation error. Insufficient memory "
+               "error.\n");
         return NULL;
     }
 
@@ -103,7 +122,6 @@ void pbcc_logger_manager_free(pbcc_logger_manager_t* manager)
     pbcc_logger_manager_logger_remove_all(manager);
 
     pubnub_mutex_lock(manager->mutw);
-    manager->loggers = NULL;
 #if PUBNUB_USE_DEFAULT_LOGGER
     if (NULL != manager->default_logger)
         pubnub_logger_free(&manager->default_logger);
@@ -131,11 +149,14 @@ int pbcc_logger_manager_logger_add(
 {
     if (NULL == manager || NULL == logger) return -1;
 
+    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
     const pubnub_logger_t* current = manager->loggers;
     while (NULL != current) {
         if (current == logger) {
             pubnub_mutex_unlock(manager->mutw);
+            pubnub_mutex_unlock(s_logger_list_lock);
             return -1;
         }
         current = current->next;
@@ -147,6 +168,7 @@ int pbcc_logger_manager_logger_add(
     manager->default_logger->next = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
     pubnub_mutex_unlock(manager->mutw);
+    pubnub_mutex_unlock(s_logger_list_lock);
 
     return 0;
 }
@@ -157,6 +179,8 @@ int pbcc_logger_manager_logger_remove(
 {
     if (NULL == manager || NULL == logger) return -1;
 
+    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
     pubnub_logger_t** current = &manager->loggers;
     while (NULL != *current) {
@@ -168,11 +192,13 @@ int pbcc_logger_manager_logger_remove(
             manager->default_logger->next = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
             pubnub_mutex_unlock(manager->mutw);
+            pubnub_mutex_unlock(s_logger_list_lock);
             return 0;
         }
         current = &(*current)->next;
     }
     pubnub_mutex_unlock(manager->mutw);
+    pubnub_mutex_unlock(s_logger_list_lock);
 
     return -1;
 }
@@ -181,18 +207,20 @@ void pbcc_logger_manager_logger_remove_all(pbcc_logger_manager_t* manager)
 {
     if (NULL == manager) return;
 
+    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
-    pubnub_logger_t* logger = manager->loggers;
-    while (NULL != logger) {
-        pubnub_logger_t* next_logger = logger->next;
-        logger->next                 = NULL;
-        logger                       = next_logger;
-    }
+    /* Detach the list from the manager without modifying the logger
+     * objects themselves.  The `next` pointers in each logger node
+     * must not be cleared here because the same logger instances may
+     * be registered with other managers that are still actively
+     * iterating through them. */
 #if PUBNUB_USE_DEFAULT_LOGGER
     manager->default_logger->next = NULL;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
     manager->loggers = NULL;
     pubnub_mutex_unlock(manager->mutw);
+    pubnub_mutex_unlock(s_logger_list_lock);
 }
 
 void pbcc_logger_manager_set_log_level(
@@ -247,7 +275,8 @@ void pbcc_logger_manager_log_text(
         manager, PUBNUB_LOG_MESSAGE_TYPE_TEXT, level, location);
     log.message = message;
 
-    pbcc_logger_manager_log_message(manager, (const pubnub_log_message_t*)&log);
+    pbcc_logger_manager_log_message(
+        (pbcc_logger_manager_t*)manager, (const pubnub_log_message_t*)&log);
 }
 
 void pbcc_logger_manager_log_text_formatted(
@@ -287,7 +316,8 @@ void pbcc_logger_manager_log_object(
     log.message = message;
     log.details = details;
 
-    pbcc_logger_manager_log_message(manager, (const pubnub_log_message_t*)&log);
+    pbcc_logger_manager_log_message(
+        (pbcc_logger_manager_t*)manager, (const pubnub_log_message_t*)&log);
 }
 
 void pbcc_logger_manager_log_error(
@@ -308,7 +338,8 @@ void pbcc_logger_manager_log_error(
     log.error_message = error_message;
     log.details       = details;
 
-    pbcc_logger_manager_log_message(manager, (const pubnub_log_message_t*)&log);
+    pbcc_logger_manager_log_message(
+        (pbcc_logger_manager_t*)manager, (const pubnub_log_message_t*)&log);
 }
 
 void pbcc_logger_manager_log_network_request(
@@ -338,7 +369,8 @@ void pbcc_logger_manager_log_network_request(
     log.canceled = canceled;
     log.failed   = failed;
 
-    pbcc_logger_manager_log_message(manager, (const pubnub_log_message_t*)&log);
+    pbcc_logger_manager_log_message(
+        (pbcc_logger_manager_t*)manager, (const pubnub_log_message_t*)&log);
 }
 
 void pbcc_logger_manager_log_network_response(
@@ -362,51 +394,77 @@ void pbcc_logger_manager_log_network_response(
     log.headers     = headers;
     log.body        = body;
 
-    pbcc_logger_manager_log_message(manager, (const pubnub_log_message_t*)&log);
+    pbcc_logger_manager_log_message(
+        (pbcc_logger_manager_t*)manager, (const pubnub_log_message_t*)&log);
 }
 
+/** Maximum number of loggers that can be dispatched in a single call.
+ *  This is used to take a snapshot of the logger list under the lock
+ *  so that iteration happens without holding the mutex and without
+ *  dereferencing `logger->next` which may be concurrently modified. */
+#define PBCC_LOG_MAX_LOGGERS 8
+
 void pbcc_logger_manager_log_message(
-    const pbcc_logger_manager_t* manager,
-    const pubnub_log_message_t*  message)
+    pbcc_logger_manager_t*      manager,
+    const pubnub_log_message_t* message)
 {
+    /* Snapshot the logger list under the lock.  We copy pointers into
+     * a local array so that the subsequent iteration does NOT follow
+     * `logger->next` -- that field may be concurrently modified by
+     * another manager's `logger_add` or `logger_remove_all`. */
+    const pubnub_logger_t* snapshot[PBCC_LOG_MAX_LOGGERS];
+    int                    count = 0;
+
+    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_lock(s_logger_list_lock);
+    pubnub_mutex_lock(manager->mutw);
 #if PUBNUB_USE_DEFAULT_LOGGER
     const pubnub_logger_t* logger = manager->default_logger;
 #else  // #if !PUBNUB_USE_DEFAULT_LOGGER
     const pubnub_logger_t* logger = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
-    while (NULL != logger) {
-        if (NULL == logger->vtable) {
-            logger = logger->next;
-            continue;
-        }
+    while (NULL != logger && count < PBCC_LOG_MAX_LOGGERS) {
+        snapshot[count++] = logger;
+        logger            = logger->next;
+    }
+    if (NULL != logger) {
+        /* More loggers registered than the snapshot can hold.  The
+         * excess loggers will NOT receive this message. */
+        printf(
+            "[PubNub] Warning: more than %d loggers registered; "
+            "excess loggers will not receive this log message.\n",
+            PBCC_LOG_MAX_LOGGERS);
+    }
+    pubnub_mutex_unlock(manager->mutw);
+    pubnub_mutex_unlock(s_logger_list_lock);
+
+    /* Dispatch to each logger outside the lock.  The snapshot array
+     * contains stable pointers -- the logger objects themselves are
+     * owned by the user and must remain valid while registered. */
+    for (int i = 0; i < count; ++i) {
+        const pubnub_logger_t* lg = snapshot[i];
+        if (NULL == lg->vtable) continue;
 
         switch (message->level) {
         case PUBNUB_LOG_LEVEL_TRACE:
-            if (NULL != logger->vtable->trace)
-                logger->vtable->trace(logger, message);
+            if (NULL != lg->vtable->trace) lg->vtable->trace(lg, message);
             break;
         case PUBNUB_LOG_LEVEL_DEBUG:
-            if (NULL != logger->vtable->debug)
-                logger->vtable->debug(logger, message);
+            if (NULL != lg->vtable->debug) lg->vtable->debug(lg, message);
             break;
         case PUBNUB_LOG_LEVEL_INFO:
-            if (NULL != logger->vtable->info)
-                logger->vtable->info(logger, message);
+            if (NULL != lg->vtable->info) lg->vtable->info(lg, message);
             break;
         case PUBNUB_LOG_LEVEL_WARNING:
-            if (NULL != logger->vtable->warn)
-                logger->vtable->warn(logger, message);
+            if (NULL != lg->vtable->warn) lg->vtable->warn(lg, message);
             break;
         case PUBNUB_LOG_LEVEL_ERROR:
-            if (NULL != logger->vtable->error)
-                logger->vtable->error(logger, message);
+            if (NULL != lg->vtable->error) lg->vtable->error(lg, message);
             break;
         default:
             /* Nothing to log */
             break;
         }
-
-        logger = logger->next;
     }
 }
 
@@ -432,7 +490,7 @@ pubnub_log_message_t pbcc_logger_manager_message_init(
     sec                          = (time_t)(unix_ms / 1000ULL);
     msec                         = (uint32_t)(unix_ms % 1000ULL);
 #elif defined(__unix__) || defined(__APPLE__) || defined(ESP_PLATFORM)
-    struct timeval tv;
+    struct timeval         tv;
     if (gettimeofday(&tv, NULL) != 0) {
         sec  = 0;
         msec = 0;
@@ -450,13 +508,13 @@ pubnub_log_message_t pbcc_logger_manager_message_init(
 
     pubnub_log_message_t message;
     memset(&message, 0, sizeof(message));
-    message.message_type          = message_type;
-    message.level                 = level;
-    message.pubnub_id             = manager->pubnub_id;
-    message.timestamp.seconds     = sec;
+    message.message_type           = message_type;
+    message.level                  = level;
+    message.pubnub_id              = manager->pubnub_id;
+    message.timestamp.seconds      = sec;
     message.timestamp.milliseconds = msec;
-    message.location              = location;
-    message.minimum_level         = manager->minimum_level;
+    message.location               = location;
+    message.minimum_level          = manager->minimum_level;
 
     return message;
 }

--- a/core/pbcc_logger_manager.c
+++ b/core/pbcc_logger_manager.c
@@ -35,7 +35,7 @@
  *  - list teardown   (detach head)      in
  * `pbcc_logger_manager_logger_remove_all`
  */
-pubnub_mutex_static_decl_and_init(s_logger_list_lock);
+pubnub_mutex_static_recursive_decl_and_init(s_logger_list_lock);
 
 
 // ----------------------------------------------
@@ -86,8 +86,9 @@ pbcc_logger_manager_t* pbcc_logger_manager_alloc(const char* pubnub_id)
     pbcc_logger_manager_t* manager =
         (pbcc_logger_manager_t*)malloc(sizeof(pbcc_logger_manager_t));
     if (NULL == manager) {
-        printf("[PubNub] Logger manager allocation error. Insufficient memory "
-               "error.\n");
+        printf(
+            "[PubNub] Logger manager allocation error. Insufficient memory "
+            "error.\n");
         return NULL;
     }
 
@@ -122,20 +123,18 @@ void pbcc_logger_manager_free(pbcc_logger_manager_t* manager)
      * logger free.  This ensures no other thread is mid-dispatch
      * (iterating loggers under the same lock) when we free the default
      * logger object. */
-    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_init_static_recursive(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
 
-    /* Detach custom loggers (same as remove_all but already under lock). */
 #if PUBNUB_USE_DEFAULT_LOGGER
-    manager->default_logger->next = NULL;
+    if (NULL != manager->default_logger) {
+        /* Detach custom loggers (same as remove_all but already under lock). */
+        manager->default_logger->next = NULL;
+        pubnub_logger_free(&manager->default_logger);
+    }
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
     manager->loggers = NULL;
-
-#if PUBNUB_USE_DEFAULT_LOGGER
-    if (NULL != manager->default_logger)
-        pubnub_logger_free(&manager->default_logger);
-#endif // #if PUBNUB_USE_DEFAULT_LOGGER
 
     pubnub_mutex_unlock(manager->mutw);
     pubnub_mutex_unlock(s_logger_list_lock);
@@ -161,7 +160,7 @@ int pbcc_logger_manager_logger_add(
 {
     if (NULL == manager || NULL == logger) return -1;
 
-    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_init_static_recursive(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
     const pubnub_logger_t* current = manager->loggers;
@@ -177,7 +176,8 @@ int pbcc_logger_manager_logger_add(
     manager->loggers = logger;
 #if PUBNUB_USE_DEFAULT_LOGGER
     // Make default logger first in a line for messages.
-    manager->default_logger->next = manager->loggers;
+    if (NULL != manager->default_logger)
+        manager->default_logger->next = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
     pubnub_mutex_unlock(manager->mutw);
     pubnub_mutex_unlock(s_logger_list_lock);
@@ -191,7 +191,7 @@ int pbcc_logger_manager_logger_remove(
 {
     if (NULL == manager || NULL == logger) return -1;
 
-    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_init_static_recursive(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
     pubnub_logger_t** current = &manager->loggers;
@@ -201,7 +201,8 @@ int pbcc_logger_manager_logger_remove(
             logger->next = NULL;
 #if PUBNUB_USE_DEFAULT_LOGGER
             // Make default logger first in a line for messages.
-            manager->default_logger->next = manager->loggers;
+            if (NULL != manager->default_logger)
+                manager->default_logger->next = manager->loggers;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
             pubnub_mutex_unlock(manager->mutw);
             pubnub_mutex_unlock(s_logger_list_lock);
@@ -219,7 +220,7 @@ void pbcc_logger_manager_logger_remove_all(pbcc_logger_manager_t* manager)
 {
     if (NULL == manager) return;
 
-    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_init_static_recursive(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
     /* Detach the list from the manager without modifying the logger
@@ -228,7 +229,7 @@ void pbcc_logger_manager_logger_remove_all(pbcc_logger_manager_t* manager)
      * be registered with other managers that are still actively
      * iterating through them. */
 #if PUBNUB_USE_DEFAULT_LOGGER
-    manager->default_logger->next = NULL;
+    if (NULL != manager->default_logger) manager->default_logger->next = NULL;
 #endif // #if PUBNUB_USE_DEFAULT_LOGGER
     manager->loggers = NULL;
     pubnub_mutex_unlock(manager->mutw);
@@ -420,7 +421,7 @@ void pbcc_logger_manager_log_message(
      * managers and can only be safely read while no other thread is
      * modifying it (via `logger_add`, `logger_remove`, `remove_all`,
      * or `pbcc_logger_manager_free`). */
-    pubnub_mutex_init_static(s_logger_list_lock);
+    pubnub_mutex_init_static_recursive(s_logger_list_lock);
     pubnub_mutex_lock(s_logger_list_lock);
     pubnub_mutex_lock(manager->mutw);
 
@@ -490,7 +491,7 @@ pubnub_log_message_t pbcc_logger_manager_message_init(
     sec                          = (time_t)(unix_ms / 1000ULL);
     msec                         = (uint32_t)(unix_ms % 1000ULL);
 #elif defined(__unix__) || defined(__APPLE__) || defined(ESP_PLATFORM)
-    struct timeval         tv;
+    struct timeval tv;
     if (gettimeofday(&tv, NULL) != 0) {
         sec  = 0;
         msec = 0;

--- a/core/pbcc_logger_manager.h
+++ b/core/pbcc_logger_manager.h
@@ -17,13 +17,6 @@
 //                Types forwarding
 // ----------------------------------------------
 
-/** Maximum number of loggers that can be dispatched per log message.
- *  Increase this value if you need to register more custom loggers
- *  per PubNub context (default logger counts as one). */
-#ifndef PBCC_MAX_LOGGERS_PER_MANAGER
-#define PBCC_MAX_LOGGERS_PER_MANAGER 8
-#endif
-
 /** Logger manager definition. */
 struct pbcc_logger_manager;
 typedef struct pbcc_logger_manager pbcc_logger_manager_t;

--- a/core/pbcc_logger_manager.h
+++ b/core/pbcc_logger_manager.h
@@ -17,6 +17,13 @@
 //                Types forwarding
 // ----------------------------------------------
 
+/** Maximum number of loggers that can be dispatched per log message.
+ *  Increase this value if you need to register more custom loggers
+ *  per PubNub context (default logger counts as one). */
+#ifndef PBCC_MAX_LOGGERS_PER_MANAGER
+#define PBCC_MAX_LOGGERS_PER_MANAGER 8
+#endif
+
 /** Logger manager definition. */
 struct pbcc_logger_manager;
 typedef struct pbcc_logger_manager pbcc_logger_manager_t;

--- a/core/pubnub_alloc_static.c
+++ b/core/pubnub_alloc_static.c
@@ -74,15 +74,16 @@ int pubnub_free(pubnub_t* pb)
 
     PUBNUB_LOG_TRACE(pb, "Try to free PubNub context");
 
+    pubnub_mutex_lock(pb->monitor);
+
     if (pb->state == PBS_NULL) {
         PUBNUB_LOG_TRACE(pb, "PubNub context not initialized. Freeing...");
-        PUBNUB_LOG_TRACE(pb, "pubnub_free: not initialized, freeing");
+        pubnub_mutex_unlock(pb->monitor);
         free(pb);
 
         return 0;
     }
 
-    pubnub_mutex_lock(pb->monitor);
     pbnc_stop(pb, PNR_CANCELLED);
     if (PBS_IDLE == pb->state) {
         PUBNUB_LOG_TRACE(pb, "PubNub context is in idle state. Freeing...");

--- a/core/pubnub_alloc_std.c
+++ b/core/pubnub_alloc_std.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 
-#if defined PUBNUB_ASSERT_LEVEL_EX
+#if defined       PUBNUB_ASSERT_LEVEL_EX
 static pubnub_t** m_allocated;
 static unsigned   m_n;
 static unsigned   m_cap;
@@ -149,15 +149,17 @@ int pubnub_free(pubnub_t* pb)
 
     PUBNUB_LOG_TRACE(pb, "Try to free PubNub context");
 
+    pubnub_mutex_lock(pb->monitor);
+
     if (pb->state == PBS_NULL) {
         PUBNUB_LOG_TRACE(pb, "PubNub context not initialized. Freeing...");
+        pubnub_mutex_unlock(pb->monitor);
         remove_allocated(pb);
         free(pb);
 
         return 0;
     }
 
-    pubnub_mutex_lock(pb->monitor);
     pbnc_stop(pb, PNR_CANCELLED);
     if (PBS_IDLE == pb->state) {
         PUBNUB_LOG_TRACE(pb, "PubNub context is in idle state. Freeing...");

--- a/core/pubnub_ccore_pubsub.c
+++ b/core/pubnub_ccore_pubsub.c
@@ -74,6 +74,18 @@ void pbcc_init(
         memcpy(p->id, str_uuid.uuid, sizeof(p->id));
     }
 #if PUBNUB_USE_LOGGER
+    /* The logger dispatch path (pbnc_stop, outcome_detected) guards logging
+     * of the cancelled/failed request on a single-byte check of
+     * `last_request_url[0]`. Because `pubnub_alloc()` does not zero the
+     * context memory, the buffer would otherwise hold arbitrary heap bytes
+     * until the first transaction runs — a cancel issued before the first
+     * transaction (a common defensive pattern in C++ wrappers that call
+     * pubnub_cancel() at the start of their subscribe) would dispatch the
+     * uninitialised buffer to user loggers. Initialise all logger-facing
+     * buffers here so every pre-transaction read is safe. */
+    p->last_request_url[0]       = '\0';
+    p->last_response_headers[0]  = '\0';
+    p->last_response_headers_len = 0;
     p->logger_manager = pbcc_logger_manager_alloc(p->id);
 #if PUBNUB_USE_DEFAULT_LOGGER
     pubnub_logger_t* default_logger = pubnub_default_logger_alloc();

--- a/core/pubnub_logger.h
+++ b/core/pubnub_logger.h
@@ -430,6 +430,11 @@ PUBNUB_EXTERN void* pubnub_logger_user_data(pubnub_logger_t* logger);
  * loggers can be registered, and all will receive log messages of appropriate
  * levels.
  *
+ * @note Up to 8 custom loggers (including the default logger) can be
+ *       dispatched per log message. If more are registered, the excess
+ *       loggers will not receive log messages and a warning will be
+ *       printed to stdout.
+ *
  * @note Pointer to the custom logger object should be valid while used by the
  *       logging subsystem. It is the user's responsibility to
  *       call `pubnub_logger_free`.

--- a/core/pubnub_logger.h
+++ b/core/pubnub_logger.h
@@ -430,11 +430,6 @@ PUBNUB_EXTERN void* pubnub_logger_user_data(pubnub_logger_t* logger);
  * loggers can be registered, and all will receive log messages of appropriate
  * levels.
  *
- * @note Up to 8 custom loggers (including the default logger) can be
- *       dispatched per log message. If more are registered, the excess
- *       loggers will not receive log messages and a warning will be
- *       printed to stdout.
- *
  * @note Pointer to the custom logger object should be valid while used by the
  *       logging subsystem. It is the user's responsibility to
  *       call `pubnub_logger_free`.

--- a/core/pubnub_logger.h
+++ b/core/pubnub_logger.h
@@ -271,6 +271,12 @@ typedef struct pubnub_log_message_network_response pubnub_log_message_network_re
  * All function pointers are optional (can be `NULL`). If a function pointer is
  * `NULL`, that log level will not be processed by this logger.
  *
+ * @note Callback implementations must not call `pubnub_logger_add`,
+ *       `pubnub_logger_remove`, `pubnub_logger_remove_all`, or `pubnub_free`
+ *       from within a logger callback.  Doing so may corrupt the active
+ *       iteration over the logger list.  Calling other PubNub APIs that emit
+ *       log messages (e.g., `pubnub_publish`) is safe.
+ *
  * @see pubnub_logger_add
  */
 struct pubnub_logger_interface {

--- a/core/pubnub_mutex.h
+++ b/core/pubnub_mutex.h
@@ -15,6 +15,8 @@
 #define pubnub_mutex_decl_and_init(m) pbpal_mutex_decl_and_init(m)
 #define pubnub_mutex_static_decl_and_init(m) pbpal_mutex_static_decl_and_init(m)
 #define pubnub_mutex_init_static(m) pbpal_mutex_init_static(m)
+#define pubnub_mutex_static_recursive_decl_and_init(m) pbpal_mutex_static_recursive_decl_and_init(m)
+#define pubnub_mutex_init_static_recursive(m) pbpal_mutex_init_static_recursive(m)
 
 #if defined(__clang__) && defined(__cplusplus)
 #define pubnub_guarded_by(x) __attribute__((guarded_by(x)))
@@ -34,6 +36,8 @@ typedef struct { int dummy; } pubnub_mutex_t;
 #define pubnub_mutex_decl_and_init(m)
 #define pubnub_mutex_static_decl_and_init(m)
 #define pubnub_mutex_init_static(m)
+#define pubnub_mutex_static_recursive_decl_and_init(m)
+#define pubnub_mutex_init_static_recursive(m)
 
 #define pubnub_guarded_by(x) 
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.2.0"
+#define PUBNUB_SDK_VERSION "7.2.1"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/freertos/pbpal_mutex.h
+++ b/freertos/pbpal_mutex.h
@@ -36,6 +36,8 @@ typedef SemaphoreHandle_t pbpal_mutex_t;
 } while(0)
 #endif /*ESP_PLATFORM*/
 
+#define pbpal_mutex_static_recursive_decl_and_init(m) pbpal_mutex_static_decl_and_init(m)
+#define pbpal_mutex_init_static_recursive(m) pbpal_mutex_init_static(m)
 
 
 #endif /*!defined INC_PBPAL_MUTEX*/

--- a/microchip_harmony/pbpal_mutex.h
+++ b/microchip_harmony/pbpal_mutex.h
@@ -17,7 +17,10 @@ typedef int pbpal_mutex_t;
 #define pbpal_mutex_destroy(m) 
 #define pbpal_mutex_decl_and_init(m) 
 #define pbpal_mutex_static_decl_and_init(m) 
-#define pbpal_mutex_init_static(m) 
+#define pbpal_mutex_init_static(m)
+
+#define pbpal_mutex_static_recursive_decl_and_init(m)
+#define pbpal_mutex_init_static_recursive(m)
 
 
 #endif /*!defined INC_PBPAL_MUTEX*/

--- a/openssl/pbpal_mutex.h
+++ b/openssl/pbpal_mutex.h
@@ -26,6 +26,8 @@ __inline int pubnub_InitCriticalSection(_Out_ LPCRITICAL_SECTION lpCS) {
 #define pbpal_mutex_static_decl_and_init(m) static CRITICAL_SECTION m; static volatile LONG m_init_##m
 
 #define pbpal_mutex_init_static(m) do { if (0 == InterlockedExchange(&m_init_##m, 1)) InitializeCriticalSection(&m); } while(0)
+#define pbpal_mutex_static_recursive_decl_and_init(m) pbpal_mutex_static_decl_and_init(m)
+#define pbpal_mutex_init_static_recursive(m) pbpal_mutex_init_static(m)
 #define pbpal_thread_id() DONT_CALL_ME_ON_WINDOWS_
 #define pbpal_mutex_init_std(m) InitializeCriticalSection(&(m))
 
@@ -40,6 +42,7 @@ typedef pthread_mutex_t pbpal_mutex_t;
         pthread_mutexattr_init(&M_attr);                             \
         pthread_mutexattr_settype(&M_attr, PTHREAD_MUTEX_RECURSIVE); \
         pthread_mutex_init(&(m), &M_attr);                           \
+        pthread_mutexattr_destroy(&M_attr);                          \
     } while (0)
 #define pbpal_mutex_lock(m) pthread_mutex_lock(&(m))
 #define pbpal_mutex_unlock(m) pthread_mutex_unlock(&(m))
@@ -47,6 +50,19 @@ typedef pthread_mutex_t pbpal_mutex_t;
 #define pbpal_mutex_decl_and_init(m) pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER
 #define pbpal_mutex_static_decl_and_init(m) static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER
 #define pbpal_mutex_init_static(m)
+#define pbpal_mutex_static_recursive_decl_and_init(m)       \
+    static pthread_mutex_t m;                               \
+    static pthread_once_t m##_once_ = PTHREAD_ONCE_INIT;    \
+    static void m##_init_fn_(void) {                        \
+        pthread_mutexattr_t M_attr_;                        \
+        pthread_mutexattr_init(&M_attr_);                   \
+        pthread_mutexattr_settype(&M_attr_,                 \
+                                  PTHREAD_MUTEX_RECURSIVE); \
+        pthread_mutex_init(&(m), &M_attr_);                 \
+        pthread_mutexattr_destroy(&M_attr_);                \
+    }
+#define pbpal_mutex_init_static_recursive(m) \
+    pthread_once(&m##_once_, m##_init_fn_)
 #define pbpal_thread_id() pthread_self()
 #define pbpal_mutex_init_std(m)  pthread_mutex_init(&(m), NULL)
 

--- a/posix/pbpal_mutex.h
+++ b/posix/pbpal_mutex.h
@@ -15,6 +15,7 @@ typedef pthread_mutex_t pbpal_mutex_t;
         pthread_mutexattr_init(&M_attr);                             \
         pthread_mutexattr_settype(&M_attr, PTHREAD_MUTEX_RECURSIVE); \
         pthread_mutex_init(&(m), &M_attr);                           \
+        pthread_mutexattr_destroy(&M_attr);                          \
     } while (0)
 #define pbpal_mutex_lock(m) pthread_mutex_lock(&(m))
 #define pbpal_mutex_unlock(m) pthread_mutex_unlock(&(m))
@@ -22,6 +23,20 @@ typedef pthread_mutex_t pbpal_mutex_t;
 #define pbpal_mutex_decl_and_init(m) pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER
 #define pbpal_mutex_static_decl_and_init(m) static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER
 #define pbpal_mutex_init_static(m)
+
+#define pbpal_mutex_static_recursive_decl_and_init(m)       \
+    static pthread_mutex_t m;                               \
+    static pthread_once_t m##_once_ = PTHREAD_ONCE_INIT;    \
+    static void m##_init_fn_(void) {                        \
+        pthread_mutexattr_t M_attr_;                        \
+        pthread_mutexattr_init(&M_attr_);                   \
+        pthread_mutexattr_settype(&M_attr_,                 \
+                                  PTHREAD_MUTEX_RECURSIVE); \
+        pthread_mutex_init(&(m), &M_attr_);                 \
+        pthread_mutexattr_destroy(&M_attr_);                \
+    }
+#define pbpal_mutex_init_static_recursive(m) \
+    pthread_once(&m##_once_, m##_init_fn_)
 
 
 #endif /*!defined INC_PBPAL_MUTEX*/

--- a/windows/pbpal_mutex.h
+++ b/windows/pbpal_mutex.h
@@ -25,6 +25,9 @@ __inline int pubnub_InitCriticalSection(_Out_ LPCRITICAL_SECTION lpCS) {
 
 #define pbpal_mutex_init_static(m) do { if (0 == InterlockedExchange(&m_init_##m, 1)) InitializeCriticalSection(&m); } while(0)
 
+#define pbpal_mutex_static_recursive_decl_and_init(m) pbpal_mutex_static_decl_and_init(m)
+#define pbpal_mutex_init_static_recursive(m) pbpal_mutex_init_static(m)
+
 
 #endif /*!defined INC_PBPAL_MUTEX*/
 


### PR DESCRIPTION
fix: Initialise logger request/response buffers in pbcc_init to make sure that the loggers doesn't receive junked data when cancelation occurs before request preparation. 

Initialise logger request/response buffers in pbcc_init to make sure that the loggers doesn't receive junked data when cancelation occurs before request preparation. 

fix: Fixed data race in situation when one logger used via logger_manager is being called from two different contexts.

Fixed data race in situation when one logger used via logger_manager is being called from two different contexts.