### PR TITLE
Replace `select()` with `poll()`

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "7.2.1"
+version: "7.2.2"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-05-14
+    version: v7.2.2
+    changes:
+      - type: bug
+        text: "Replace inline `select()`/`FD_SET` with `poll()` on non-Windows platforms in `pbpal_check_connect()`. On Linux and macOS `FD_SET` writes to a fixed 1024-bit bitmap and corrupts the stack when a socket fd value exceeds `FD_SETSIZE`. `poll()` has no fd-value limitation. Windows retains `select()` because its `fd_set` is array-based and safe."
+      - type: improvement
+        text: "Add `pbpal_ntf_callback_poller_poll_unit_test.c` covering init/deinit, save/remove, watch events, poll detection of readable and writable sockets, multiple sockets, socket update, and a high fd number test case (fd=1500) that validates the fix for the `FD_SETSIZE` overflow."
   - date: 2026-05-06
     version: v7.2.1
     changes:
@@ -1186,7 +1193,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1245,7 +1252,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1304,7 +1311,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1359,7 +1366,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1413,7 +1420,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1462,7 +1469,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1508,7 +1515,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.1
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v7.2.2
+May 14 2026
+
+#### Fixed
+- Replace inline `select()`/`FD_SET` with `poll()` on non-Windows platforms in `pbpal_check_connect()`. On Linux and macOS `FD_SET` writes to a fixed 1024-bit bitmap and corrupts the stack when a socket fd value exceeds `FD_SETSIZE`. `poll()` has no fd-value limitation. Windows retains `select()` because its `fd_set` is array-based and safe.
+
+#### Modified
+- Add `pbpal_ntf_callback_poller_poll_unit_test.c` covering init/deinit, save/remove, watch events, poll detection of readable and writable sockets, multiple sockets, socket update, and a high fd number test case (fd=1500) that validates the fix for the `FD_SETSIZE` overflow.
+
 ## v7.2.1
 May 06 2026
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.2.1"
+#define PUBNUB_SDK_VERSION "7.2.2"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
 
-all: pubnub_parse_ipv6_addr_unit_test pubnub_dns_codec_unit_test
+all: pubnub_parse_ipv6_addr_unit_test pubnub_dns_codec_unit_test pbpal_ntf_callback_poller_poll_unit_test
 
 OS := $(shell uname)
 # Coverage doesn't seem to work on MacOS for some reason, but, since
@@ -48,6 +48,12 @@ pbhash_set_unit_test: pbref_counter.c pbhash_set.c pbarray.c pbhash_set_unit_tes
 	gcc -o pbhash_set_unit_test.so -shared $(CFLAGS) $(LDFLAGS) -I../core/c99 -Wall $(COVERAGE_FLAGS) pbref_counter.c pbhash_set.c pbarray.c pbhash_set_unit_test.c -lcgreen -lm
 	$(CGREEN_RUNNER) ./pbhash_set_unit_test.so
 	#$(GCOVR) -r . --html --html-details -o coverage.html
+
+POLLER_POLL_SOURCE_FILES = ../core/pubnub_assert_std.c sockets/pbpal_ntf_callback_poller_poll.c
+
+pbpal_ntf_callback_poller_poll_unit_test: sockets/pbpal_ntf_callback_poller_poll_unit_test.c sockets/pbpal_ntf_callback_poller_poll.c
+	gcc -o pbpal_ntf_callback_poller_poll_unit_test.so -shared $(CFLAGS) -I../posix -U PUBNUB_USE_LOGGER -D PUBNUB_USE_LOGGER=0 $(LDFLAGS) -Wall $(COVERAGE_FLAGS) -fPIC $(POLLER_POLL_SOURCE_FILES) sockets/pbpal_ntf_callback_poller_poll_unit_test.c -lcgreen -lm
+	$(CGREEN_RUNNER) ./pbpal_ntf_callback_poller_poll_unit_test.so
 
 clean:
 	find . -type d -iname "*.dSYM" -exec rm -rf {} \+

