### PR TITLE
Fix subscribables options override and event listener refcount.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "7.2.2"
+version: "7.2.3"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-05-21
+    version: v7.2.3
+    changes:
+      - type: bug
+        text: "When building a subscription’s subscribable set, caller-supplied options now actually override `receive_presence_events` instead of copying `sub->options` again, so set-level presence settings are applied consistently."
+      - type: bug
+        text: "Removal no longer decrements the listener refcount twice (once manually and once in the array destructor), and add paths release the allocator's transient ref at the end, so shared listeners are not freed too early (use-after-free for N≥3 arrays) and global listeners are not leaked after a single remove."
   - date: 2026-05-14
     version: v7.2.2
     changes:
@@ -1193,7 +1200,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1252,7 +1259,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1311,7 +1318,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1366,7 +1373,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1420,7 +1427,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1469,7 +1476,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1515,7 +1522,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.2
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v7.2.3
+May 21 2026
+
+#### Fixed
+- When building a subscription’s subscribable set, caller-supplied options now actually override `receive_presence_events` instead of copying `sub->options` again, so set-level presence settings are applied consistently.
+- Removal no longer decrements the listener refcount twice (once manually and once in the array destructor), and add paths release the allocator's transient ref at the end, so shared listeners are not freed too early (use-after-free for N≥3 arrays) and global listeners are not leaked after a single remove.
+
 ## v7.2.2
 May 14 2026
 

--- a/core/pbcc_subscribe_event_listener.c
+++ b/core/pbcc_subscribe_event_listener.c
@@ -381,7 +381,12 @@ enum pubnub_res pbcc_event_listener_add_message_listener(
 
     const enum pubnub_res result =
         pbcc_add_listener_(listener->global_events, _listener);
-    if (PNR_OK != result) { pbcc_listener_free_(_listener); }
+    /*
+     * Release transient ref from pbcc_listener_alloc_. On success the array
+     * slot keeps the listener via pbcc_add_listener_'s increment; on failure
+     * no increment ran, so this frees the listener.
+     */
+    pbcc_listener_free_(_listener);
     pubnub_mutex_unlock(listener->mutw);
 
     return result;
@@ -470,8 +475,12 @@ enum pubnub_res pbcc_event_listener_add_subscription_object_listener(
             pbcc_remove_object_listener_(listener, name, _listener);
         }
     }
-    /** Manual `free` required if arrays doesn't manage listener lifetime. */
-    if (PNR_OK != rslt && !added) { pbcc_listener_free_(_listener); }
+    /*
+     * Release transient ref from pbcc_listener_alloc_. Success: one ref per
+     * array remains from pbcc_add_listener_. Partial rollback / total failure:
+     * arrays no longer hold refs, so this drops the last ref and frees.
+     */
+    pbcc_listener_free_(_listener);
     pubnub_mutex_unlock(listener->mutw);
 
     return rslt;
@@ -701,7 +710,6 @@ enum pubnub_res pbcc_remove_listener_(
             _listener->subscription_object == listener->subscription_object &&
             _listener->callback == listener->callback &&
             _listener->user_data == listener->user_data) {
-            pbref_counter_decrement(_listener->counter);
             pbarray_remove(listeners, (void**)&_listener, true);
         }
         else {

--- a/core/pubnub_subscribe_event_engine.c
+++ b/core/pubnub_subscribe_event_engine.c
@@ -674,7 +674,7 @@ pbhash_set_t* pubnub_subscription_subscribables_(
     const pubnub_t*               pb   = sub->entity->pb;
 
     if (NULL != options) {
-        opts.receive_presence_events = sub->options.receive_presence_events;
+        opts.receive_presence_events = options->receive_presence_events;
     }
 
     const pubnub_subscribable_location location =

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.2.2"
+#define PUBNUB_SDK_VERSION "7.2.3"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */


### PR DESCRIPTION
fix(subscription): Caller options now override presence flag; no silent ignore.

When building a subscription’s subscribable set, caller-supplied options now actually override `receive_presence_events` instead of copying `sub->options` again, so set-level presence settings are applied consistently.

fix(listener): One refcount drop per remove; transient add ref released—no UAF or leak.

Removal no longer decrements the listener refcount twice (once manually and once in the array destructor), and add paths release the allocator's transient ref at the end, so shared listeners are not freed too early (use-after-free for N≥3 arrays) and global listeners are not leaked after a single remove.