### PR TITLE
Fix infinite DNS retry loop when IPv6 DNS servers are unreachable

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: c-core
 schema: 1
-version: "7.2.4"
+version: "7.2.5"
 scm: github.com/pubnub/c-core
 changelog:
+  - date: 2026-07-30
+    version: v7.2.5
+    changes:
+      - type: bug
+        text: "Clear the IPv6 address buffer in `get_dns_ip()` when a server is skipped due to prior failure marking, so `user_provided_ipv6_dns` correctly becomes false and the rotation falls through to IPv4 DNS servers."
   - date: 2026-06-22
     version: v7.2.4
     changes:
@@ -1207,7 +1212,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1266,7 +1271,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1325,7 +1330,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1380,7 +1385,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1434,7 +1439,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1483,7 +1488,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"
@@ -1529,7 +1534,7 @@ sdks:
           - distribution-type: source code
             distribution-repository: GitHub release
             package-name: C-Core
-            location: https://github.com/pubnub/c-core/releases/tag/v7.2.4
+            location: https://github.com/pubnub/c-core/releases/tag/v7.2.5
             requires:
               - name: "miniz"
                 min-version: "2.0.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v7.2.5
+July 30 2026
+
+#### Fixed
+- Clear the IPv6 address buffer in `get_dns_ip()` when a server is skipped due to prior failure marking, so `user_provided_ipv6_dns` correctly becomes false and the rotation falls through to IPv4 DNS servers.
+
 ## v7.2.4
 June 22 2026
 

--- a/core/pubnub_version_internal.h
+++ b/core/pubnub_version_internal.h
@@ -3,7 +3,7 @@
 #define INC_PUBNUB_VERSION_INTERNAL
 
 
-#define PUBNUB_SDK_VERSION "7.2.4"
+#define PUBNUB_SDK_VERSION "7.2.5"
 
 
 #endif /* !defined INC_PUBNUB_VERSION_INTERNAL */

--- a/lib/sockets/pbpal_resolv_and_connect_sockets.c
+++ b/lib/sockets/pbpal_resolv_and_connect_sockets.c
@@ -266,11 +266,13 @@ static void get_dns_ip(
                  pb, (struct pubnub_ipv6_address*)pv6->s6_addr) == -1) ||
             (dns_check->dns_server_check & dns_check->dns_mask)) {
             dns_check->dns_mask <<= 1;
+            memset(pv6, 0, sizeof(*pv6));
 
             if ((pubnub_get_dns_secondary_server_ipv6(
                      pb, (struct pubnub_ipv6_address*)pv6->s6_addr) == -1) ||
                 (dns_check->dns_server_check & dns_check->dns_mask)) {
                 dns_check->dns_mask <<= 1;
+                memset(pv6, 0, sizeof(*pv6));
             }
         }
         user_provided_ipv6_dns = !IN6_IS_ADDR_UNSPECIFIED(pv6);


### PR DESCRIPTION
fix(dns): Fix infinite DNS retry loop when IPv6 DNS servers are unreachable

Clear the IPv6 address buffer in `get_dns_ip()` when a server is skipped due to prior failure marking, so `user_provided_ipv6_dns` correctly becomes false and the rotation falls through to IPv4 DNS servers.