--- a/lib/sockets/pbpal_ntf_callback_poller_poll.c
+++ b/lib/sockets/pbpal_ntf_callback_poller_poll.c
@@ -11,6 +11,7 @@
 #include "core/pubnub_logger.h"
 #endif // PUBNUB_USE_LOGGER
 
+#include <errno.h>
 #include <string.h>
 
 
@@ -188,6 +189,7 @@ int pbpal_ntf_poll_away(struct pbpal_poll_data* data, int ms)
 
     rslt = poll(data->apoll, data->size, ms);
     if (SOCKET_ERROR == rslt) {
+#if PUBNUB_USE_LOGGER
 #if defined(_WIN32)
             int socket_error = WSAGetLastError();
 #else
@@ -198,6 +200,7 @@ int pbpal_ntf_poll_away(struct pbpal_poll_data* data, int ms)
                 "poll() failed with error %d (%u sockets polled)",
                 socket_error,
                 (unsigned)data->size);
+#endif /* PUBNUB_USE_LOGGER */
             return -1;
         }
     if (rslt > 0) {

--- a/lib/sockets/pbpal_ntf_callback_poller_poll_unit_test.c
+++ b/lib/sockets/pbpal_ntf_callback_poller_poll_unit_test.c
@@ -1,0 +1,332 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+#include "pubnub_internal.h"
+
+#include "pubnub_get_native_socket.h"
+#include "core/pbpal_ntf_callback_poller.h"
+#include "core/pubnub_assert.h"
+
+#include "cgreen/cgreen.h"
+#include "cgreen/mocks.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <poll.h>
+
+#define attest assert_that
+#define equals is_equal_to
+#define differs is_not_equal_to
+
+/* Assert handler */
+static bool    m_expect_Assert;
+static jmp_buf m_Assert_exp_jmpbuf;
+
+void assert_handler(char const* s, const char* file, long i)
+{
+    printf("%s:%ld: Pubnub assert failed '%s'\n", file, i, s);
+    if (m_expect_Assert) {
+        m_expect_Assert = false;
+        longjmp(m_Assert_exp_jmpbuf, 1);
+    }
+}
+
+/* Track requeue calls */
+static pubnub_t* s_last_requeued;
+static int       s_requeue_count;
+
+int pbntf_requeue_for_processing(pubnub_t* pb)
+{
+    s_last_requeued = pb;
+    ++s_requeue_count;
+    return 0;
+}
+
+pbpal_native_socket_t pubnub_get_native_socket(pubnub_t* pb)
+{
+    if (NULL == pb) { return -1; }
+    return pb->pal.socket;
+}
+
+void pb_sleep_ms(unsigned long ms) { (void)ms; }
+
+
+Describe(pbpal_poller_poll);
+
+BeforeEach(pbpal_poller_poll) {
+    s_last_requeued = NULL;
+    s_requeue_count = 0;
+    m_expect_Assert = false;
+}
+
+AfterEach(pbpal_poller_poll) {}
+
+
+Ensure(pbpal_poller_poll, init_and_deinit)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    attest(data, differs(NULL));
+
+    pbpal_ntf_callback_poller_deinit(&data);
+    attest(data == NULL);
+}
+
+
+Ensure(pbpal_poller_poll, save_and_remove_socket)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), equals(0));
+    ctx.pal.socket = sv[0];
+
+    pbpal_ntf_callback_save_socket(data, &ctx);
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+
+    close(sv[0]);
+    close(sv[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, watch_in_and_out_events)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), equals(0));
+    ctx.pal.socket = sv[0];
+
+    pbpal_ntf_callback_save_socket(data, &ctx);
+
+    attest(pbpal_ntf_watch_in_events(data, &ctx), equals(0));
+    attest(pbpal_ntf_watch_out_events(data, &ctx), equals(0));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+    close(sv[0]);
+    close(sv[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, poll_away_detects_writable_socket)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), equals(0));
+    ctx.pal.socket = sv[0];
+
+    pbpal_ntf_callback_save_socket(data, &ctx);
+    /* sv[0] should be immediately writable */
+    int rslt = pbpal_ntf_poll_away(data, 100);
+    attest(rslt > 0);
+    attest(s_requeue_count, equals(1));
+    attest(s_last_requeued, equals(&ctx));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+    close(sv[0]);
+    close(sv[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, poll_away_detects_readable_socket)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), equals(0));
+    ctx.pal.socket = sv[0];
+
+    pbpal_ntf_callback_save_socket(data, &ctx);
+    pbpal_ntf_watch_in_events(data, &ctx);
+
+    /* Write to sv[1] so sv[0] becomes readable */
+    write(sv[1], "x", 1);
+
+    int rslt = pbpal_ntf_poll_away(data, 100);
+    attest(rslt > 0);
+    attest(s_requeue_count, equals(1));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+    close(sv[0]);
+    close(sv[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, poll_away_timeout_when_not_ready)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), equals(0));
+    ctx.pal.socket = sv[0];
+
+    pbpal_ntf_callback_save_socket(data, &ctx);
+    /* Watch for read but don't write anything — should timeout */
+    pbpal_ntf_watch_in_events(data, &ctx);
+
+    int rslt = pbpal_ntf_poll_away(data, 1);
+    attest(rslt, equals(0));
+    attest(s_requeue_count, equals(0));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+    close(sv[0]);
+    close(sv[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, multiple_sockets)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx1 = { 0 }, ctx2 = { 0 }, ctx3 = { 0 };
+    int sv1[2], sv2[2], sv3[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv1), equals(0));
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv2), equals(0));
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv3), equals(0));
+
+    ctx1.pal.socket = sv1[0];
+    ctx2.pal.socket = sv2[0];
+    ctx3.pal.socket = sv3[0];
+
+    pbpal_ntf_callback_save_socket(data, &ctx1);
+    pbpal_ntf_callback_save_socket(data, &ctx2);
+    pbpal_ntf_callback_save_socket(data, &ctx3);
+
+    /* Remove middle one */
+    pbpal_ntf_callback_remove_socket(data, &ctx2);
+
+    /* Poll — ctx1 and ctx3 should be writable */
+    s_requeue_count = 0;
+    int rslt = pbpal_ntf_poll_away(data, 100);
+    attest(rslt > 0);
+    attest(s_requeue_count, equals(2));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx1);
+    pbpal_ntf_callback_remove_socket(data, &ctx3);
+    close(sv1[0]); close(sv1[1]);
+    close(sv2[0]); close(sv2[1]);
+    close(sv3[0]); close(sv3[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, works_with_high_fd_numbers)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), equals(0));
+
+    /* Move sv[0] to a high fd number (>= FD_SETSIZE which is typically 1024).
+       This is the exact scenario that triggers the bug with select()/FD_SET. */
+    int high_fd = dup2(sv[0], 1500);
+    /* dup2 must succeed — CI runners should have ulimit >= 1500.
+       If this fails the test environment is misconfigured. */
+    attest(high_fd, equals(1500));
+    close(sv[0]);
+    ctx.pal.socket = high_fd;
+
+    pbpal_ntf_callback_save_socket(data, &ctx);
+
+    /* The high-fd socket should be immediately writable —
+       this would crash with the old select()/FD_SET approach. */
+    int rslt = pbpal_ntf_poll_away(data, 100);
+    attest(rslt > 0);
+    attest(s_requeue_count, equals(1));
+    attest(s_last_requeued, equals(&ctx));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+    close(high_fd);
+    close(sv[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, update_socket)
+{
+    struct pbpal_poll_data* data = pbpal_ntf_callback_poller_init();
+    pubnub_t ctx = { 0 };
+    int sv1[2], sv2[2];
+
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv1), equals(0));
+    attest(socketpair(AF_UNIX, SOCK_STREAM, 0, sv2), equals(0));
+
+    ctx.pal.socket = sv1[0];
+    pbpal_ntf_callback_save_socket(data, &ctx);
+
+    /* Simulate socket change */
+    ctx.pal.socket = sv2[0];
+    pbpal_ntf_callback_update_socket(data, &ctx);
+
+    /* Poll should work with the new socket */
+    int rslt = pbpal_ntf_poll_away(data, 100);
+    attest(rslt > 0);
+    attest(s_requeue_count, equals(1));
+
+    pbpal_ntf_callback_remove_socket(data, &ctx);
+    close(sv1[0]); close(sv1[1]);
+    close(sv2[0]); close(sv2[1]);
+    pbpal_ntf_callback_poller_deinit(&data);
+}
+
+
+Ensure(pbpal_poller_poll, high_fd_poll_connect_pattern)
+{
+    /* This test directly mirrors the pattern used in pbpal_check_connect():
+       a non-blocking TCP socket with fd >= FD_SETSIZE polled for POLLOUT.
+       With the old select()/FD_SET approach this would corrupt the stack. */
+    int skt = socket(AF_INET, SOCK_STREAM, 0);
+    attest(skt >= 0);
+
+    int high_fd = dup2(skt, 1500);
+    attest(high_fd, equals(1500));
+    close(skt);
+
+    /* Set non-blocking (same as SDK does before connect) */
+    int flags = fcntl(high_fd, F_GETFL, 0);
+    fcntl(high_fd, F_SETFL, flags | O_NONBLOCK);
+
+    /* Initiate non-blocking connect to localhost:1 (will get ECONNREFUSED
+       or EINPROGRESS — either is fine, we just need to poll) */
+    struct sockaddr_in addr = { 0 };
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(1);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    connect(high_fd, (struct sockaddr*)&addr, sizeof(addr));
+
+    /* This is the exact pattern from pbpal_check_connect — poll for POLLOUT */
+    struct pollfd pfd;
+    pfd.fd      = high_fd;
+    pfd.events  = POLLOUT;
+    pfd.revents = 0;
+    int rslt = poll(&pfd, 1, 300);
+
+    /* We expect either timeout (0) or ready (>0, connection refused is still
+       an event). The critical assertion is that we reach this point without
+       crashing — with FD_SET on fd=1500 the stack would be corrupted. */
+    attest(rslt >= 0);
+    if (rslt > 0) {
+        attest(pfd.revents & (POLLOUT | POLLERR | POLLHUP));
+    }
+
+    close(high_fd);
+}

