### PR TITLE
Reset `http_buf_len` on NTLM proxy retry to prevent assert crash

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -7,7 +7,7 @@ changelog:
     version: v7.3.0
     changes:
       - type: feature
-        text: "`fill_sspi_identity` now splits `DOMAIN\user` and `user@domain` formats into separate User and Domain fields so proxies requiring domain-qualified credentials can authenticate."
+        text: "`fill_sspi_identity` now splits `DOMAIN\\user` and `user@domain` formats into separate User and Domain fields so proxies requiring domain-qualified credentials can authenticate."
       - type: bug
         text: "Reset `http_buf_len` to 0 in `pbproxyFinRetry` so the stale 407 body length does not trip the assert guarding `proxy_saved_path` memcpy on the next CONNECT attempt."
       - type: bug

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,23 @@
 name: c-core
 schema: 1
-version: "7.2.5"
+version: "7.3.0"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-07-30
+    version: v7.3.0
+    changes:
+      - type: feature
+        text: "`fill_sspi_identity` now splits `DOMAIN\user` and `user@domain` formats into separate User and Domain fields so proxies requiring domain-qualified credentials can authenticate."
+      - type: bug
+        text: "Reset `http_buf_len` to 0 in `pbproxyFinRetry` so the stale 407 body length does not trip the assert guarding `proxy_saved_path` memcpy on the next CONNECT attempt."
+      - type: bug
+        text: "The warning fired on the normal case instead of when SSPI needs more space than our buffer provides. Flip the comparison and update the log message."
+      - type: improvement
+        text: "Replace the 512-byte stack buffer with `pbbase64_decode_alloc_std` so large NTLM Type-2 challenges from domain-joined proxies are no longer silently dropped."
+      - type: improvement
+        text: "NTLMv2 Type-3 with extended target info and MIC frequently exceeds 1024 bytes. Raised to 4096 to cover all known SSPI scenarios."
+      - type: improvement
+        text: "Add tests for oversized 407 body triggering retry-path assert, and direct `pbntlm_core_handle` tests with 600, 2048, and 4200 byte challenges."
   - date: 2026-07-30
     version: v7.2.5
     changes:
@@ -1212,7 +1227,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1271,7 +1286,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1330,7 +1345,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1385,7 +1400,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1439,7 +1454,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1488,7 +1503,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1534,7 +1549,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
+            location: https://github.com/pubnub/c-core/releases/tag/v7.3.0
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v7.3.0
+July 30 2026
+
+#### Added
+- `fill_sspi_identity` now splits `DOMAIN\user` and `user@domain` formats into separate User and Domain fields so proxies requiring domain-qualified credentials can authenticate.
+
+#### Fixed
+- Reset `http_buf_len` to 0 in `pbproxyFinRetry` so the stale 407 body length does not trip the assert guarding `proxy_saved_path` memcpy on the next CONNECT attempt.
+- The warning fired on the normal case instead of when SSPI needs more space than our buffer provides. Flip the comparison and update the log message.
+
+#### Modified
+- Replace the 512-byte stack buffer with `pbbase64_decode_alloc_std` so large NTLM Type-2 challenges from domain-joined proxies are no longer silently dropped.
+- NTLMv2 Type-3 with extended target info and MIC frequently exceeds 1024 bytes. Raised to 4096 to cover all known SSPI scenarios.
+- Add tests for oversized 407 body triggering retry-path assert, and direct `pbntlm_core_handle` tests with 600, 2048, and 4200 byte challenges.
+
 ## v7.2.5
 July 30 2026
 

--- a/core/pbntlm_core.c
+++ b/core/pbntlm_core.c
@@ -8,6 +8,8 @@
 
 #include "lib/base64/pbbase64.h"
 
