### PR TITLE
Fix a callback API crash on Windows during shutdown/reconnect.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: c-core
 schema: 1
-version: "7.2.3"
+version: "7.2.4"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-06-22
+    version: v7.2.4
+    changes:
+      - type: bug
+        text: "Fix timer-list assert in callback API on Windows when closing or reconnecting during async DnsQueryEx DNS resolution."
+      - type: improvement
+        text: "Harden callback API timer-list handling on all platforms: remove before re-add in `pbntf_got_socket_callback()`, and always unregister watcher/timer/queue state from `pbpal_close()/pbpal_free()` on callback builds."
   - date: 2026-05-21
     version: v7.2.3
     changes:
@@ -1200,7 +1207,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1259,7 +1266,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1318,7 +1325,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1373,7 +1380,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1427,7 +1434,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1476,7 +1483,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1522,7 +1529,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.3
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v7.2.4
+June 22 2026
+
+#### Fixed
+- Fix timer-list assert in callback API on Windows when closing or reconnecting during async DnsQueryEx DNS resolution.
+
+#### Modified
+- Harden callback API timer-list handling on all platforms: remove before re-add in `pbntf_got_socket_callback()`, and always unregister watcher/timer/queue state from `pbpal_close()/pbpal_free()` on callback builds.
+
 ## v7.2.3
 May 21 2026
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.2.3"
+#define PUBNUB_SDK_VERSION "7.2.4"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/lib/sockets/pbpal_sockets.c
+++ b/lib/sockets/pbpal_sockets.c
@@ -5,9 +5,6 @@
 #include "core/pubnub_ntf_sync.h"
 #include "core/pubnub_netcore.h"
 #include "core/pubnub_assert.h"
-#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
-#include "windows/pbpal_dns_query_ex.h"
-#endif
 #if PUBNUB_USE_LOGGER
 #include "core/pubnub_logger.h"
 #endif // PUBNUB_USE_LOGGER