--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -27,6 +27,7 @@ typedef ADDRESS_FAMILY sa_family_t;
 #else
 #include "posix/pubnub_get_native_socket.h"
 #include <netinet/tcp.h>
+#include <poll.h>
 #endif
 
 #define PUBNUB_DEFAULT_IPV4_DNS_SERVER "8.8.8.8"
@@ -1158,9 +1159,7 @@ pbpal_pick_address_and_connect:
 
 enum pbpal_resolv_n_connect_result pbpal_check_connect(pubnub_t* pb)
 {
-    fd_set         write_set;
     int            rslt;
-    struct timeval timev           = { 0, 300000 };
     int            error_code      = 0;
     size_t         error_code_size = sizeof(error_code);
 
@@ -1240,19 +1239,32 @@ enum pbpal_resolv_n_connect_result pbpal_check_connect(pubnub_t* pb)
         return pbpal_connect_failed;
     }
 
-    FD_ZERO(&write_set);
-    FD_SET(pb->pal.socket, &write_set);
-    rslt = select(pb->pal.socket + 1, NULL, &write_set, NULL, &timev);
+#if defined(_WIN32)
+    {
+        fd_set         write_set;
+        struct timeval timev = { 0, 300000 };
+        FD_ZERO(&write_set);
+        FD_SET(pb->pal.socket, &write_set);
+        rslt = select(pb->pal.socket + 1, NULL, &write_set, NULL, &timev);
+    }
+#else
+    {
+        struct pollfd pfd;
+        pfd.fd      = pb->pal.socket;
+        pfd.events  = POLLOUT;
+        pfd.revents = 0;
+        rslt = poll(&pfd, 1, 300);
+    }
+#endif
     if (SOCKET_ERROR == rslt) {
-        PUBNUB_LOG_ERROR(pb, "Socket select() error.");
+        PUBNUB_LOG_ERROR(pb, "Socket poll/select error.");
         return pbpal_connect_resource_failure;
     }
     else if (rslt > 0) {
-        PUBNUB_LOG_TRACE(pb, "Socket select() event.");
+        PUBNUB_LOG_TRACE(pb, "Socket connected.");
 #if defined(_WIN32)
-        // Complete TCP Keep-Alive configuration if connection established.
         pbpal_set_tcp_keepalive(pb);
-#endif /* defined(_WIN32) */
+#endif
         return pbpal_connect_success;
     }
     return pbpal_connect_wouldblock;