+#include <stdlib.h>
+
 
 void pbntlm_core_init(pubnub_t* pb)
 {
@@ -25,9 +27,7 @@ void pbntlm_core_deinit(pubnub_t* pb)
 
 void pbntlm_core_handle(pubnub_t* pb, char const* base64_msg, size_t length)
 {
-    int             i;
-    uint8_t         msg[512];
-    pubnub_bymebl_t data = { msg, sizeof msg / sizeof msg[0] };
+    pubnub_bymebl_t data;
 
     if (pbntlmDone == pb->ntlm_context.state) {
         pbntlm_core_init(pb);
@@ -42,14 +42,15 @@ void pbntlm_core_handle(pubnub_t* pb, char const* base64_msg, size_t length)
         pbntlm_core_deinit(pb);
         return;
     }
-    i = pbbase64_decode_std(base64_msg, length, &data);
-    if (0 != i) {
-        PUBNUB_LOG_ERROR(pb, "Base64 decode failed with error code: %d", i);
+    data = pbbase64_decode_alloc_std(base64_msg, length);
+    if (NULL == data.ptr) {
+        PUBNUB_LOG_ERROR(pb, "Base64 decode (alloc) of NTLM challenge failed");
         pbntlm_core_deinit(pb);
         return;
     }
     (void)pbntlm_unpack_type2(pb, &pb->ntlm_context, data);
     pb->ntlm_context.state = pbntlmSendAuthenticate;
+    free(data.ptr);
 }
 
 

--- a/core/pbntlm_core.c
+++ b/core/pbntlm_core.c
@@ -48,7 +48,12 @@ void pbntlm_core_handle(pubnub_t* pb, char const* base64_msg, size_t length)
         pbntlm_core_deinit(pb);
         return;
     }
-    (void)pbntlm_unpack_type2(pb, &pb->ntlm_context, data);
+    if (0 != pbntlm_unpack_type2(pb, &pb->ntlm_context, data)) {
+        PUBNUB_LOG_ERROR(pb, "Failed to unpack NTLM Type-2 challenge");
+        free(data.ptr);
+        pbntlm_core_deinit(pb);
+        return;
+    }
     pb->ntlm_context.state = pbntlmSendAuthenticate;
     free(data.ptr);
 }

--- a/core/pbntlm_packer_sspi.c
+++ b/core/pbntlm_packer_sspi.c
@@ -6,6 +6,8 @@
 
 #include "pubnub_assert.h"
 
+#include <string.h>
+
 
 #pragma comment(lib, "secur32")
 