@@ -305,14 +302,13 @@ void pbpal_forget(pubnub_t* pb)
 int pbpal_close(pubnub_t* pb)
 {
     pb->unreadlen = 0;
-#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
-    /* Cancel any pending DnsQueryEx queries. Must happen regardless of
-       socket state because the DnsQueryEx path does not create a UDP
-       socket (pb->pal.socket stays SOCKET_INVALID). */
-    pbpal_os_dns_cancel(pb);
+#if defined(PUBNUB_CALLBACK_API)
+    /* Unregister from watcher/timer/queue even when no socket exists yet
+       (e.g. Windows DnsQueryEx async DNS). pbntf_lost_socket() also
+       cancels pending DnsQueryEx on Windows. */
+    pbntf_lost_socket(pb);
 #endif
     if (pb->pal.socket != SOCKET_INVALID) {
-        pbntf_lost_socket(pb);
         socket_close(pb->pal.socket);
         pb->pal.socket = SOCKET_INVALID;
         pb->sock_state = STATE_NONE;
@@ -325,13 +321,10 @@ int pbpal_close(pubnub_t* pb)
 
 void pbpal_free(pubnub_t* pb)
 {
-#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
-    pbpal_os_dns_cancel(pb);
+#if defined(PUBNUB_CALLBACK_API)
+    pbntf_lost_socket(pb);
 #endif
     if (pb->pal.socket != SOCKET_INVALID) {
-        /* While this should not happen, it doesn't hurt to be paranoid.
-         */
-        pbntf_lost_socket(pb);
         socket_close(pb->pal.socket);
     }
 }

--- a/openssl/pbpal_openssl.c
+++ b/openssl/pbpal_openssl.c
@@ -7,9 +7,6 @@
 #include "core/pubnub_ntf_sync.h"
 #include "core/pubnub_netcore.h"
 #include "core/pubnub_assert.h"
-#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
-#include "windows/pbpal_dns_query_ex.h"
-#endif
 #if PUBNUB_USE_LOGGER
 #include "core/pbcc_logger_manager.h"
 #endif // PUBNUB_USE_LOGGER
@@ -444,16 +441,15 @@ void pbpal_forget(pubnub_t* pb)
 int pbpal_close(pubnub_t* pb)
 {
     pb->unreadlen = 0;
-#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
-    pbpal_os_dns_cancel(pb);
-#endif
     if (pb->pal.ssl != NULL) {
         SSL_shutdown(pb->pal.ssl);
         SSL_free(pb->pal.ssl);
         pb->pal.ssl = NULL;
     }
+#if defined(PUBNUB_CALLBACK_API)
+    pbntf_lost_socket(pb);
+#endif
     if (pb->pal.socket != SOCKET_INVALID) {
-        pbntf_lost_socket(pb);
         socket_close(pb->pal.socket);
         pb->pal.socket = SOCKET_INVALID;
         pb->sock_state = STATE_NONE;
@@ -466,9 +462,6 @@ int pbpal_close(pubnub_t* pb)
 
 void pbpal_free(pubnub_t* pb)
 {
-#if defined(_WIN32) && defined(PUBNUB_CALLBACK_API)
-    pbpal_os_dns_cancel(pb);
-#endif
     /* While this should not happen, it doesn't hurt to 'catch' it, if it
      * happens..
      */
@@ -480,8 +473,10 @@ void pbpal_free(pubnub_t* pb)
         SSL_free(pb->pal.ssl);
         pb->pal.ssl = NULL;
     }
+#if defined(PUBNUB_CALLBACK_API)
+    pbntf_lost_socket(pb);
+#endif
     if (pb->pal.socket != SOCKET_INVALID) {
-        pbntf_lost_socket(pb);
         PUBNUB_LOG_TRACE(pb, "Unexpectedly socket still exists. Closing...");
         socket_close(pb->pal.socket);
         pb->pal.socket = SOCKET_INVALID;

--- a/openssl/pubnub_ntf_callback_windows.c
+++ b/openssl/pubnub_ntf_callback_windows.c
@@ -167,6 +167,7 @@ MAYBE_INLINE int pbntf_got_socket_callback(pubnub_t* pb)
 
     if (PUBNUB_TIMERS_API) {
         EnterCriticalSection(&m_watcher.timerlock);
+        pbpal_remove_timer_safe(pb, &m_watcher.timer_head);
         m_watcher.timer_head = pubnub_timer_list_add(
             m_watcher.timer_head, pb, pb->transaction_timeout_ms);
         LeaveCriticalSection(&m_watcher.timerlock);

--- a/posix/pubnub_ntf_callback_posix.c
+++ b/posix/pubnub_ntf_callback_posix.c
@@ -259,6 +259,7 @@ MAYBE_INLINE int pbntf_got_socket_callback(pubnub_t* pb)
 
     if (PUBNUB_TIMERS_API) {
         pthread_mutex_lock(&m_watcher.timerlock);
+        pbpal_remove_timer_safe(pb, &m_watcher.timer_head);
         m_watcher.timer_head = pubnub_timer_list_add(
             m_watcher.timer_head, pb, pb->transaction_timeout_ms);
         pthread_mutex_unlock(&m_watcher.timerlock);

--- a/windows/pubnub_ntf_callback_windows.c
+++ b/windows/pubnub_ntf_callback_windows.c
@@ -167,6 +167,7 @@ MAYBE_INLINE int pbntf_got_socket_callback(pubnub_t* pb)
 
     if (PUBNUB_TIMERS_API) {
         EnterCriticalSection(&m_watcher.timerlock);
+        pbpal_remove_timer_safe(pb, &m_watcher.timer_head);
         m_watcher.timer_head = pubnub_timer_list_add(
             m_watcher.timer_head, pb, pb->transaction_timeout_ms);
         LeaveCriticalSection(&m_watcher.timerlock);


### PR DESCRIPTION
fix(crash): Fix timer-list assert in callback API on Windows

Fix timer-list assert in callback API on Windows when closing or reconnecting during async DnsQueryEx DNS resolution.

refactor(callback): Harden callback API timer-list handling on all platforms

Harden callback API timer-list handling on all platforms: remove before re-add in `pbntf_got_socket_callback()`, and always unregister watcher/timer/queue state from `pbpal_close()/pbpal_free()` on callback builds.