--- a/openssl/pbpal_connect_openssl.c
+++ b/openssl/pbpal_connect_openssl.c
@@ -6,7 +6,7 @@
 #include <winsock2.h>
 #include <Ws2tcpip.h>
 #else
-#include <sys/select.h>
+#include <poll.h>
 #define SOCKET_ERROR -1
 #endif
 
@@ -361,32 +361,41 @@ enum pbpal_tls_result pbpal_check_tls(pubnub_t* pb)
        when the FSM fires, so select() returns immediately. */
     if (PBS_WAIT_TLS_CONNECT == pb->state
         && 0 != pb->pal.tls_connect_last_error) {
-        fd_set         read_set, write_set;
-        struct timeval timev     = { 0, 300000 };
-        const bool     want_read =
+        const bool want_read =
             (SSL_ERROR_WANT_READ == pb->pal.tls_connect_last_error);
 
-        FD_ZERO(&read_set);
-        FD_ZERO(&write_set);
-        FD_SET(pb->pal.socket, want_read ? &read_set : &write_set);
-
-        rslt = select(
-            pb->pal.socket + 1,
-            want_read ? &read_set : NULL,
-            want_read ? NULL : &write_set,
-            NULL,
-            &timev);
+#if defined(_WIN32)
+        {
+            fd_set         read_set, write_set;
+            struct timeval timev = { 0, 300000 };
+            FD_ZERO(&read_set);
+            FD_ZERO(&write_set);
+            FD_SET(pb->pal.socket, want_read ? &read_set : &write_set);
+            rslt = select(
+                pb->pal.socket + 1,
+                want_read ? &read_set : NULL,
+                want_read ? NULL : &write_set,
+                NULL,
+                &timev);
+        }
+#else
+        {
+            struct pollfd pfd;
+            pfd.fd      = pb->pal.socket;
+            pfd.events  = want_read ? POLLIN : POLLOUT;
+            pfd.revents = 0;
+            rslt = poll(&pfd, 1, 300);
+        }
+#endif
         if (SOCKET_ERROR == rslt) {
-            PUBNUB_LOG_ERROR(pb, "TLS select() error during handshake.");
+            PUBNUB_LOG_ERROR(pb, "TLS poll/select error during handshake.");
             pb->pal.tls_connect_last_error = 0;
             return pbtlsFailed;
         }
         if (0 == rslt) {
-            /* select() timed out — socket not ready yet. Return the
-               same wait direction without calling SSL_connect(). */
             return want_read ? pbtlsStartedWaitRead : pbtlsStartedWaitWrite;
         }
-        PUBNUB_LOG_TRACE(pb, "TLS select() event, resuming handshake.");
+        PUBNUB_LOG_TRACE(pb, "TLS socket ready, resuming handshake.");
     }
 
     bool needRead = false, needWrite = false;


### PR DESCRIPTION
fix(socket): replace `select()` with `poll()` in `pbpal_check_connect`

Replace inline `select()`/`FD_SET` with `poll()` on non-Windows platforms in `pbpal_check_connect()`. On Linux and macOS `FD_SET` writes to a fixed 1024-bit bitmap and corrupts the stack when a socket fd value exceeds `FD_SETSIZE`. `poll()` has no fd-value limitation. Windows retains `select()` because its `fd_set` is array-based and safe.

test(poller): add unit tests for `poll()`-based callback poller

Add `pbpal_ntf_callback_poller_poll_unit_test.c` covering init/deinit, save/remove, watch events, poll detection of readable and writable sockets, multiple sockets, socket update, and a high fd number test case (fd=1500) that validates the fix for the `FD_SETSIZE` overflow.