@@ -28,16 +30,36 @@ static void fill_sspi_identity(
     char const*              username,
     char const*              password)
 {
+    char const* sep;
+
     PUBNUB_ASSERT_OPT(NULL != identity);
     PUBNUB_ASSERT_OPT(NULL != username);
     PUBNUB_ASSERT_OPT(NULL != password);
 
-    identity->User       = (unsigned char*)username;
-    identity->UserLength = strlen(username);
-
-    /* For now, don't use the domain */
-    identity->Domain       = (unsigned char*)"";
-    identity->DomainLength = 0;
+    sep = strchr(username, '\\');
+    if (sep != NULL) {
+        /* DOMAIN\user format */
+        identity->Domain       = (unsigned char*)username;
+        identity->DomainLength = (unsigned long)(sep - username);
+        identity->User         = (unsigned char*)(sep + 1);
+        identity->UserLength   = strlen(sep + 1);
+    }
+    else {
+        sep = strchr(username, '@');
+        if (sep != NULL) {
+            /* user@domain (UPN) format */
+            identity->User         = (unsigned char*)username;
+            identity->UserLength   = (unsigned long)(sep - username);
+            identity->Domain       = (unsigned char*)(sep + 1);
+            identity->DomainLength = strlen(sep + 1);
+        }
+        else {
+            identity->User       = (unsigned char*)username;
+            identity->UserLength = strlen(username);
+            identity->Domain       = (unsigned char*)"";
+            identity->DomainLength = 0;
+        }
+    }
 
     identity->Password       = (unsigned char*)password;
     identity->PasswordLength = strlen(password);
@@ -52,11 +74,13 @@ void pbntlm_packer_init(pubnub_t* context, pbntlm_ctx_t* pb)
 
     PUBNUB_ASSERT_OPT(pb != NULL);
 
-    if (sspi_max_token <= PUBNUB_NTLM_MAX_TOKEN) {
+    if (sspi_max_token > PUBNUB_NTLM_MAX_TOKEN) {
         PUBNUB_LOG_WARNING(
             context,
-            "NTLM token for SSPI is smaller (%lu) that maximum allowed (%d).",
+            "SSPI max token (%lu) exceeds PUBNUB_NTLM_MAX_TOKEN (%d). "
+            "Type-2 challenges larger than %d bytes will be rejected.",
             sspi_max_token,
+            PUBNUB_NTLM_MAX_TOKEN,
             PUBNUB_NTLM_MAX_TOKEN);
     }
 

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -162,6 +162,11 @@ enum NPBNTLM_State {
 /** Maximum supported length of the NTLM token (message) */
 #define PUBNUB_NTLM_MAX_TOKEN 4096
 
+/** Buffer size for the proxy authorization header.
+    Accounts for base64 expansion (4/3) + prefix + padding. */
+#define PUBNUB_PROXY_AUTH_HEADER_MAX_SIZE \
+    ((PUBNUB_NTLM_MAX_TOKEN * 4 / 3 + 4) + 64)
+
 #if PUBNUB_USE_WIN_SSPI
 #define SECURITY_WIN32
 #include <sspi.h>

--- a/core/pubnub_internal_common.h
+++ b/core/pubnub_internal_common.h
@@ -160,7 +160,7 @@ enum NPBNTLM_State {
 };
 
 /** Maximum supported length of the NTLM token (message) */
-#define PUBNUB_NTLM_MAX_TOKEN 1024
+#define PUBNUB_NTLM_MAX_TOKEN 4096
 
 #if PUBNUB_USE_WIN_SSPI
 #define SECURITY_WIN32

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -723,6 +723,7 @@ static enum pubnub_res finish(struct pubnub_* pb)
     case pbproxyFinRetry:
         PUBNUB_LOG_TRACE(pb, "Proxy: retry in current connection.");
         pb->flags.retry_after_close = true;
+        pb->core.http_buf_len = 0;
         if (pb->flags.should_close) {
             close_connection(pb);
             return PNR_OK;

--- a/core/pubnub_netcore.c
+++ b/core/pubnub_netcore.c
@@ -1337,7 +1337,7 @@ next_state:
         else if (0 == i) {
 #if PUBNUB_PROXY_API
             if (!pb->proxy_tunnel_established) {
-                char hedr[1024] = "\r\n";
+                char hedr[PUBNUB_PROXY_AUTH_HEADER_MAX_SIZE] = "\r\n";
                 if (0 == pbproxy_http_header_to_send(
                              pb, hedr + 2, sizeof hedr - 2)) {
                     PUBNUB_LOG_TRACE(pb, "Sending HTTP proxy header: %s", hedr);

--- a/core/pubnub_proxy_NTLM_test.c
+++ b/core/pubnub_proxy_NTLM_test.c
@@ -16,6 +16,8 @@
 
 #include "pubnub_json_parse.h"
 #include "pubnub_keep_alive.h"
+#include "pbntlm_core.h"
+#include "lib/base64/pbbase64.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -1459,6 +1461,249 @@ proxy_CONNECT_NTLM_sets_timeout_and_max_operation_count_for_keep_alive(void)
     AfterEach();
 }
 
+static void CONNECT_NTLM_407_body_larger_than_http_buf_does_not_assert(void)
+{
+    int  proxy_port = 500;
+    char large_body[PUBNUB_BUF_MAXLEN + 100];
+
+    memset(large_body, 'X', sizeof large_body - 1);
+    large_body[sizeof large_body - 1] = '\0';
+
+    BeforeEach();
+    pubnub_init(pbp, "publ-key", "sub-key");
+    attest(
+        pubnub_set_proxy_manual(
+            pbp, pbproxyHTTP_CONNECT, "proxy_server_url", proxy_port) == 0);
+    attest(
+        pubnub_set_proxy_authentication_username_password(
+            pbp, "serious", "password") == 0);
+    expect_have_dns_for_proxy_server();
+
+    expect_first_outgoing_CONNECT();
+
+    {
+        char content_length_hdr[64];
+        char* response;
+        size_t response_len;
+        char headers[] =
+            "HTTP/1.1 407 Proxy Authentication Required\r\n"
+            "Proxy-Authenticate: NTLM\r\n"
+            "Connection: close\r\n"
+            "Content-Type: text/html\r\n";
+        char end_headers[] = "\r\n";
+
+        snprintf(content_length_hdr,
+                 sizeof content_length_hdr,
+                 "Content-Length: %d\r\n",
+                 (int)(sizeof large_body - 1));
+
+        response_len = strlen(headers) + strlen(content_length_hdr)
+                       + strlen(end_headers) + strlen(large_body);
+        response = (char*)malloc(response_len + 1);
+        assert(response != NULL);
+        strcpy(response, headers);
+        strcat(response, content_length_hdr);
+        strcat(response, end_headers);
+        strcat(response, large_body);
+
+        incoming(response);
+        free(response);
+    }
+
+    expect("pbpal_close", pbp, "", 0);
+    expect_have_dns_for_proxy_server_without_enqueue_for_processing();
+    expect_outgoing_with_encoded_credentials_CONNECT(
+        "/subscribe/sub-key/health/0/0?pnsdk=unit-test-0.1",
+        "\r\nProxy-Authorization: NTLM "
+        "TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAKAKs/AAAADw==");
+    incoming(
+        "HTTP/1.1 407 ProxyAuthentication Required ( Access is denied. )\r\n"
+        "Via: 1.1 SPIRIT1B\r\n"
+        "Proxy-Authenticate: NTLM "
+        "TlRMTVNTUAACAAAAEAAQADgAAAA1goriluCDYHcYI/"
+        "sAAAAAAAAAAFQAVABIAAAABQLODgAAAA9TAFAASQBSAEkAVAAxAEIAAgAQAFMAUABJAFIA"
+        "SQBUADEAQgABABAAUwBQAEkAUgBJAFQAMQBCAAQAEABzAHAAaQByAGkAdAAxAGIAAwAQAH"
+        "MAcABpAHIAaQB0ADEAYgAAAAAA\r\n"
+        "Connection: Keep-Alive\r\n"
+        "Proxy-Connection: Keep-Alive\r\n"
+        "Pragma: no-cache\r\n"
+        "Cache-Control: no-cache\r\n"
+        "Content-Type: text/html\r\n"
+        "Content-Length: 11\r\n"
+        "\r\n"
+        "<comment>\r\n");
+    expect_outgoing_with_encoded_credentials_CONNECT(
+        "/subscribe/sub-key/health/0/0?pnsdk=unit-test-0.1",
+        "\r\nProxy-Authorization: NTLM "
+        "TlRMTVNTUAADAAAAGAAYAIQAAADQANAAnAAAAAAAAABYAAAADgAOAFgAAAAeAB4AZgAAAA"
+        "AAAABsAQAABYKIogoAqz8AAAAPccZQvLc9g1+"
+        "Nren4B1Ib4HMAZQByAGkAbwB1AHMARABFAFMASwBUAE8AUAAtADcAMQA0ADQARgBSAEsAA"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPYV7z8b1u4i3PisNiYQE1QEBAAAAAAAAukU1J0O"
+        "40wGP8Kgb8CDzxgAAAAACABAAUwBQAEkAUgBJAFQAMQBCAAEAEABTAFAASQBSAEkAVAAxA"
+        "EIABAAQAHMAcABpAHIAaQB0ADEAYgADABAAcwBwAGkAcgBpAHQAMQBiAAgAMAAwAAAAAAA"
+        "AAAEAAAAAIAAAptCBZNmwVx+"
+        "C4b7LJ01Abe4XUAITMf9HDfeJZOCOJR8KABAAAAAAAAAAAAAAAAAAAAAAAAkAAAAAAAAAA"
+        "AAAAA==");
+    incoming(
+        "HTTP/1.1 200 Connection established\r\n"
+        "Via: 1.1 SPIRIT1B\r\n"
+        "Expires: 7200\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n");
+    expect_outgoing_with_url(
+        "/subscribe/sub-key/health/0/0?pnsdk=unit-test-0.1");
+    incoming(
+        "HTTP/1.1 200 Connection established\r\n"
+        "Via: 1.1 SPIRIT1B\r\n"
+        "Content-Length: 26\r\n"
+        "\r\n"
+        "[[],\"1516014978925123457\"]");
+    attest(pubnub_subscribe(pbp, "health", NULL) == PNR_STARTED);
+
+    attest(pbnc_fsm(pbp) == 0);
+    attest(pbnc_fsm(pbp) == 0);
+    attest(pbnc_fsm(pbp) == 0);
+
+    expect("pbntf_lost_socket", pbp, "", 0);
+    expect("pbntf_trans_outcome", pbp, "", 0);
+    attest(pbnc_fsm(pbp) == 0);
+
+    attest(pubnub_get(pbp) == NULL);
+    attest(pubnub_last_http_code(pbp) == 200);
+
+    AfterEach();
+}
+
+static char* make_ntlm_type2_base64(size_t target_decoded_size, size_t* out_len)
+{
+    uint8_t* raw;
+    pubnub_bymebl_t raw_block;
+    size_t encoded_len;
+    char* encoded;
+
+    assert(target_decoded_size >= 56);
+    raw = (uint8_t*)calloc(1, target_decoded_size);
+    assert(raw != NULL);
+
+    /* NTLMSSP signature */
+    memcpy(raw, "NTLMSSP\0", 8);
+    /* Type 2 message indicator */
+    raw[8] = 0x02;
+    /* TargetNameFields: Len=16, MaxLen=16, Offset=56 */
+    raw[12] = 0x10; raw[14] = 0x10; raw[16] = 0x38;
+    /* NegotiateFlags */
+    raw[20] = 0x35; raw[21] = 0x82; raw[22] = 0x8a; raw[23] = 0xe2;
+    /* ServerChallenge (8 bytes at offset 24) */
+    raw[24] = 0x01; raw[25] = 0x02; raw[26] = 0x03; raw[27] = 0x04;
+    raw[28] = 0x05; raw[29] = 0x06; raw[30] = 0x07; raw[31] = 0x08;
+    /* TargetInfoFields: Len and MaxLen = (target_decoded_size - 72) at offset 40 */
+    {
+        uint16_t info_len = (uint16_t)(target_decoded_size - 72);
+        raw[40] = (uint8_t)(info_len & 0xFF);
+        raw[41] = (uint8_t)(info_len >> 8);
+        raw[42] = raw[40]; raw[43] = raw[41];
+        /* Offset = 72 */
+        raw[44] = 72;
+    }
+    /* TargetName at offset 56 (16 bytes): "DOMAIN" in UTF-16LE */
+    raw[56] = 'D'; raw[58] = 'O'; raw[60] = 'M'; raw[62] = 'A';
+    raw[64] = 'I'; raw[66] = 'N';
+
+    raw_block.ptr = raw;
+    raw_block.size = target_decoded_size;
+    encoded_len = ((target_decoded_size + 2) / 3) * 4 + 1;
+    encoded = (char*)malloc(encoded_len);
+    assert(encoded != NULL);
+    assert(0 == pbbase64_encode_std(raw_block, encoded, &encoded_len));
+
+    free(raw);
+    *out_len = encoded_len;
+    return encoded;
+}
+
+
+static void NTLM_core_handle_accepts_challenge_larger_than_512_bytes(void)
+{
+    size_t base64_len;
+    char* challenge;
+
+    BeforeEach();
+    pubnub_init(pbp, "publ-key", "sub-key");
+
+    /* 600 bytes decoded — exceeds the old 512-byte stack buffer */
+    challenge = make_ntlm_type2_base64(600, &base64_len);
+
+    pbntlm_core_init(pbp);
+    attest(pbp->ntlm_context.state == pbntlmSendNegotiate);
+
+    /* Advance to RcvChallenge state (skip Negotiate since std packer can't) */
+    pbp->ntlm_context.state = pbntlmRcvChallenge;
+
+    pbntlm_core_handle(pbp, challenge, base64_len);
+
+    /* With the dynamic alloc fix, decode succeeds and state advances */
+    attest(pbp->ntlm_context.state == pbntlmSendAuthenticate);
+
+    pbntlm_core_deinit(pbp);
+    free(challenge);
+    AfterEach();
+}
+
+
+static void NTLM_core_handle_accepts_challenge_up_to_max_token_size(void)
+{
+    size_t base64_len;
+    char* challenge;
+
+    BeforeEach();
+    pubnub_init(pbp, "publ-key", "sub-key");
+
+    /* 2048 bytes decoded — exceeds old PUBNUB_NTLM_MAX_TOKEN (1024) */
+    challenge = make_ntlm_type2_base64(2048, &base64_len);
+
+    pbntlm_core_init(pbp);
+    pbp->ntlm_context.state = pbntlmRcvChallenge;
+
+    pbntlm_core_handle(pbp, challenge, base64_len);
+
+    /* With PUBNUB_NTLM_MAX_TOKEN raised to 4096, this fits in in_token */
+    attest(pbp->ntlm_context.state == pbntlmSendAuthenticate);
+    attest(pbp->ntlm_context.in_token_size == 2048);
+
+    pbntlm_core_deinit(pbp);
+    free(challenge);
+    AfterEach();
+}
+
+
+static void NTLM_core_handle_rejects_challenge_exceeding_max_token(void)
+{
+    size_t base64_len;
+    char* challenge;
+
+    BeforeEach();
+    pubnub_init(pbp, "publ-key", "sub-key");
+
+    /* 4200 bytes decoded — exceeds PUBNUB_NTLM_MAX_TOKEN (4096) */
+    challenge = make_ntlm_type2_base64(4200, &base64_len);
+
+    pbntlm_core_init(pbp);
+    pbp->ntlm_context.state = pbntlmRcvChallenge;
+
+    pbntlm_core_handle(pbp, challenge, base64_len);
+
+    /* Base64 decode succeeds (dynamic alloc handles any size), but
+       unpack_type2 rejects it (> in_token buffer). State still advances
+       since unpack_type2 return is ignored — no crash/abort. */
+    attest(pbp->ntlm_context.state == pbntlmSendAuthenticate);
+    attest(pbp->ntlm_context.in_token_size == 0);
+
+    pbntlm_core_deinit(pbp);
+    free(challenge);
+    AfterEach();
+}
+
+
 /* Test runner */
 int main(int argc, char* argv[])
 {
@@ -1466,4 +1711,8 @@ int main(int argc, char* argv[])
     proxy_establishes_CONNECT_NTLM_connection();
     CONNECT_NTLM_proxy_closes_connection_on_407_dialogue_continues();
     proxy_CONNECT_NTLM_sets_timeout_and_max_operation_count_for_keep_alive();
+    CONNECT_NTLM_407_body_larger_than_http_buf_does_not_assert();
+    NTLM_core_handle_accepts_challenge_larger_than_512_bytes();
+    NTLM_core_handle_accepts_challenge_up_to_max_token_size();
+    NTLM_core_handle_rejects_challenge_exceeding_max_token();
 }

--- a/core/pubnub_proxy_NTLM_test.c
+++ b/core/pubnub_proxy_NTLM_test.c
@@ -1693,13 +1693,31 @@ static void NTLM_core_handle_rejects_challenge_exceeding_max_token(void)
     pbntlm_core_handle(pbp, challenge, base64_len);
 
     /* Base64 decode succeeds (dynamic alloc handles any size), but
-       unpack_type2 rejects it (> in_token buffer). State still advances
-       since unpack_type2 return is ignored — no crash/abort. */
-    attest(pbp->ntlm_context.state == pbntlmSendAuthenticate);
+       unpack_type2 rejects it (> in_token buffer). Handler detects the
+       failure and deinits the NTLM context. */
+    attest(pbp->ntlm_context.state == pbntlmDone);
     attest(pbp->ntlm_context.in_token_size == 0);
 
-    pbntlm_core_deinit(pbp);
     free(challenge);
+    AfterEach();
+}
+
+
+static void NTLM_core_handle_rejects_invalid_base64(void)
+{
+    char const invalid_b64[] = "!!!not-valid-base64!!!";
+
+    BeforeEach();
+    pubnub_init(pbp, "publ-key", "sub-key");
+
+    pbntlm_core_init(pbp);
+    pbp->ntlm_context.state = pbntlmRcvChallenge;
+
+    pbntlm_core_handle(pbp, invalid_b64, sizeof invalid_b64 - 1);
+
+    /* Base64 decode fails (returns NULL), handler deinits the context. */
+    attest(pbp->ntlm_context.state == pbntlmDone);
+
     AfterEach();
 }
 
@@ -1715,4 +1733,5 @@ int main(int argc, char* argv[])
     NTLM_core_handle_accepts_challenge_larger_than_512_bytes();
     NTLM_core_handle_accepts_challenge_up_to_max_token_size();
     NTLM_core_handle_rejects_challenge_exceeding_max_token();
+    NTLM_core_handle_rejects_invalid_base64();
 }

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.2.5"
+#define PUBNUB_SDK_VERSION "7.3.0"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/core/samples/pubnub_sync_proxy_from_system_sample.c
+++ b/core/samples/pubnub_sync_proxy_from_system_sample.c
@@ -1,0 +1,95 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+/** @file pubnub_sync_proxy_from_system_sample.c
+
+    Minimal sample demonstrating a synchronous publish using the
+    system-configured proxy (auto-detected from Windows IE/WinHTTP
+    settings). NTLM authentication uses the current logon session
+    credentials via SSPI automatically.
+
+    Prerequisites (Windows):
+      - VS Code with C/C++ extension
+      - Build Tools for Visual Studio (provides cl.exe, nmake, Windows SDK)
+        Download: https://visualstudio.microsoft.com/downloads/
+        Select "Desktop development with C++" workload during install.
+
+    Build (from the repo root, in a VS Developer Command Prompt or
+    terminal initialized with vcvars64.bat):
+
+        cd windows
+        set "USE_PROXY=1" && nmake /f windows.mk pubnub_sync_proxy_from_system_sample.exe
+
+    Run:
+
+        pubnub_sync_proxy_from_system_sample.exe
+
+    The proxy is auto-detected from Windows system settings (IE LAN
+    settings, WinHTTP proxy, or WPAD/PAC auto-discovery).
+*/
+
+#include "pubnub_sync.h"
+
+#include "core/pubnub_helper.h"
+#include "core/pubnub_alloc.h"
+#include "core/pubnub_pubsubapi.h"
+#include "core/pubnub_coreapi.h"
+#include "core/pubnub_proxy.h"
+#include "core/pubnub_generate_uuid.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+int main(int argc, char* argv[])
+{
+    pubnub_t*              pb;
+    enum pubnub_res        res;
+    char const*            chan = "hello_world";
+    struct Pubnub_UUID     uuid;
+    struct Pubnub_UUID_String str_uuid;
+
+    (void)argc;
+    (void)argv;
+
+    pb = pubnub_alloc();
+    if (NULL == pb) {
+        fprintf(stderr, "Failed to allocate PubNub context\n");
+        return 1;
+    }
+    pubnub_init(pb, "demo", "demo");
+
+    if (0 == pubnub_generate_uuid_v4_random(&uuid)) {
+        str_uuid = pubnub_uuid_to_string(&uuid);
+        pubnub_set_user_id(pb, str_uuid.uuid);
+    }
+    else {
+        pubnub_set_user_id(pb, "proxy-system-sample");
+    }
+
+    printf("Detecting proxy from system configuration...\n");
+    if (0 != pubnub_set_proxy_from_system(pb, pbproxyHTTP_CONNECT)) {
+        fprintf(stderr,
+                "No system proxy found or auto-detection failed.\n"
+                "Check IE LAN settings or WinHTTP proxy configuration.\n");
+        pubnub_free(pb);
+        return 1;
+    }
+    printf("System proxy configured successfully.\n");
+
+    printf("Publishing to channel '%s'...\n", chan);
+    res = pubnub_publish(pb, chan, "\"Hello from system proxy sample\"");
+    if (PNR_STARTED == res) { res = pubnub_await(pb); }
+
+    if (PNR_OK == res) {
+        printf("Published OK! Response: %s\n", pubnub_last_publish_result(pb));
+    }
+    else {
+        fprintf(stderr,
+                "Publish failed: %d (%s)\n",
+                res,
+                pubnub_res_2_string(res));
+    }
+
+    pubnub_free(pb);
+    return (res == PNR_OK) ? 0 : 1;
+}

--- a/core/samples/pubnub_sync_proxy_manual_sample.c
+++ b/core/samples/pubnub_sync_proxy_manual_sample.c
@@ -1,0 +1,112 @@
+/* -*- c-file-style:"stroustrup"; indent-tabs-mode: nil -*- */
+
+/** @file pubnub_sync_proxy_manual_sample.c
+
+    Minimal sample demonstrating a synchronous publish through a
+    manually configured HTTP CONNECT proxy with NTLM authentication.
+
+    Prerequisites (Windows):
+      - VS Code with C/C++ extension
+      - Build Tools for Visual Studio (provides cl.exe, nmake, Windows SDK)
+        Download: https://visualstudio.microsoft.com/downloads/
+        Select "Desktop development with C++" workload during install.
+
+    Build (from the repo root, in a VS Developer Command Prompt or
+    terminal initialized with vcvars64.bat):
+
+        cd windows
+        set "USE_PROXY=1" && nmake /f windows.mk pubnub_sync_proxy_manual_sample.exe
+
+    Run:
+
+        pubnub_sync_proxy_manual_sample.exe <proxy_host> <proxy_port> [DOMAIN\user] [password]
+
+    If username/password are omitted, SSPI uses the current Windows
+    logon credentials (transparent/SSO authentication).
+*/
+
+#include "pubnub_sync.h"
+
+#include "core/pubnub_helper.h"
+#include "core/pubnub_alloc.h"
+#include "core/pubnub_pubsubapi.h"
+#include "core/pubnub_coreapi.h"
+#include "core/pubnub_proxy.h"
+#include "core/pubnub_generate_uuid.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+int main(int argc, char* argv[])
+{
+    pubnub_t*              pb;
+    enum pubnub_res        res;
+    char const*            chan = "hello_world";
+    char const*            proxy_host;
+    uint16_t               proxy_port;
+    char const*            username = NULL;
+    char const*            password = NULL;
+    struct Pubnub_UUID     uuid;
+    struct Pubnub_UUID_String str_uuid;
+
+    if (argc < 3) {
+        fprintf(stderr,
+                "Usage: %s <proxy_host> <proxy_port> [DOMAIN\\user] [password]\n",
+                argv[0]);
+        return 1;
+    }
+
+    proxy_host = argv[1];
+    proxy_port = (uint16_t)atoi(argv[2]);
+    if (argc > 3) { username = argv[3]; }
+    if (argc > 4) { password = argv[4]; }
+
+    pb = pubnub_alloc();
+    if (NULL == pb) {
+        fprintf(stderr, "Failed to allocate PubNub context\n");
+        return 1;
+    }
+    pubnub_init(pb, "demo", "demo");
+
+    if (0 == pubnub_generate_uuid_v4_random(&uuid)) {
+        str_uuid = pubnub_uuid_to_string(&uuid);
+        pubnub_set_user_id(pb, str_uuid.uuid);
+    }
+    else {
+        pubnub_set_user_id(pb, "proxy-manual-sample");
+    }
+
+    printf("Setting proxy: %s:%u (HTTP CONNECT)\n", proxy_host, proxy_port);
+    if (0 != pubnub_set_proxy_manual(pb, pbproxyHTTP_CONNECT, proxy_host, proxy_port)) {
+        fprintf(stderr, "Failed to set proxy\n");
+        pubnub_free(pb);
+        return 1;
+    }
+
+    if (username != NULL) {
+        printf("Setting credentials: user=%s\n", username);
+        pubnub_set_proxy_authentication_username_password(pb, username, password);
+    }
+    else {
+        printf("Using current Windows logon credentials (SSPI/SSO)\n");
+    }
+
+    printf("Publishing to channel '%s'...\n", chan);
+    res = pubnub_publish(pb, chan, "\"Hello from manual proxy sample\"");
+    if (PNR_STARTED == res) { res = pubnub_await(pb); }
+
+    if (PNR_OK == res) {
+        printf("Published OK! Response: %s\n", pubnub_last_publish_result(pb));
+    }
+    else {
+        fprintf(stderr,
+                "Publish failed: %d (%s)\n",
+                res,
+                pubnub_res_2_string(res));
+    }
+
+    pubnub_free(pb);
+    return (res == PNR_OK) ? 0 : 1;
+}

--- a/make/common/source_files.mk
+++ b/make/common/source_files.mk
@@ -309,17 +309,18 @@ APP_CONTEXT_SOURCE_FILES = \
 
 # Custom proxy feature source files.
 PROXY_SOURCE_FILES = \
-    ../core/pbhttp_digest.c     \
-    ../core/pbntlm_core.c       \
-    ../core/pbntlm_packer_std.c \
-    ../core/pubnub_proxy.c      \
+    ../core/pbhttp_digest.c    \
+    ../core/pbntlm_core.c      \
+    ../core/pubnub_proxy.c     \
     ../core/pubnub_proxy_core.c
 
 # `PROXY_SOURCE_FILES` extension for POSIX build.
-PROXY_SOURCE_FILES_POSIX =
+PROXY_SOURCE_FILES_POSIX = \
+    ../core/pbntlm_packer_std.c
 
 # `PROXY_SOURCE_FILES` extension for Windows build.
 PROXY_SOURCE_FILES_WINDOWS = \
+    ../core/pbntlm_packer_sspi.c                    \
     ../windows/pubnub_set_proxy_from_system_windows.c
 
 

--- a/make/common/targets_app.mk
+++ b/make/common/targets_app.mk
@@ -59,6 +59,20 @@ SYNC_OBJECTS_SOURCES = $(subst /,$(PATH_SEP),$(SYNC_OBJECTS_SOURCES_))
 pubnub_objects_api_sample$(APP_EXT): $(SYNC_OBJECTS_SOURCES) pubnub_sync$(LIB_EXT)
 	$(COMPILER) $(OUT_FLAG)$@ $(COMPILER_FLAGS) $(CPPFLAGS) $(PREREQUISITES) $(LDLIBS)
 
+SYNC_PROXY_MANUAL_SOURCES_ = ../core/samples/pubnub_sync_proxy_manual_sample.c
+SYNC_PROXY_MANUAL_SOURCES = $(subst /,$(PATH_SEP),$(SYNC_PROXY_MANUAL_SOURCES_))
+pubnub_sync_proxy_manual_sample$(APP_EXT): \
+    $(SYNC_PROXY_MANUAL_SOURCES) \
+    pubnub_sync$(LIB_EXT)
+	$(COMPILER) $(OUT_FLAG)$@ $(COMPILER_FLAGS) $(CPPFLAGS) $(PREREQUISITES) $(LDLIBS)
+
+SYNC_PROXY_SYSTEM_SOURCES_ = ../core/samples/pubnub_sync_proxy_from_system_sample.c
+SYNC_PROXY_SYSTEM_SOURCES = $(subst /,$(PATH_SEP),$(SYNC_PROXY_SYSTEM_SOURCES_))
+pubnub_sync_proxy_from_system_sample$(APP_EXT): \
+    $(SYNC_PROXY_SYSTEM_SOURCES) \
+    pubnub_sync$(LIB_EXT)
+	$(COMPILER) $(OUT_FLAG)$@ $(COMPILER_FLAGS) $(CPPFLAGS) $(PREREQUISITES) $(LDLIBS)
+
 
 # ----------------- Samples based on callback PubNub library -----------------
 


### PR DESCRIPTION
feat(ntlm): parse domain from username in SSPI identity for NTLM proxy auth

`fill_sspi_identity` now splits `DOMAIN\user` and `user@domain` formats into separate User and
Domain fields so proxies requiring domain-qualified credentials can authenticate.

fix(proxy): reset `http_buf_len` on NTLM proxy retry to prevent assert crash

Reset `http_buf_len` to 0 in `pbproxyFinRetry` so the stale 407 body length does not trip the
assert guarding `proxy_saved_path` memcpy on the next CONNECT attempt.

fix(ntlm): correct inverted SSPI max-token guard in `pbntlm_packer_sspi.c`

The warning fired on the normal case instead of when SSPI needs more space than our buffer provides.
Flip the comparison and update the log message.

refactor(ntlm): use dynamic allocation for Type-2 challenge decode in `pbntlm_core_handle`

Replace the 512-byte stack buffer with `pbbase64_decode_alloc_std` so large NTLM Type-2 challenges
from domain-joined proxies are no longer silently dropped.

refactor(ntlm): raise `PUBNUB_NTLM_MAX_TOKEN` from 1024 to 4096

NTLMv2 Type-3 with extended target info and MIC frequently exceeds 1024 bytes. Raised to 4096 to
cover all known SSPI scenarios.

test(proxy): add NTLM proxy regression tests

Add tests for oversized 407 body triggering retry-path assert, and direct `pbntlm_core_handle`
tests with 600, 2048, and 4200 byte challenges.